### PR TITLE
bump puppet version dependency to at least 4.7.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -50,7 +50,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirements": "=> 4.6.1 < 6.0.0"
+      "version_requirements": "=> 4.7.1 < 6.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
4.7.1 is the oldest LTS we support

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
