### PR TITLE
older versions of puppet don't know about the --to_yaml option

### DIFF
--- a/lib/facter/alert_manager_running.rb
+++ b/lib/facter/alert_manager_running.rb
@@ -1,9 +1,5 @@
 Facter.add('prometheus_alert_manager_running') do
   setcode do
-    begin
-      Facter::Core::Execution.execute('puppet resource service alert_manager').scan('running')[0]
-    rescue Facter::Core::Execution::ExecutionFailure
-      'not installed'
-    end
+    Facter::Core::Execution.execute('puppet resource service alert_manager 2>&1').scan('running')[0]
   end
 end

--- a/lib/facter/alert_manager_running.rb
+++ b/lib/facter/alert_manager_running.rb
@@ -1,5 +1,9 @@
 Facter.add('prometheus_alert_manager_running') do
   setcode do
-    Facter::Core::Execution.exec('puppet resource service alert_manager').scan('running')[0]
+    begin
+      Facter::Core::Execution.execute('puppet resource service alert_manager').scan('running')[0]
+    rescue Facter::Core::Execution::ExecutionFailure
+      'not installed'
+    end
   end
 end

--- a/lib/facter/alert_manager_running.rb
+++ b/lib/facter/alert_manager_running.rb
@@ -1,6 +1,5 @@
 Facter.add('prometheus_alert_manager_running') do
   setcode do
-    svc_status = YAML.load(Facter::Core::Execution.exec('puppet resource service alert_manager --to_yaml'))
-    svc_status['service']['alert_manager']['ensure']
+    Facter::Core::Execution.exec('puppet resource service alert_manager').scan('running')[0]
   end
 end


### PR DESCRIPTION
switching back to scanning the result

fixes #118