### PR TITLE
Remove systemd module dependency and fix missing path for a exec

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,5 @@ fixtures:
   repositories:
     archive: "https://github.com/voxpupuli/puppet-archive"
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib"
-    systemd: "https://github.com/camptocamp/puppet-systemd"
   symlinks:
     "prometheus": "#{source_dir}"

--- a/manifests/service_reload.pp
+++ b/manifests/service_reload.pp
@@ -17,6 +17,7 @@ class prometheus::service_reload() {
 
     exec { 'prometheus-reload':
       command     => $prometheus_reload,
+      path        => [ '/usr/bin', '/bin', '/usr/sbin' ],
       refreshonly => true,
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -13,10 +13,6 @@
       "version_requirement":">=1.3.0 <2.0.0"
     },
     {
-      "name":"camptocamp/systemd",
-      "version_requirement":">=0.4.0 <1.0.0"
-    },
-    {
       "name":"puppetlabs/stdlib",
       "version_requirement":">= 4.6.0 <5.0.0"
     }


### PR DESCRIPTION
camptocamp/systemd only replaces a single exec but can cause conflicts with the many other systemd puppet modules around.
