### PR TITLE
$DAEMON info is only available for the prometheus daemon

### DIFF
--- a/templates/daemon.debian.erb
+++ b/templates/daemon.debian.erb
@@ -59,18 +59,6 @@ do_start()
     start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --chuid $USER --background --make-pidfile -- \
         $DAEMON_ARGS \
         || return 2
-
-    for i in `seq 1 30`; do
-        if ! start-stop-daemon --quiet --stop --test --pidfile $PIDFILE --exec $DAEMON --user $USER; then
-            RETVAL=2
-            sleep 1
-            continue
-        fi
-        if "$DAEMON" info ${RPC_ADDR} >/dev/null; then
-            return 0
-        fi
-    done
-    return "$RETVAL"
 }
 
 


### PR DESCRIPTION
Without this patch, the script will loop with the following:
```
+ start-stop-daemon --quiet --stop --test --pidfile /var/run/apache_exporter/apache_exporter.pid --exec /usr/local/bin/apache_exporter --user apache-exporter
+ /usr/local/bin/apache_exporter info
INFO[0000] Starting Server: :9117                        source=apache_exporter.go:283
FATA[0000] listen tcp :9117: bind: address already in use  source=apache_exporter.go:285
```