### PR TITLE
move systemd files to /etc

### DIFF
--- a/manifests/alert_manager/config.pp
+++ b/manifests/alert_manager/config.pp
@@ -23,7 +23,7 @@ class prometheus::alert_manager::config(
         }
       }
       'systemd' : {
-        file { '/lib/systemd/system/alert_manager.service':
+        file { '/etc/systemd/system/alert_manager.service':
           mode    => '0644',
           owner   => 'root',
           group   => 'root',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,7 +27,7 @@ class prometheus::config(
         }
       }
       'systemd' : {
-        file { '/lib/systemd/system/prometheus.service':
+        file { '/etc/systemd/system/prometheus.service':
           mode    => '0644',
           owner   => 'root',
           group   => 'root',

--- a/manifests/node_exporter/config.pp
+++ b/manifests/node_exporter/config.pp
@@ -23,7 +23,7 @@ class prometheus::node_exporter::config(
         }
       }
       'systemd' : {
-        file { '/lib/systemd/system/node_exporter.service':
+        file { '/etc/systemd/system/node_exporter.service':
           mode    => '0644',
           owner   => 'root',
           group   => 'root',


### PR DESCRIPTION
To be able to install prometheus from package with systemd file, move the systemd file generated with puppet to /etc 
So we can install from a package and be able to customize the systemd file via puppet.

see   https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Unit%20File%20Load%20Path