### PR TITLE
Configuration filename changed

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -91,5 +91,9 @@ class prometheus::config(
     mode    => $prometheus::config_mode,
     content => template('prometheus/prometheus.yaml.erb'),
   }
+  file {"${prometheus::config_dir}/prometheus.yml":
+    ensure => 'link',
+    target => "${prometheus::config_dir}/prometheus.yaml",
+  }
 
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -90,7 +90,7 @@ class prometheus::config(
     group   => $prometheus::group,
     mode    => $prometheus::config_mode,
     content => template('prometheus/prometheus.yaml.erb'),
-  }
+  } ->
   file {"${prometheus::config_dir}/prometheus.yml":
     ensure => 'link',
     target => "${prometheus::config_dir}/prometheus.yaml",


### PR DESCRIPTION
Hello,

I don't exactly know how and when it changed, but in the [documentation](https://prometheus.io/docs/introduction/getting_started/) it's now written the configuration file is prometheus.yml and not prometheus.yaml like in this recipe. 

I propose this dumb fix which supports both by using a symbolic link. Alternatively we could also have a variable with the filename.

Regards
