### PR TITLE
Add validation to config changes

### DIFF
--- a/manifests/alerts.pp
+++ b/manifests/alerts.pp
@@ -8,34 +8,32 @@
 #  [*alerts*]
 #  Array (< prometheus 2.0.0) or Hash (>= prometheus 2.0.0) of alerts (see README).
 #
+#  [*alertfile_name*]
+#  Filename to use when storing the alerts file
+#
 class prometheus::alerts (
   String $location,
   Variant[Array,Hash] $alerts,
-  String $alertfile_name  = 'alert.rules'
+  String $alertfile_name = $prometheus::params::alertfile_name,
 ) inherits prometheus::params {
-
-  if $alerts != [] and $alerts != {} {
-    if ( versioncmp($::prometheus::version, '2.0.0') < 0 ){
-
-      file { "${location}/${alertfile_name}":
-        ensure  => 'file',
-        owner   => $prometheus::user,
-        group   => $prometheus::group,
-        notify  => Class['::prometheus::service_reload'],
-        content => epp("${module_name}/alerts.epp"),
-      }
-
+  if ( versioncmp($::prometheus::version, '2.0.0') < 0 ){
+    file { "${location}/${alertfile_name}":
+      ensure       => 'file',
+      owner        => $prometheus::user,
+      group        => $prometheus::group,
+      notify       => Class['::prometheus::service_reload'],
+      content      => epp("${module_name}/alerts.epp"),
+      validate_cmd => "${prometheus::bin_dir}/promtool check-rules %",
     }
-    else {
-
-      file { "${location}/${alertfile_name}":
-        ensure  => 'file',
-        owner   => $prometheus::user,
-        group   => $prometheus::group,
-        notify  => Class['::prometheus::service_reload'],
-        content => $alerts.to_yaml,
-      }
-
+  }
+  else {
+    file { "${location}/${alertfile_name}":
+      ensure       => 'file',
+      owner        => $prometheus::user,
+      group        => $prometheus::group,
+      notify       => Class['::prometheus::service_reload'],
+      content      => $alerts.to_yaml,
+      validate_cmd => "${prometheus::bin_dir}/promtool check rules %",
     }
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,11 +1,10 @@
 # Class prometheus::config
 # Configuration class for prometheus monitoring system
-class prometheus::config(
+class prometheus::config (
   $global_config,
   $rule_files,
   $scrape_configs,
   $remote_read_configs,
-  $purge = true,
   $config_template = $::prometheus::params::config_template,
   $storage_retention = $::prometheus::params::storage_retention,
 ) {
@@ -113,14 +112,7 @@ class prometheus::config(
     $cfg_verify_cmd = 'check-config'
   }
 
-  file { $prometheus::config_dir:
-    ensure  => 'directory',
-    owner   => $prometheus::user,
-    group   => $prometheus::group,
-    purge   => $purge,
-    recurse => $purge,
-  }
-  -> file { 'prometheus.yaml':
+  file { 'prometheus.yaml':
     ensure       => present,
     path         => "${prometheus::config_dir}/prometheus.yaml",
     owner        => $prometheus::user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -137,7 +137,7 @@ class prometheus (
   $download_extension         = $::prometheus::params::download_extension,
   $package_name               = $::prometheus::params::package_name,
   $package_ensure             = $::prometheus::params::package_ensure,
-  $config_dir                 = $::prometheus::params::config_dir,
+  String $config_dir          = $::prometheus::params::config_dir,
   $localstorage               = $::prometheus::params::localstorage,
   $extra_options              = '',
   Hash $config_hash           = {},
@@ -176,6 +176,10 @@ class prometheus (
 
   anchor {'prometheus_first': }
   -> class { '::prometheus::install': }
+  -> class { '::prometheus::alerts':
+    location => $config_dir,
+    alerts   => $alerts,
+  }
   -> class { '::prometheus::config':
     global_config       => $global_config,
     rule_files          => $rule_files,
@@ -184,10 +188,6 @@ class prometheus (
     purge               => $purge_config_dir,
     config_template     => $config_template,
     storage_retention   => $storage_retention,
-  }
-  -> class { '::prometheus::alerts':
-    location => $config_dir,
-    alerts   => $alerts,
   }
   -> class { '::prometheus::run_service': }
   -> class { '::prometheus::service_reload': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -175,7 +175,9 @@ class prometheus (
   $config_hash_real = assert_type(Hash, deep_merge($config_defaults, $config_hash))
 
   anchor {'prometheus_first': }
-  -> class { '::prometheus::install': }
+  -> class { '::prometheus::install':
+    purge_config_dir => $purge_config_dir,
+  }
   -> class { '::prometheus::alerts':
     location => $config_dir,
     alerts   => $alerts,
@@ -185,7 +187,6 @@ class prometheus (
     rule_files          => $rule_files,
     scrape_configs      => $scrape_configs,
     remote_read_configs => $remote_read_configs,
-    purge               => $purge_config_dir,
     config_template     => $config_template,
     storage_retention   => $storage_retention,
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -33,6 +33,9 @@ class prometheus::install
           ensure => link,
           notify => $::prometheus::notify_service,
           target => "/opt/prometheus-${prometheus::version}.${prometheus::os}-${prometheus::arch}/prometheus";
+        "${::prometheus::bin_dir}/promtool":
+          ensure => link,
+          target => "/opt/prometheus-${prometheus::version}.${prometheus::os}-${prometheus::arch}/promtool";
         $::prometheus::shared_dir:
           ensure => directory,
           owner  => $::prometheus::user,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,8 +3,9 @@
 # Currently only the install from url is implemented, when Prometheus will deliver packages for some Linux distros I will
 # implement the package install method as well
 # The package method needs specific yum or apt repo settings which are not made yet by the module
-class prometheus::install
-{
+class prometheus::install (
+  Boolean $purge_config_dir = true,
+) {
   if $::prometheus::localstorage {
     file { $::prometheus::localstorage:
       ensure => 'directory',
@@ -80,5 +81,12 @@ class prometheus::install
       ensure => 'present',
       system => true,
     })
+  }
+  file { $prometheus::config_dir:
+    ensure  => 'directory',
+    owner   => $prometheus::user,
+    group   => $prometheus::group,
+    purge   => $purge_config_dir,
+    recurse => $purge_config_dir,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -130,7 +130,8 @@ class prometheus::params {
   $beanstalkd_exporter_config = '/etc/beanstalkd-exporter.conf'
   $package_ensure = 'latest'
   $package_name = 'prometheus'
-  $rule_files = [ "${config_dir}/alert.rules" ]
+  $alertfile_name = 'alert.rules'
+  $rule_files = [ "${config_dir}/${alertfile_name}" ]
   $scrape_configs = [ { 'job_name'=> 'prometheus', 'scrape_interval'=> '10s', 'scrape_timeout'=> '10s', 'static_configs'=> [ { 'targets'=> [ 'localhost:9090' ], 'labels'=> { 'alias'=> 'Prometheus'} } ] } ]
   $remote_read_configs = []
   $shared_dir = '/usr/local/share/prometheus'

--- a/spec/classes/prometheus_spec.rb
+++ b/spec/classes/prometheus_spec.rb
@@ -176,7 +176,7 @@ describe 'prometheus' do
 
           # prometheus::alerts
           it {
-            is_expected.not_to contain_file('/etc/prometheus/alert.rules')
+            is_expected.to contain_file('/etc/prometheus/alert.rules')
           }
 
           # prometheus::run_service


### PR DESCRIPTION
This PR adds a symlink to promtool in the same way a symlink to prometheus is currently added to /usr/local/bin.
Than it uses File's `validate_cmd` to call promtool and avoid replacing a configuration file with a broken version, both for the central config and for the alert rules.

Finally, also fix the first error thrown by the config check: we create the alerts file even if no alerts were provided. The empty file won't trigger a syntax error and also doesn't bother prometheus itself.

Fixes #31 