### PR TITLE
Correct typo in documentation header for node_exporter

### DIFF
--- a/manifests/node_exporter.pp
+++ b/manifests/node_exporter.pp
@@ -18,7 +18,7 @@
 #  Collectors to enable, addtionally to the defaults
 #  https://github.com/prometheus/node_exporter#enabled-by-default
 #
-#  [*collectors_disbale*]
+#  [*collectors_disable*]
 #  disable collectors which are enabled by default
 #  https://github.com/prometheus/node_exporter#enabled-by-default
 #


### PR DESCRIPTION
The documentation on collectors_disable had a typo saying disbale.
