### PR TITLE
node_exporter 0.15.0 compatibiity

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 | ----------------    | ----------------------------------- |
 | >= 0.16.2           | latest                              |
 
+node_exporter >= 0.15.0
+
 
 ## Background
 
@@ -82,9 +84,7 @@ alertrules:
 On the monitored nodes:
 
 ```puppet
-class { '::prometheus::node_exporter':
-  collectors => ['diskstats','filesystem','loadavg','meminfo','netdev','stat','time']
-}
+   include prometheus::node_exporter
 ```
 
 or:
@@ -92,14 +92,9 @@ or:
 ```puppet
 class { 'prometheus::node_exporter':
     version => '0.12.0',
-    collectors => ['diskstats','filesystem','loadavg','meminfo','logind','netdev','netstat','stat','time','interrupts','ntp','tcpstat'],
-    extra_options => '-collector.ntp.server ntp1.orange.intra',
+    collectors_disable => ['loadavg','mdadm' ],
+    extra_options => '--collector.ntp.server ntp1.orange.intra',
 }
-```
-
-or simply:
-```puppet
-include ::prometheus::node_exporter
 ```
 
 For more information regarding class parameters please take a look at class docstring.

--- a/manifests/node_exporter.pp
+++ b/manifests/node_exporter.pp
@@ -85,32 +85,32 @@
 #  [*version*]
 #  The binary release version
 class prometheus::node_exporter (
-  $arch                             = $::prometheus::params::arch,
-  $bin_dir                          = $::prometheus::params::bin_dir,
-  $collectors                       = undef,
-  Array[String] $collectors_enable  = [],
-  Array[String] $collectors_disable = [],
-  $download_extension               = $::prometheus::params::node_exporter_download_extension,
-  $download_url                     = undef,
-  $download_url_base                = $::prometheus::params::node_exporter_download_url_base,
-  $extra_groups                     = $::prometheus::params::node_exporter_extra_groups,
-  $extra_options                    = '',
-  $group                            = $::prometheus::params::node_exporter_group,
-  $init_style                       = $::prometheus::params::init_style,
-  $install_method                   = $::prometheus::params::install_method,
-  $manage_group                     = true,
-  $manage_service                   = true,
-  $manage_user                      = true,
-  $os                               = $::prometheus::params::os,
-  $package_ensure                   = $::prometheus::params::node_exporter_package_ensure,
-  $package_name                     = $::prometheus::params::node_exporter_package_name,
-  $purge_config_dir                 = true,
-  $restart_on_change                = true,
-  $service_enable                   = true,
-  $service_ensure                   = 'running',
-  $service_name                     = 'node_exporter',
-  $user                             = $::prometheus::params::node_exporter_user,
-  $version                          = $::prometheus::params::node_exporter_version,
+  String                  $arch               = $::prometheus::params::arch,
+  String                  $bin_dir            = $::prometheus::params::bin_dir,
+  Optional[Array[String]] $collectors                       = undef,
+  Array[String]           $collectors_enable  = [],
+  Array[String]           $collectors_disable = [],
+  String                  $download_extension = $::prometheus::params::node_exporter_download_extension,
+  Optional[String]        $download_url       = undef,
+  String                  $download_url_base  = $::prometheus::params::node_exporter_download_url_base,
+  Array[String]           $extra_groups       = $::prometheus::params::node_exporter_extra_groups,
+  String                  $extra_options      = '',
+  String                  $group              = $::prometheus::params::node_exporter_group,
+  Optional[String]        $init_style         = $::prometheus::params::init_style,
+  String                  $install_method     = $::prometheus::params::install_method,
+  Boolean                 $manage_group       = true,
+  Boolean                 $manage_service     = true,
+  Boolean                 $manage_user        = true,
+  String                  $os                 = $::prometheus::params::os,
+  String                  $package_ensure     = $::prometheus::params::node_exporter_package_ensure,
+  String                  $package_name       = $::prometheus::params::node_exporter_package_name,
+  Boolean                 $purge_config_dir   = true,
+  Boolean                 $restart_on_change  = true,
+  Boolean                 $service_enable     = true,
+  String                  $service_ensure     = 'running',
+  String                  $service_name       = 'node_exporter',
+  String                  $user               = $::prometheus::params::node_exporter_user,
+  String                  $version            = $::prometheus::params::node_exporter_version,
 ) inherits prometheus::params {
   # Prometheus added a 'v' on the realease name at 0.13.0
   if versioncmp ($version, '0.13.0') >= 0 {
@@ -120,10 +120,6 @@ class prometheus::node_exporter (
     $release = $version
   }
   $real_download_url = pick($download_url,"${download_url_base}/download/${release}/${package_name}-${version}.${os}-${arch}.${download_extension}")
-  validate_bool($purge_config_dir)
-  validate_bool($manage_user)
-  validate_bool($manage_service)
-  validate_bool($restart_on_change)
   if $collectors {
     warning('Use of $collectors parameter is deprecated')
   }

--- a/manifests/node_exporter.pp
+++ b/manifests/node_exporter.pp
@@ -124,7 +124,7 @@ class prometheus::node_exporter (
   validate_bool($manage_user)
   validate_bool($manage_service)
   validate_bool($restart_on_change)
-  if $collectors != undef {
+  if $collectors {
     warning('Use of $collectors parameter is deprecated')
   }
 

--- a/manifests/node_exporter.pp
+++ b/manifests/node_exporter.pp
@@ -11,7 +11,16 @@
 #  Directory where binaries are located
 #
 #  [*collectors*]
-#  The set of node node_exporter collectors. Use default collectors if empty.
+#  deprecated, unused kept for migration scenatrios
+#  will be removed in next release
+#
+#  [*collectors_enable*]
+#  Collectors to enable, addtionally to the defaults
+#  https://github.com/prometheus/node_exporter#enabled-by-default
+#
+#  [*collectors_disbale*]
+#  disable collectors which are enabled by default
+#  https://github.com/prometheus/node_exporter#enabled-by-default
 #
 #  [*download_extension*]
 #  Extension for the release binary archive
@@ -76,30 +85,32 @@
 #  [*version*]
 #  The binary release version
 class prometheus::node_exporter (
-  $arch                 = $::prometheus::params::arch,
-  $bin_dir              = $::prometheus::params::bin_dir,
-  $collectors           = $::prometheus::params::node_exporter_collectors,
-  $download_extension   = $::prometheus::params::node_exporter_download_extension,
-  $download_url         = undef,
-  $download_url_base    = $::prometheus::params::node_exporter_download_url_base,
-  $extra_groups         = $::prometheus::params::node_exporter_extra_groups,
-  $extra_options        = '',
-  $group                = $::prometheus::params::node_exporter_group,
-  $init_style           = $::prometheus::params::init_style,
-  $install_method       = $::prometheus::params::install_method,
-  $manage_group         = true,
-  $manage_service       = true,
-  $manage_user          = true,
-  $os                   = $::prometheus::params::os,
-  $package_ensure       = $::prometheus::params::node_exporter_package_ensure,
-  $package_name         = $::prometheus::params::node_exporter_package_name,
-  $purge_config_dir     = true,
-  $restart_on_change    = true,
-  $service_enable       = true,
-  $service_ensure       = 'running',
-  $service_name         = 'node_exporter',
-  $user                 = $::prometheus::params::node_exporter_user,
-  $version              = $::prometheus::params::node_exporter_version,
+  $arch                             = $::prometheus::params::arch,
+  $bin_dir                          = $::prometheus::params::bin_dir,
+  $collectors                       = undef,
+  Array[String] $collectors_enable  = [],
+  Array[String] $collectors_disable = [],
+  $download_extension               = $::prometheus::params::node_exporter_download_extension,
+  $download_url                     = undef,
+  $download_url_base                = $::prometheus::params::node_exporter_download_url_base,
+  $extra_groups                     = $::prometheus::params::node_exporter_extra_groups,
+  $extra_options                    = '',
+  $group                            = $::prometheus::params::node_exporter_group,
+  $init_style                       = $::prometheus::params::init_style,
+  $install_method                   = $::prometheus::params::install_method,
+  $manage_group                     = true,
+  $manage_service                   = true,
+  $manage_user                      = true,
+  $os                               = $::prometheus::params::os,
+  $package_ensure                   = $::prometheus::params::node_exporter_package_ensure,
+  $package_name                     = $::prometheus::params::node_exporter_package_name,
+  $purge_config_dir                 = true,
+  $restart_on_change                = true,
+  $service_enable                   = true,
+  $service_ensure                   = 'running',
+  $service_name                     = 'node_exporter',
+  $user                             = $::prometheus::params::node_exporter_user,
+  $version                          = $::prometheus::params::node_exporter_version,
 ) inherits prometheus::params {
   # Prometheus added a 'v' on the realease name at 0.13.0
   if versioncmp ($version, '0.13.0') >= 0 {
@@ -113,18 +124,27 @@ class prometheus::node_exporter (
   validate_bool($manage_user)
   validate_bool($manage_service)
   validate_bool($restart_on_change)
-  validate_array($collectors)
+  if $collectors != undef {
+    warning('Use of $collectors parameter is deprecated')
+  }
+
   $notify_service = $restart_on_change ? {
     true    => Service[$service_name],
     default => undef,
   }
 
-  if empty($collectors) {
-    $options = $extra_options
-  } else {
-    $str_collectors = join($collectors, ',')
-    $options = "-collectors.enabled=${str_collectors} ${extra_options}"
+  $cmd_collectors_enable = $collectors_enable.map |$collector| {
+    "--collector.${collector}"
   }
+
+  $cmd_collectors_disable = $collectors_disable.map |$collector| {
+    "--no-collector.${collector}"
+  }
+
+
+    $options = join([$extra_options,
+      join($cmd_collectors_enable, ' '),
+      join($cmd_collectors_disable, ' ') ], ' ')
 
   prometheus::daemon { $service_name :
     install_method     => $install_method,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -89,7 +89,6 @@ class prometheus::params {
   $mongodb_exporter_package_name = 'mongodb_exporter'
   $mongodb_exporter_user = 'mongodb-exporter'
   $mongodb_exporter_version = '0.3.1'
-  $node_exporter_collectors = ['diskstats','filesystem','loadavg','meminfo','netdev','stat','time']
   $node_exporter_download_extension = 'tar.gz'
   $node_exporter_download_url_base = 'https://github.com/prometheus/node_exporter/releases'
   $node_exporter_extra_groups = []

--- a/spec/classes/node_exporter_spec.rb
+++ b/spec/classes/node_exporter_spec.rb
@@ -7,6 +7,33 @@ describe 'prometheus::node_exporter' do
         facts
       end
 
+      context 'without parameters' do
+        it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '  ') }
+      end
+
+      context 'without collector parameters' do
+        let(:params) do
+          {
+            collectors_enable: %w[foo bar],
+            collectors_disable: %w[baz qux]
+          }
+        end
+
+        it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: ' --collector.foo --collector.bar --no-collector.baz --no-collector.qux') }
+      end
+
+      context 'without collector parameters and extra options' do
+        let(:params) do
+          {
+            collectors_enable: %w[foo bar],
+            collectors_disable: %w[baz qux],
+            extra_options: '--path.procfs /host/proc --path.sysfs /host/sys'
+          }
+        end
+
+        it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '--path.procfs /host/proc --path.sysfs /host/sys --collector.foo --collector.bar --no-collector.baz --no-collector.qux') }
+      end
+
       context 'with version specified' do
         let(:params) do
           {


### PR DESCRIPTION
fixes #70
fixes #33

change collector parameterization to be compatible with node_exporter 0.15.0

this should be released with a major version since it breaks paramter compatinbility

for two step migration of profiles and roles using this keep node_exporter::collectors paramter as noop with deprecation warning for at least one release