### PR TITLE
Class Defiinitions: alerts.pp

### DIFF
--- a/manifests/alerts.pp
+++ b/manifests/alerts.pp
@@ -9,9 +9,9 @@
 #  Array of alerts (see README)
 #
 class prometheus::alerts (
-  String $location,
-  Array  $alerts,
-  String $alertfile_name  = 'alert.rules'
+  $location        = $::prometheus::params::alertmanager_config_dir,
+  $alerts          = [],
+  $alertfile_name  = 'alert.rules'
 ) inherits prometheus::params {
 
     if $alerts != [] {


### PR DESCRIPTION
Not really a vulnerability, but ensuring that this module will still run in older puppet environments.  We are currently using Puppet 3.8.7 (I know, it's REALLY old).  Basically with the manafests/alerts.pp file declarations the way they begin presently, it results in the following error:

```
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Syntax error at 'String'; expected ')' at /puppet/src/environments/production/modules/prometheus/manifests/alerts.pp:12 on node redacted.example.net 
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```

This will correct the definition using the defaults that are already available.