### PR TITLE
Bump dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,15 +10,15 @@
   "dependencies": [
     {
       "name": "puppet/archive",
-      "version_requirement": ">=1.3.0 < 3.0.0"
+      "version_requirement": ">=2.2.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 <5.0.0"
+      "version_requirement": ">= 4.13.1 < 5.0.0"
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 1.1.1 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Ensure puppetlabs/stdlib 4.13.1 is the minimum acceptable version across this modules's dependencies.
Fixes #123 
I've marked it as a breaking change due to puppet-archive being a major version jump, and to be nice.