### PR TITLE
Get rid of leading whitespace in generated configs

### DIFF
--- a/templates/alert_manager.yaml.erb
+++ b/templates/alert_manager.yaml.erb
@@ -1,8 +1,8 @@
-<% require 'yaml' %>
-<% global = scope.lookupvar('::prometheus::alert_manager::global') %>
-<% templates = scope.lookupvar('::prometheus::alert_manager::templates') %>
-<% route = scope.lookupvar('::prometheus::alert_manager::route') %>
-<% receivers = scope.lookupvar('::prometheus::alert_manager::receivers') %>
-<% inhibit_rules = scope.lookupvar('::prometheus::alert_manager::inhibit_rules') %>
-<% full_config = { 'global'=>global, 'templates'=>templates, 'route'=>route, 'receivers'=>receivers, 'inhibit_rules'=>inhibit_rules }%>
-<%= full_config.to_yaml %>
+<% require 'yaml' -%>
+<% global = scope.lookupvar('::prometheus::alert_manager::global') -%>
+<% templates = scope.lookupvar('::prometheus::alert_manager::templates') -%>
+<% route = scope.lookupvar('::prometheus::alert_manager::route') -%>
+<% receivers = scope.lookupvar('::prometheus::alert_manager::receivers') -%>
+<% inhibit_rules = scope.lookupvar('::prometheus::alert_manager::inhibit_rules') -%>
+<% full_config = { 'global'=>global, 'templates'=>templates, 'route'=>route, 'receivers'=>receivers, 'inhibit_rules'=>inhibit_rules } -%>
+<%= full_config.to_yaml -%>

--- a/templates/prometheus.yaml.erb
+++ b/templates/prometheus.yaml.erb
@@ -1,6 +1,6 @@
-<% require 'yaml' %>
-<% global_config = scope.lookupvar('::prometheus::global_config') %>
-<% rule_files = scope.lookupvar('::prometheus::rule_files') %>
-<% scrape_configs = scope.lookupvar('::prometheus::scrape_configs') %>
-<% full_config = { 'global'=>global_config, 'rule_files'=>rule_files, 'scrape_configs'=>scrape_configs }%>
-<%= full_config.to_yaml %>
+<% require 'yaml' -%>
+<% global_config = scope.lookupvar('::prometheus::global_config') -%>
+<% rule_files = scope.lookupvar('::prometheus::rule_files') -%>
+<% scrape_configs = scope.lookupvar('::prometheus::scrape_configs') -%>
+<% full_config = { 'global'=>global_config, 'rule_files'=>rule_files, 'scrape_configs'=>scrape_configs } -%>
+<%= full_config.to_yaml -%>


### PR DESCRIPTION
Small fix to remove all leading whitespace from generated config files.
