### PR TITLE
Remove quotes from all instances of quoted array values.

### DIFF
--- a/templates/prometheus.yaml.erb
+++ b/templates/prometheus.yaml.erb
@@ -17,4 +17,4 @@ if @prometheus_v2
     full_config['remote_read'] = remote_read_configs
 end
  -%>
-<%= full_config.to_yaml(options = {:line_width => -1}).gsub(/source_labels: ".+?"/) { |x| x.gsub('"', '') } -%>
+<%= full_config.to_yaml(options = {:line_width => -1}).gsub(/.*:\W"\[.*\]"/) { |x| x.gsub('"', '') } -%>


### PR DESCRIPTION
Previous regex removed quotes from souce_label value which
contains an inline array as the value. There are other values
which also need the quotes removing. For example:
- job_name: 'blackbox'
  params:
    module: '[simple_http]'

