### PR TITLE
Allow override of extract command for archives

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -15,6 +15,7 @@ prometheus::bin_dir: '/usr/local/bin'
 prometheus::version: '2.4.3'
 prometheus::install_method: 'url'
 prometheus::manage_prometheus_server: false
+prometheus::extract_command: ~
 prometheus::alert_relabel_config: []
 prometheus::alertmanagers_config: []
 prometheus::alertmanager::config_dir: '/etc/alertmanager'

--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -56,31 +56,35 @@
 #  [*manage_service*]
 #  Should puppet manage the service? (default true)
 #
+#  [*extract_command*]
+#  Custom command passed to the archive resource to extract the downloaded archive.
+#
 define prometheus::daemon (
   String $version,
   Variant[Stdlib::HTTPSUrl, Stdlib::HTTPUrl] $real_download_url,
   $notify_service,
   String $user,
   String $group,
-  String $install_method          = $prometheus::install_method,
-  String $download_extension      = $prometheus::download_extension,
-  String $os                      = $prometheus::os,
-  String $arch                    = $prometheus::real_arch,
-  Stdlib::Absolutepath $bin_dir   = $prometheus::bin_dir,
-  String $bin_name                = $name,
-  Optional[String] $package_name  = undef,
-  String $package_ensure          = 'installed',
-  Boolean $manage_user            = true,
-  Array $extra_groups             = [],
-  Boolean $manage_group           = true,
-  Boolean $purge                  = true,
-  String $options                 = '',
-  String $init_style              = $prometheus::init_style,
-  String $service_ensure          = 'running',
-  Boolean $service_enable         = true,
-  Boolean $manage_service         = true,
-  Hash[String, Scalar] $env_vars  = {},
-  Optional[String] $env_file_path = $prometheus::env_file_path,
+  String $install_method               = $prometheus::install_method,
+  String $download_extension           = $prometheus::download_extension,
+  String $os                           = $prometheus::os,
+  String $arch                         = $prometheus::real_arch,
+  Stdlib::Absolutepath $bin_dir        = $prometheus::bin_dir,
+  String $bin_name                     = $name,
+  Optional[String] $package_name       = undef,
+  String $package_ensure               = 'installed',
+  Boolean $manage_user                 = true,
+  Array $extra_groups                  = [],
+  Boolean $manage_group                = true,
+  Boolean $purge                       = true,
+  String $options                      = '',
+  String $init_style                   = $prometheus::init_style,
+  String $service_ensure               = 'running',
+  Boolean $service_enable              = true,
+  Boolean $manage_service              = true,
+  Hash[String, Scalar] $env_vars       = {},
+  Optional[String] $env_file_path      = $prometheus::env_file_path,
+  Optional[String[1]] $extract_command = $prometheus::extract_command,
 ) {
 
   case $install_method {
@@ -108,6 +112,7 @@ define prometheus::daemon (
           creates         => "/opt/${name}-${version}.${os}-${arch}/${name}",
           cleanup         => true,
           before          => File["/opt/${name}-${version}.${os}-${arch}/${name}"],
+          extract_command => $extract_command,
         }
       }
       file { "/opt/${name}-${version}.${os}-${arch}/${name}":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -130,6 +130,9 @@
 #  via a reverse proxy). Used for generating relative and absolute links back to Alertmanager itself.
 #  If omitted, relevant URL components will be derived automatically.
 #
+#  [*extract_command*]
+#  Custom command passed to the archive resource to extract the downloaded archive.
+#
 # Actions:
 #
 # Requires: see Modulefile
@@ -175,6 +178,7 @@ class prometheus (
   Boolean $manage_group,
   Boolean $purge_config_dir,
   Boolean $manage_user,
+  Optional[String[1]] $extract_command,
   Hash $extra_alerts    = {},
   Hash $config_hash     = {},
   Hash $config_defaults = {},

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,6 +25,7 @@ class prometheus::install {
         checksum_verify => false,
         creates         => "/opt/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/prometheus",
         cleanup         => true,
+        extract_command => $prometheus::extract_command,
       }
       -> file {
         "/opt/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/prometheus":


### PR DESCRIPTION
Usecase:

The current `puppet-archive` extraction logic preserves the uid/gid in the tarball when extracting. This will permit users of GNU tar to use something like '--no-same-owner' or similar for their platform.