### PR TITLE
blackbox exporters source_labels must be unquoted

### DIFF
--- a/templates/prometheus.yaml.erb
+++ b/templates/prometheus.yaml.erb
@@ -11,4 +11,4 @@
     'alertmanagers'=>scope.lookupvar('::prometheus::alertmanagers_config'),
   }
 } -%>
-<%= full_config.to_yaml -%>
+<%= full_config.to_yaml.gsub(/source_labels: ".+?"/) { |x| x.gsub('"', '') } -%>


### PR DESCRIPTION
when setting relabel configs we can not provide an array as to_yaml
converts this to folded. blackbox exporter expets this to be a flow
style array without any quotes.

in puppet we provide the information (e.g.):

    'relabel_configs' => [
      {
        'source_labels' => '[__address__]',
        'target_label'  => '__param_target',
      },
      {
        'source_labels' => '[__param_target]',
        'target_label'  => 'instance',
      },
      {
        'target_label' => '__address',
        'replacement'  => '127.0.0.1:9115',
      },
    ],

within the template we gsub the double quotes which '.to_yaml' adds.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
