### PR TITLE
allow specification of a custom template

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,7 @@ class prometheus::config(
   $rule_files,
   $scrape_configs,
   $purge = true,
+  $config_template = $::prometheus::params::config_template,
 ) {
 
   if $prometheus::init_style {
@@ -89,7 +90,7 @@ class prometheus::config(
     owner   => $prometheus::user,
     group   => $prometheus::group,
     mode    => $prometheus::config_mode,
-    content => template('prometheus/prometheus.yaml.erb'),
+    content => template($config_template),
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,9 @@
 #  [*config_defaults*]
 #  Startup config defaults
 #
+#  [*config_template*]
+#  Configuration template to use (template/prometheus.yaml.erb)
+#
 #  [*config_mode*]
 #  Configuration file mode (default 0660)
 #
@@ -119,6 +122,7 @@ class prometheus (
   $extra_options        = '',
   $config_hash          = {},
   $config_defaults      = {},
+  $config_template      = $::prometheus::params::config_template,
   $config_mode          = $::prometheus::params::config_mode,
   $service_enable       = true,
   $service_ensure       = 'running',
@@ -157,11 +161,12 @@ class prometheus (
   ->
   class { '::prometheus::install': } ->
   class { '::prometheus::config':
-    global_config  => $global_config,
-    rule_files     => $rule_files,
-    scrape_configs => $scrape_configs,
-    purge          => $purge_config_dir,
-    notify         => $notify_service,
+    global_config   => $global_config,
+    rule_files      => $rule_files,
+    scrape_configs  => $scrape_configs,
+    purge           => $purge_config_dir,
+    notify          => $notify_service,
+    config_template => $config_template,
   } ->
   class { '::prometheus::run_service': } ->
   anchor {'prometheus_last': }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,7 @@ class prometheus::params {
   $alert_manager_download_extension = 'tar.gz'
   $alert_manager_package_ensure = 'latest'
   $alert_manager_package_name = 'alertmanager'
+  $config_template = 'prometheus/prometheus.yaml.erb'
   $config_mode = '0660'
   $global_config = { 'scrape_interval'=> '15s', 'evaluation_interval'=> '15s', 'external_labels'=> { 'monitor'=>'master'}}
   $rule_files = [ "${config_dir}/alert.rules" ]


### PR DESCRIPTION
we haven't managed to pass relabel configs without weird encoding issues (\. and other regex chars get interpreted and saved as values like \x5c.
so we've added a parameter to override the used template and hardcode the stuff in the template to avoid the weird hiera yaml decode and template yaml encode

example: `prometheus::config_template: 'components/prometheus/aws.yaml.erb'`

whereas the template might look like (this is actual example for some annoying apache storm metric rewriting)

    <% require 'yaml' -%>
    <% global_config = scope.lookupvar('::prometheus::global_config') -%>
    <% rule_files = scope.lookupvar('::prometheus::rule_files') -%>
    <% full_config = { 'global'=>global_config, 'rule_files'=>rule_files} -%>
    <%= full_config.to_yaml -%>
    
        scrape_configs:
          - job_name: some-job-name
          scrape_interval: "5s"
          scrape_timeout: "5s"
          static_configs:
            - targets:
                - "foo:1234"
                - "bar:1234"
                - "baz:1234"
            - labels:
                alias: "Awesome Production"
          metric_relabel_configs:
            - source_labels: ['operation']
              regex:         '\"(.*)\..*\"'
              target_label:  'metric'
              replacement:   '$1'
            - source_labels: ['operation']
              regex:         '\".*\.(.*)\"'
              target_label:  'sub_metric'
              replacement:   '$1'
            - source_labels: ['operation']
              target_label:  'operation'
              replacement:   ''

