### PR TITLE
add support for newer releases of node_exporter

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,6 @@
+fixtures:
+  repositories:
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib"
+    staging: "https://github.com/nanliu/puppet-staging"
+  symlinks:
+    "prometheus": "#{source_dir}"

--- a/manifests/node_exporter/install.pp
+++ b/manifests/node_exporter/install.pp
@@ -5,11 +5,16 @@
 # The package method needs specific yum or apt repo settings which are not made yet by the module
 class prometheus::node_exporter::install
 {
+
   case $::prometheus::node_exporter::install_method {
     'url': {
       include staging
       $staging_file = "node_exporter-${prometheus::node_exporter::version}.${prometheus::node_exporter::download_extension}"
-      $binary = "${::staging::path}/node_exporter"
+      if( versioncmp($::prometheus::node_exporter::version, '0.12.0') == -1 ){
+        $binary = "${::staging::path}/node_exporter"
+      } else {
+          $binary = "${::staging::path}/node_exporter-${::prometheus::node_exporter::version}.${::prometheus::node_exporter::os}-${::prometheus::node_exporter::arch}/node_exporter"
+      }
       staging::file { $staging_file:
         source => $prometheus::node_exporter::real_download_url,
       } ->

--- a/spec/classes/node_exporter-version_spec.rb
+++ b/spec/classes/node_exporter-version_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe "prometheus::node_exporter" do
+
+  context 'uses the correct binary path for version < 0.12.0' do
+    let(:facts) { {
+        'operatingsystem' => 'CentOS',
+        'operatingsystemrelease' => '7.0',
+        'architecture' => 'amd64',
+        'kernel' => 'Linux',
+    } }
+
+    let(:params) { {:version => '0.10.0', :arch => 'amd64', :os => 'linux'} }
+
+    it do
+      should contain_file('/usr/local/bin/node_exporter').with({
+        'target' => '/opt/staging/node_exporter'
+      })
+    end
+  end
+
+  context 'uses the correct binary path for versions >= 0.12' do
+    let(:facts) { {
+        'operatingsystem' => 'CentOS',
+        'operatingsystemrelease' => '7.0',
+        'architecture' => 'amd64',
+        'kernel' => 'Linux',
+    } }
+
+    let(:params) { {:version => '0.12.0', :arch => 'amd64', :os => 'linux'} }
+
+    it do
+      should contain_file('/usr/local/bin/node_exporter').with({
+        'target' => '/opt/staging/node_exporter-0.12.0.linux-amd64/node_exporter'
+      })
+    end
+  end
+
+end


### PR DESCRIPTION
Similar to PR #2 - this PR fixes the path for versions of node_exporter >= 0.12. It keeps the default as 0.11.0 for backwards compatiability and adds some spec tests to help ensure we're doing the right thing.
