### PR TITLE
Switch systemd restart from always to on-failure

### DIFF
--- a/templates/prometheus.systemd.erb
+++ b/templates/prometheus.systemd.erb
@@ -14,7 +14,7 @@ ExecStart=<%= scope.lookupvar('prometheus::bin_dir') %>/prometheus \
   <%= scope.lookupvar('prometheus::extra_options') %>
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
-Restart=always
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
detailed explanation: https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=
TL;DR: Only restart the service it if actually failed, not _always_

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
