### PR TITLE
Alertmanager global config should be a hash not an array

### DIFF
--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -139,7 +139,7 @@ class prometheus::alertmanager (
   $download_url_base         = $::prometheus::params::alertmanager_download_url_base,
   $extra_groups              = $::prometheus::params::alertmanager_extra_groups,
   $extra_options             = '',
-  Array $global              = $::prometheus::params::alertmanager_global,
+  Hash $global               = $::prometheus::params::alertmanager_global,
   $group                     = $::prometheus::params::alertmanager_group,
   Array $inhibit_rules       = $::prometheus::params::alertmanager_inhibit_rules,
   $init_style                = $::prometheus::params::init_style,

--- a/spec/classes/alertmanager_spec.rb
+++ b/spec/classes/alertmanager_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'prometheus::alertmanager' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      context 'with version specified' do
+        let(:params) do
+          {
+            version: '0.9.1',
+            arch: 'amd64',
+            os: 'linux'
+          }
+        end
+
+        describe 'install correct binary' do
+          it { is_expected.to contain_file('/usr/local/bin/alertmanager').with('target' => '/opt/alertmanager-0.9.1.linux-amd64/alertmanager') }
+        end
+        describe 'config file contents' do
+          it {
+            is_expected.to contain_file('/etc/alertmanager/alertmanager.yaml')
+            verify_contents(catalogue, '/etc/alertmanager/alertmanager.yaml', ['---', 'global:', '  smtp_smarthost: localhost:25', '  smtp_from: alertmanager@localhost'])
+          }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
19427e2 introduced a incorrect type for the global parameter, this pull request corrects this