### PR TITLE
Support for Prometheus PushGateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This module automates the install and configuration of Prometheus monitoring too
 
 ### What This Module Affects
 
-* Installs the prometheus daemon, alertmanager or exporters(via url or package)
+* Installs the prometheus daemon, alertmanager, pushgateway or exporters(via url or package)
   * The package method was implemented, but currently there isn't any package for prometheus
 * Optionally installs a user to run it under
 * Installs a configuration file for prometheus daemon (/etc/prometheus/prometheus.yaml) or for alertmanager (/etc/prometheus/alert.rules)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,18 @@ class prometheus::params {
   $alert_manager_download_extension = 'tar.gz'
   $alert_manager_package_ensure = 'latest'
   $alert_manager_package_name = 'alertmanager'
+  $push_gateway_version = '0.3.0'
+  $push_gateway_download_url_base = 'https://github.com/prometheus/pushgateway/releases'
+  $push_gateway_download_extension = 'tar.gz'
+  $push_gateway_package_name = 'pushgateway'
+  $push_gateway_package_ensure = 'latest'
+  $push_gateway_log_format = 'logger:stderr'
+  $push_gateway_log_level = 'info'
+  $push_gateway_storage_path=''
+  $push_gateway_persistence_file = ''
+  $push_gateway_persistence_interval = '5m0s'
+  $push_gateway_listen_address = ':9091'
+  $push_gateway_telemetry_path = '/metrics'
   $config_mode = '0660'
   $global_config = { 'scrape_interval'=> '15s', 'evaluation_interval'=> '15s', 'external_labels'=> { 'monitor'=>'master'}}
   $rule_files = [ "${config_dir}/alert.rules" ]

--- a/manifests/push_gateway.pp
+++ b/manifests/push_gateway.pp
@@ -1,0 +1,131 @@
+# Class: prometheus::push_gateway
+#
+# This module manages prometheus push_gateway
+#
+# Parameters:
+#
+#  [*manage_user*]
+#  Whether to create user for prometheus or rely on external code for that
+#
+#  [*user*]
+#  User running prometheus
+#
+#  [*manage_group*]
+#  Whether to create user for prometheus or rely on external code for that
+#
+#  [*group*]
+#  Group under which prometheus is running
+#
+#  [*bin_dir*]
+#  Directory where binaries are located
+#
+#  [*arch*]
+#  Architecture (amd64 or i386)
+#
+#  [*version*]
+#  Prometheus push_gateway release
+#
+#  [*install_method*]
+#  Installation method: url or package (only url is supported currently)
+#
+#  [*os*]
+#  Operating system (linux is the only one supported)
+#
+#  [*download_url*]
+#  Complete URL corresponding to the Prometheus push_gateway release, default to undef
+#
+#  [*download_url_base*]
+#  Base URL for prometheus push_gateway
+#
+#  [*download_extension*]
+#  Extension of Prometheus push_gateway binaries archive
+#
+#  [*package_name*]
+#  Prometheus push_gateway package name - not available yet
+#
+#  [*package_ensure*]
+#  If package, then use this for package ensure default 'latest'
+#
+#  [*extra_options*]
+#  Extra options added to push gateway startup command
+#
+#  [*service_enable*]
+#  Whether to enable or not prometheus push_gateway service from puppet (default true)
+#
+#  [*service_ensure*]
+#  State ensured from prometheus push_gateway service (default 'running')
+#
+#  [*manage_service*]
+#  Should puppet manage the prometheus push_gateway service? (default true)
+#
+#  [*restart_on_change*]
+#  Should puppet restart prometheus push_gateway on configuration change? (default true)
+#
+#  [*init_style*]
+#  Service startup scripts style (e.g. rc, upstart or systemd)
+#
+# Actions:
+#
+# Requires: see Modulefile
+#
+# Sample Usage:
+#
+class prometheus::push_gateway (
+  $manage_user          = true,
+  $user                 = $::prometheus::params::user,
+  $manage_group         = true,
+  $group                = $::prometheus::params::group,
+  $bin_dir              = $::prometheus::params::bin_dir,
+  $arch                 = $::prometheus::params::arch,
+  $version              = $::prometheus::params::push_gateway_version,
+  $install_method       = $::prometheus::params::install_method,
+  $os                   = $::prometheus::params::os,
+  $download_url         = undef,
+  $download_url_base    = $::prometheus::params::push_gateway_download_url_base,
+  $download_extension   = $::prometheus::params::push_gateway_download_extension,
+  $package_name         = $::prometheus::params::push_gateway_package_name,
+  $package_ensure       = $::prometheus::params::push_gateway_package_ensure,
+  $extra_options        = '',
+  $log_format           = $::prometheus::params::push_gateway_log_format,
+  $log_level            = $::prometheus::params::push_gateway_log_level,
+  $storage_path         = $::prometheus::params::push_gateway_storage_path,
+  $persistence_file     = $::prometheus::params::push_gateway_persistence_file,
+  $persistence_interval = $::prometheus::params::push_gateway_persistence_interval,
+  $listen_address       = $::prometheus::params::push_gateway_listen_address,
+  $telemetry_path       = $::prometheus::params::push_gateway_telemetry_path,
+  $config_mode          = $::prometheus::params::config_mode,
+  $service_enable       = true,
+  $service_ensure       = 'running',
+  $manage_service       = true,
+  $restart_on_change    = true,
+  $init_style           = $::prometheus::params::init_style,
+) inherits prometheus::params {
+  $real_download_url    = pick($download_url,
+    "${download_url_base}/download/${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
+
+  validate_bool($manage_user)
+  validate_bool($manage_service)
+  validate_bool($restart_on_change)
+  $notify_service = $restart_on_change ? {
+    true    => Class['::prometheus::push_gateway::run_service'],
+    default => undef,
+  }
+
+  if $storage_path and $persistence_file {
+    $persistence_path = "${storage_path}/${persistence_file}"
+  }
+  else {
+    $persistence_path = ""
+  }
+  $cmd_options = "-log.format ${log_format} -log.level \"${log_level}\" -persistence.file \"${persistence_path}\" -persistence.interval \"${persistence_interval}\" -web.listen-address \"${listen_address}\" -web.telemetry-path \"${telemetry_path}\""
+
+  anchor {'push_gateway_first': }
+  ->
+  class { '::prometheus::push_gateway::install': } ->
+  class { '::prometheus::push_gateway::config':
+    purge  => $purge_config_dir,
+    notify => $notify_service,
+  } ->
+  class { '::prometheus::push_gateway::run_service': } ->
+  anchor {'push_gateway_last': }
+}

--- a/manifests/push_gateway/config.pp
+++ b/manifests/push_gateway/config.pp
@@ -1,0 +1,76 @@
+# Class prometheus::push_gateway::config
+# Configuration class for prometheus node exporter
+class prometheus::push_gateway::config(
+  $purge = true,
+) {
+
+  if $prometheus::push_gateway::init_style {
+
+    case $prometheus::push_gateway::init_style {
+      'upstart' : {
+        file { '/etc/init/push_gateway.conf':
+          mode    => '0444',
+          owner   => 'root',
+          group   => 'root',
+          content => template('prometheus/push_gateway.upstart.erb'),
+        }
+        file { '/etc/init.d/push_gateway':
+          ensure => link,
+          target => '/lib/init/upstart-job',
+          owner  => 'root',
+          group  => 'root',
+          mode   => '0755',
+        }
+      }
+      'systemd' : {
+        file { '/lib/systemd/system/push_gateway.service':
+          mode    => '0644',
+          owner   => 'root',
+          group   => 'root',
+          content => template('prometheus/push_gateway.systemd.erb'),
+        }~>
+        exec { 'push_gateway-systemd-reload':
+          command     => 'systemctl daemon-reload',
+          path        => [ '/usr/bin', '/bin', '/usr/sbin' ],
+          refreshonly => true,
+        }
+      }
+      'sysv' : {
+        file { '/etc/init.d/push_gateway':
+          mode    => '0555',
+          owner   => 'root',
+          group   => 'root',
+          content => template('prometheus/push_gateway.sysv.erb')
+        }
+      }
+      'debian' : {
+        file { '/etc/init.d/push_gateway':
+          mode    => '0555',
+          owner   => 'root',
+          group   => 'root',
+          content => template('prometheus/push_gateway.debian.erb')
+        }
+      }
+      'sles' : {
+        file { '/etc/init.d/push_gateway':
+          mode    => '0555',
+          owner   => 'root',
+          group   => 'root',
+          content => template('prometheus/push_gateway.sles.erb')
+        }
+      }
+      'launchd' : {
+        file { '/Library/LaunchDaemons/io.push_gateway.daemon.plist':
+          mode    => '0644',
+          owner   => 'root',
+          group   => 'wheel',
+          content => template('prometheus/push_gateway.launchd.erb')
+        }
+      }
+      default : {
+        fail("I don't know how to create an init script for style ${prometheus::push_gateway::init_style}")
+      }
+    }
+  }
+
+}

--- a/manifests/push_gateway/install.pp
+++ b/manifests/push_gateway/install.pp
@@ -1,0 +1,74 @@
+# Class prometheus::push_gateway::install
+# Install prometheus node push_gateway via different methods with parameters from init
+# Currently only the install from url is implemented, when Prometheus will deliver packages for some Linux distros I will
+# implement the package install method as well
+# The package method needs specific yum or apt repo settings which are not made yet by the module
+class prometheus::push_gateway::install
+{
+  if $::prometheus::push_gateway::storage_path
+  {
+    file { $::prometheus::push_gateway::storage_path:
+      ensure => 'directory',
+      owner  => $::prometheus::user,
+      group  =>  $::prometheus::group,
+      mode   => '0755',
+    }
+  }
+  case $::prometheus::push_gateway::install_method {
+    'url': {
+      include staging
+      $staging_file = "push_gateway-${prometheus::push_gateway::version}.${prometheus::push_gateway::download_extension}"
+      if( versioncmp($::prometheus::push_gateway::version, '0.1.0') == -1 ){
+        $binary = "${::staging::path}/pushgateway-${::prometheus::push_gateway::version}.${::prometheus::os}-${::prometheus::arch}"
+      } else {
+        $binary = "${::staging::path}/pushgateway-${::prometheus::push_gateway::version}.${::prometheus::os}-${::prometheus::arch}/pushgateway"
+      }
+      staging::file { $staging_file:
+        source => $prometheus::push_gateway::real_download_url,
+      } ->
+      staging::extract { $staging_file:
+        target  => $::staging::path,
+        creates => $binary,
+      } ->
+      file {
+        $binary:
+          owner => 'root',
+          group => 0, # 0 instead of root because OS X uses "wheel".
+          mode  => '0555';
+        "${::prometheus::push_gateway::bin_dir}/push_gateway":
+          ensure => link,
+          notify => $::prometheus::push_gateway::notify_service,
+          target => $binary,
+      }
+    }
+    'package': {
+      package { $::prometheus::push_gateway::package_name:
+        ensure => $::prometheus::push_gateway::package_ensure,
+      }
+      if $::prometheus::push_gateway::manage_user {
+        User[$::prometheus::push_gateway::user] -> Package[$::prometheus::push_gateway::package_name]
+      }
+    }
+    'none': {}
+    default: {
+      fail("The provided install method ${::prometheus::install_method} is invalid")
+    }
+  }
+  if $::prometheus::push_gateway::manage_user {
+    ensure_resource('user', [ $::prometheus::push_gateway::user ], {
+      ensure => 'present',
+      system => true,
+      groups => $::prometheus::push_gateway::extra_groups,
+    })
+
+    if $::prometheus::push_gateway::manage_group {
+      Group[$::prometheus::push_gateway::group] -> User[$::prometheus::push_gateway::user]
+    }
+  }
+  if $::prometheus::push_gateway::manage_group {
+    ensure_resource('group', [ $::prometheus::push_gateway::group ], {
+      ensure => 'present',
+      system => true,
+    })
+  }
+}

--- a/manifests/push_gateway/run_service.pp
+++ b/manifests/push_gateway/run_service.pp
@@ -1,0 +1,20 @@
+# == Class prometheus::push_gateway::service
+#
+# This class is meant to be called from prometheus::push_gateway
+# It ensure the push_gateway service is running
+#
+class prometheus::push_gateway::run_service {
+
+  $init_selector = $prometheus::push_gateway::init_style ? {
+    'launchd' => 'io.push_gateway.daemon',
+    default   => 'push_gateway',
+  }
+
+  if $prometheus::push_gateway::manage_service == true {
+    service { 'push_gateway':
+      ensure => $prometheus::push_gateway::service_ensure,
+      name   => $init_selector,
+      enable => $prometheus::push_gateway::service_enable,
+    }
+  }
+}

--- a/templates/push_gateway.debian.erb
+++ b/templates/push_gateway.debian.erb
@@ -1,0 +1,173 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          push_gateway
+# Required-Start:    $local_fs $remote_fs
+# Required-Stop:     $local_fs $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      S 0 1 6
+# Short-Description: Prometheus push gateway
+# Description:       The pushgateway handles provides an intermediary for ephemeral metrics.
+#
+### END INIT INFO
+
+# Do NOT "set -e"
+
+# PATH should only include /usr/* if it runs after the mountnfs.sh script
+PATH=/usr/sbin:/usr/bin:/sbin:/bin:<%= scope.lookupvar('prometheus::push_gateway::bin_dir') %>
+DESC="Prometheus push gateway"
+NAME=push_gateway
+DAEMON=<%= scope.lookupvar('prometheus::push_gateway::bin_dir') %>/$NAME
+PIDFILE=/var/run/$NAME/$NAME.pid
+DAEMON_ARGS=" <%= scope.lookupvar('prometheus::push_gateway::cmd_options') %> <%= scope.lookupvar('prometheus::push_gateway::extra_options') %>"
+USER=<%= scope.lookupvar('prometheus::push_gateway::user') %>
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# Load the VERBOSE setting and other rcS variables
+[ -f /etc/default/rcS ] && . /etc/default/rcS
+
+# Define LSB log_* functions.
+# Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
+. /lib/lsb/init-functions
+
+#
+# Function to create run directory
+#
+mkrundir() {
+        [ ! -d /var/run/prometheus ] && mkdir -p /var/run/prometheus
+        chown $USER /var/run/prometheus
+}
+
+#
+# Function that starts the daemon/service
+#
+do_start()
+{
+    # Return
+    #   0 if daemon has been started
+    #   1 if daemon was already running
+    #   2 if daemon could not be started
+    mkrundir
+    start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --chuid $USER --background --make-pidfile --test > /dev/null \
+        || return 1
+    start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --chuid $USER --background --make-pidfile -- \
+        $DAEMON_ARGS \
+        || return 2
+
+    for i in `seq 1 30`; do
+        if ! start-stop-daemon --quiet --stop --test --pidfile $PIDFILE --exec $DAEMON --user $USER; then
+            RETVAL=2
+            sleep 1
+            continue
+        fi
+        if "$DAEMON" info ${RPC_ADDR} >/dev/null; then
+            return 0
+        fi
+    done
+    return "$RETVAL"
+}
+
+
+#
+# Function that stops the daemon/service
+#
+do_stop()
+{
+    # Return
+    #   0 if daemon has been stopped
+    #   1 if daemon was already stopped
+    #   2 if daemon could not be stopped
+    #   other if a failure occurred
+    start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name $NAME
+    RETVAL="$?"
+    [ "$RETVAL" = 2 ] && return 2
+    # Wait for children to finish too if this is a daemon that forks
+    # and if the daemon is only ever run from this initscript.
+    # If the above conditions are not satisfied then add some other code
+    # that waits for the process to drop all resources that could be
+    # needed by services started subsequently.  A last resort is to
+    # sleep for some time.
+    start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
+    [ "$?" = 2 ] && return 2
+    # Many daemons don't delete their pidfiles when they exit.
+    rm -f $PIDFILE
+    return "$RETVAL"
+}
+
+#
+# Function that sends a SIGHUP to the daemon/service
+#
+do_reload() {
+    #
+    # If the daemon can reload its configuration without
+    # restarting (for example, when it is sent a SIGHUP),
+    # then implement that here.
+    #
+    start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name $NAME
+    return 0
+}
+
+case "$1" in
+  start)
+    [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+    do_start
+    case "$?" in
+        0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+        2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+    esac
+    ;;
+  stop)
+    [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+    do_stop
+    case "$?" in
+        0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+        2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+    esac
+    ;;
+  #reload|force-reload)
+    #
+    # If do_reload() is not implemented then leave this commented out
+    # and leave 'force-reload' as an alias for 'restart'.
+    #
+    #log_daemon_msg "Reloading $DESC" "$NAME"
+    #do_reload
+    #log_end_msg $?
+    #;;
+  restart|force-reload)
+    #
+    # If the "reload" option is implemented then remove the
+    # 'force-reload' alias
+    #
+    log_daemon_msg "Restarting $DESC" "$NAME"
+    do_stop
+    case "$?" in
+      0|1)
+        do_start
+        case "$?" in
+            0) log_end_msg 0 ;;
+            1) log_end_msg 1 ;; # Old process is still running
+            *) log_end_msg 1 ;; # Failed to start
+        esac
+        ;;
+      *)
+        # Failed to stop
+        log_end_msg 1
+        ;;
+    esac
+    ;;
+  status)
+      status_of_proc -p $PIDFILE $DAEMON $NAME && exit 0 || exit $?
+      ;;
+  *)
+    #echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
+    echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+    exit 3
+    ;;
+esac
+
+:

--- a/templates/push_gateway.launchd.erb
+++ b/templates/push_gateway.launchd.erb
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>             <string>io.push_gateway.daemon</string>
+    <key>UserName</key>          <string><%= scope.lookupvar('prometheus::push_gateway::user') %></string>
+    <key>GroupName</key>         <string><%= scope.lookupvar('prometheus::push_gateway::group') %></string>
+<% if scope.lookupvar('prometheus::push_gateway::service_enable') %>
+    <key>Disabled</key>          <false/>
+<% else %>
+    <key>Disabled></key>         <true/>
+<% end %>
+    <key>RunAtLoad</key>         <true/>
+    <key>KeepAlive</key>         <true/>
+    <key>ProgramArguments</key>
+        <array>
+            <string><%= scope.lookupvar('prometheus::push_gateway::bin_dir') %>/prometheus</string>
+            <string>agent</string>
+<% require 'shellwords' %>
+<% for cmd_option in Shellwords.split(scope.lookupvar('prometheus::push_gateway::cmd_options')) %>
+<% for extra_option in Shellwords.split(scope.lookupvar('prometheus::push_gateway::extra_options')) %>
+            <string><%= cmd_option %> <%= extra_option %></string>
+<% end %>
+        </array>
+</dict>
+</plist>

--- a/templates/push_gateway.sles.erb
+++ b/templates/push_gateway.sles.erb
@@ -1,0 +1,99 @@
+#!/bin/bash
+#
+#       /etc/rc.d/init.d/push_gateway
+#
+#       Daemonize the prometheus push gateway.
+#
+### BEGIN INIT INFO
+# Provides:          push_gateway
+# Required-Start:    network
+# Should-Start:      $null
+# Required-Stop:     $null
+# Should-Stop:	     $null
+# Default-Start:     3 5
+# Default-Stop:      0 1 2 6
+# Short-Description: Prometheus push gateway
+# Description:       The pushgateway handles provides an intermediary for ephemeral metrics.
+### END INIT INFO
+
+. /etc/rc.status
+
+rc_reset
+
+push_gateway_BIN=<%= scope.lookupvar('prometheus::push_gateway::bin_dir') %>/push_gateway
+LOG_FILE=/var/log/push_gateway
+
+
+# read settings like GOMAXPROCS from "/etc/sysconfig/prometheus"
+[ -e /etc/sysconfig/push_gateway ] && . /etc/sysconfig/push_gateway
+
+export GOMAXPROCS=${GOMAXPROCS:-2}
+
+
+case "$1" in
+    start)
+        echo -n "Starting Prometheus push gateway"
+        ## Start daemon with startproc(8). If this fails
+        ## the return value is set appropriately by startproc.
+        startproc $push_gateway_BIN <%= scope.lookupvar('prometheus::push_gateway::cmd_options') %> <%= scope.lookupvar('prometheus::push_gateway::extra_options') %> >> "$LOG_FILE"
+
+        # Remember status and be verbose
+        rc_status -v
+        ;;
+    stop)
+        echo -n "Shutting down prometheus "
+        ## Stop daemon with killproc(8) and if this fails
+        ## killproc sets the return value according to LSB.
+
+        killproc -TERM $push_gateway_BIN
+
+        # Remember status and be verbose
+        rc_status -v
+        ;;
+    restart)
+        ## Stop the service and regardless of whether it was
+        ## running or not, start it again.
+        $0 stop
+        $0 start
+
+        # Remember status and be quiet
+        rc_status
+        ;;
+    reload)
+        # If it supports signaling:
+        echo -n "Reload service prometheus "
+        killproc -HUP $push_gateway_BIN
+        #touch /var/run/prometheus.pid
+        rc_status -v
+
+        ## Otherwise if it does not support reload:
+        #rc_failed 3
+        #rc_status -v
+        ;;
+    status)
+        echo -n "Checking for service prometheus "
+        ## Check status with checkproc(8), if process is running
+        ## checkproc will return with exit status 0.
+
+        # Return value is slightly different for the status command:
+        # 0 - service up and running
+        # 1 - service dead, but /var/run/  pid  file exists
+        # 2 - service dead, but /var/lock/ lock file exists
+        # 3 - service not running (unused)
+        # 4 - service status unknown :-(
+        # 5--199 reserved (5--99 LSB, 100--149 distro, 150--199 appl.)
+
+        # NOTE: checkproc returns LSB compliant status values.
+        checkproc $push_gateway_BIN
+        # NOTE: rc_status knows that we called this init script with
+        # "status" option and adapts its messages accordingly.
+        rc_status -v
+        ;;
+    *)
+        ## If no parameters are given, print which are avaiable.
+        echo "Usage: $0 {start|stop|status|restart|reload}"
+        exit 1
+        ;;
+esac
+
+rc_exit

--- a/templates/push_gateway.systemd.erb
+++ b/templates/push_gateway.systemd.erb
@@ -1,0 +1,17 @@
+[Unit]
+Description=The pushgateway handles provides an intermediary for ephemeral metrics.
+Wants=basic.target
+After=basic.target network.target
+
+[Service]
+User=<%= scope.lookupvar('prometheus::push_gateway::user') %>
+Group=<%= scope.lookupvar('prometheus::push_gateway::group') %>
+ExecStart=<%= scope.lookupvar('prometheus::push_gateway::bin_dir') %>/push_gateway \
+  <%= scope.lookupvar('prometheus::push_gateway::cmd_options') %> <%= scope.lookupvar('prometheus::push_gateway::extra_options') %>
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
+Restart=always
+RestartSec=42s
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/push_gateway.sysv.erb
+++ b/templates/push_gateway.sysv.erb
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+#       /etc/rc.d/init.d/push_gateway
+#
+#       Daemonize the prometheus push gateway
+#
+# chkconfig:   2345 95 20
+# description: The pushgateway handles provides an intermediary for ephemeral metrics.
+# processname: push_gateway
+# pidfile: /var/run/push_gateway/pidfile
+
+# Source function library.
+. /etc/init.d/functions
+
+DAEMON=<%= scope.lookupvar('prometheus::push_gateway::bin_dir') %>/push_gateway
+PID_FILE=/var/run/push_gateway/push_gateway.pid
+LOG_FILE=/var/log/push_gateway
+
+[ -e /etc/sysconfig/push_gateway ] && . /etc/sysconfig/push_gateway
+
+export GOMAXPROCS=${GOMAXPROCS:-2}
+
+#
+# Create the /var/run/push_gateway directory, which can live on a tmpfs
+# filesystem and be destroyed between reboots.
+#
+mkrundir() {
+        [ ! -d /var/run/push_gateway ] && mkdir -p /var/run/push_gateway
+        chown <%= scope.lookupvar('prometheus::push_gateway::user') %> /var/run/push_gateway
+}
+
+#
+# Create a PID file if it doesn't already exist, for clean upgrades
+# from previous init-script controlled daemons.
+#
+KILLPROC_OPT="-p ${PID_FILE}"
+mkpidfile() {
+        # Create PID file if it didn't exist
+        mkrundir
+        [ ! -f $PID_FILE ] && pidofproc $DAEMON > $PID_FILE
+        chown <%= scope.lookupvar('prometheus::push_gateway::user') %> /var/run/push_gateway
+        if [ $? -ne 0 ] ; then
+            rm $PID_FILE
+            KILLPROC_OPT=""
+        fi
+}
+
+start() {
+        echo -n "Starting prometheus push gateway: "
+        mkrundir
+        [ -f $PID_FILE ] && rm $PID_FILE
+        daemon --user=<%= scope.lookupvar('prometheus::push_gateway::user') %> \
+            --pidfile="$PID_FILE" \
+            "$DAEMON" <%= scope.lookupvar('prometheus::push_gateway::cmd_options') %> <%= scope.lookupvar('prometheus::push_gateway::extra_options') %> >> "$LOG_FILE" &
+        retcode=$?
+        mkpidfile
+        touch /var/lock/subsys/push_gateway
+        return $retcode
+}
+
+stop() {
+        DELAY=5 # seconds maximum to wait for a leave
+
+        echo -n "Shutting down prometheus push_gateway: "
+        mkpidfile
+
+        push_gateway_pid=$(cat $PID_FILE)
+        killproc $KILLPROC_OPT $DAEMON -INT
+        retcode=$?
+
+        # We'll wait if necessary to make sure the leave works, and return
+        # early if we can.  If not, escalate to harsher signals.
+        try=0
+        while [ $try -lt $DELAY ]; do
+        if ! checkpid $push_gateway_pid ; then
+          rm -f /var/lock/subsys/push_gateway
+          return $retcode
+        fi
+        sleep 1
+          let try+=1
+        done
+
+        # If acting as a server, use a SIGTERM to avoid a leave.
+        # This behavior is also configurable.  Avoid doing a "leave" because
+        # having servers missing is a bad thing that we want to notice.
+        #
+        # A SIGTERM will mark the node as "failed" until it rejoins.
+        # killproc with no arguments uses TERM, then escalates to KILL.
+        killproc $KILLPROC_OPT $DAEMON
+        retcode=$?
+
+        rm -f /var/lock/subsys/push_gateway $PID_FILE
+        return $retcode
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status -p ${PID_FILE} $DAEMON
+        ;;
+    restart)
+        stop
+        start
+        ;;
+    reload)
+        mkpidfile
+        killproc $KILLPROC_OPT $DAEMON -HUP
+        ;;
+    condrestart)
+        [ -f /var/lock/subsys/push_gateway ] && restart || :
+        ;;
+    *)
+        echo "Usage: push_gateway {start|stop|status|reload|restart}"
+        exit 1
+        ;;
+esac
+retcode=$?
+# Don't let the [OK] get stomped on.
+echo
+exit $retcode

--- a/templates/push_gateway.upstart.erb
+++ b/templates/push_gateway.upstart.erb
@@ -1,0 +1,30 @@
+# Prometheus Push Gateway (Upstart unit)
+description "The pushgateway handles provides an intermediary for ephemeral metrics."
+start on runlevel [2345]
+stop on runlevel [06]
+
+env push_gateway=<%= scope.lookupvar('prometheus::push_gateway::bin_dir') %>/push_gateway
+env USER=<%= scope.lookupvar('prometheus::push_gateway::user') %>
+env GROUP=<%= scope.lookupvar('prometheus::push_gateway::group') %>
+env DEFAULTS=/etc/default/push_gateway
+env RUNDIR=/var/run/push_gateway
+env PID_FILE=/var/run/push_gateway/push_gateway.pid
+pre-start script
+  [ -e $DEFAULTS ] && . $DEFAULTS
+
+  mkdir -p $RUNDIR           || true
+  chmod 0750 $RUNDIR         || true
+  chown $USER:$GROUP $RUNDIR || true
+end script
+
+script
+    # read settings like GOMAXPROCS from "/etc/default/push_gateway", if available.
+    [ -e $DEFAULTS ] && . $DEFAULTS
+
+    export GOMAXPROCS=${GOMAXPROCS:-2}
+    exec start-stop-daemon -c $USER -g $GROUP -p $PID_FILE -x $push_gateway -S -- <%= scope.lookupvar('prometheus::push_gateway::cmd_options') %> <%= scope.lookupvar('prometheus::push_gateway::extra_options') %>
+end script
+
+respawn
+respawn limit 10 10
+kill timeout 10

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,3 +1,4 @@
 include prometheus
 include prometheus::node_exporter
 include prometheus::alert_manager
+include prometheus::push_gateway


### PR DESCRIPTION
Here is proposed support for pushgateway (https://github.com/prometheus/pushgateway)

It's based heavily on the existing alert_manager code and should be comprehensive. There's no configuration file for a pushgateway just command-line switches so I've broken those down as params.

I admit that I've only tested this on CentOS7 (systemd), but all the other service-start scripts are so close to those for alertmanager that issues seem unlikely.
