### PR TITLE
Fix isssue with node_exporter containing empty pid on RHEL6.

### DIFF
--- a/templates/daemon.sysv.erb
+++ b/templates/daemon.sysv.erb
@@ -54,6 +54,7 @@ start() {
             <%- require 'shellwords' -%>
             "$DAEMON" <%= Shellwords.escape(@options) %> >> "$LOG_FILE" &
         retcode=$?
+        sleep 1
         mkpidfile
         touch /var/lock/subsys/<%= @name %>
         return $retcode


### PR DESCRIPTION
On RHEL 6 servers, sometimes the mkpidfile functions runs before the
process is fully started which results in an empty PIDFILE. Even though
the process is running, the service status returns

[root@aliwgp01:/root]# /etc/init.d/node_exporter status
node_exporter dead but pid file exists

Adding a sleep for 1 second resolves this

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
