### PR TITLE
Use same namespace for Prometheus and its components

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,7 +27,7 @@ class prometheus::config(
         }
       }
       'systemd' : {
-        file { '/lib/systemd/system/prometheus.service':
+        file { '/etc/systemd/system/prometheus.service':
           mode    => '0644',
           owner   => 'root',
           group   => 'root',


### PR DESCRIPTION
We should not use different directories for Systemd unit files.