### PR TITLE
Feature/alerts prometheus2

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ or simply:
 include ::prometheus
 ```
 
-To add alert rules, add the following to the class prometheus:
+To add alert rules, add the following to the class prometheus in case you are using prometheus < 2.0:
 ```puppet
     alerts => [{ 'name' => 'InstanceDown', 'condition' => 'up == 0', 'timeduration' => '5m', labels => [{ 'name' => 'severity', 'content' => 'page'}], 'annotations' => [{ 'name' => 'summary', content => 'Instance {{ $labels.instance }} down'}, {'name' => 'description', content => '{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes.' }]}]
 ```
@@ -89,6 +89,23 @@ alertrules:
                 name: 'description'
                 content: '{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes.'
 
+```
+
+When using prometheus >= 2.0, we use the new yaml format (https://prometheus.io/docs/prometheus/2.0/migration/#recording-rules-and-alerts) configuration
+
+```yaml
+alerts:
+  groups:
+    - name: alert.rules
+      rules:
+      - alert: 'InstanceDown'
+        expr: 'up == 0'
+        for: '5m'
+        labels:
+          'severity': 'page'
+        annotations:
+          'summary': 'Instance {{ $labels.instance }} down'
+          'description': '{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes.'
 ```
 
 On the monitored nodes:

--- a/manifests/alerts.pp
+++ b/manifests/alerts.pp
@@ -14,9 +14,8 @@ class prometheus::alerts (
   String $alertfile_name  = 'alert.rules'
 ) inherits prometheus::params {
 
-  if ( versioncmp($::prometheus::version, '2.0.0') < 0 ){
-
-    if $alerts != [] {
+  if $alerts != [] and $alerts != {} {
+    if ( versioncmp($::prometheus::version, '2.0.0') < 0 ){
 
       file { "${location}/${alertfile_name}":
         ensure  => 'file',
@@ -27,17 +26,16 @@ class prometheus::alerts (
       }
 
     }
+    else {
 
-  }
-  else {
+      file { "${location}/${alertfile_name}":
+        ensure  => 'file',
+        owner   => $prometheus::user,
+        group   => $prometheus::group,
+        notify  => Class['::prometheus::service_reload'],
+        content => $alerts.to_yaml,
+      }
 
-    file { "${location}/${alertfile_name}":
-      ensure  => 'file',
-      owner   => $prometheus::user,
-      group   => $prometheus::group,
-      notify  => Class['::prometheus::service_reload'],
-      content => $alerts.to_yaml,
     }
-
   }
 }

--- a/manifests/alerts.pp
+++ b/manifests/alerts.pp
@@ -10,18 +10,22 @@
 #
 class prometheus::alerts (
   String $location,
-  Variant[Array,Hash] $alerts = {},
+  Variant[Array,Hash] $alerts,
   String $alertfile_name  = 'alert.rules'
 ) inherits prometheus::params {
 
   if ( versioncmp($::prometheus::version, '2.0.0') < 0 ){
 
-    file { "${location}/${alertfile_name}":
-      ensure  => 'file',
-      owner   => $prometheus::user,
-      group   => $prometheus::group,
-      notify  => Class['::prometheus::service_reload'],
-      content => epp("${module_name}/alerts.epp"),
+    if $alerts != [] {
+
+      file { "${location}/${alertfile_name}":
+        ensure  => 'file',
+        owner   => $prometheus::user,
+        group   => $prometheus::group,
+        notify  => Class['::prometheus::service_reload'],
+        content => epp("${module_name}/alerts.epp"),
+      }
+
     }
 
   }

--- a/manifests/alerts.pp
+++ b/manifests/alerts.pp
@@ -3,7 +3,7 @@
 # This module manages prometheus alerts for prometheus
 #
 #  [*location*]
-#  Whether to create the alert file for prometheus
+#  Where to create the alert file for prometheus
 #
 #  [*alerts*]
 #  Array (< prometheus 2.0.0) or Hash (>= prometheus 2.0.0) of alerts (see README).

--- a/manifests/alerts.pp
+++ b/manifests/alerts.pp
@@ -6,22 +6,34 @@
 #  Whether to create the alert file for prometheus
 #
 #  [*alerts*]
-#  Array of alerts (see README)
+#  Array (< prometheus 2.0.0) or Hash (>= prometheus 2.0.0) of alerts (see README).
 #
 class prometheus::alerts (
   String $location,
-  Array  $alerts,
+  Variant[Array,Hash] $alerts = {},
   String $alertfile_name  = 'alert.rules'
 ) inherits prometheus::params {
 
-    if $alerts != [] {
-        file{ "${location}/${alertfile_name}":
-                ensure  => 'file',
-                owner   => $prometheus::user,
-                group   => $prometheus::group,
-                notify  => Class['::prometheus::service_reload'],
-                content => epp("${module_name}/alerts.epp"),
-        }
+  if ( versioncmp($::prometheus::version, '2.0.0') < 0 ){
+
+    file { "${location}/${alertfile_name}":
+      ensure  => 'file',
+      owner   => $prometheus::user,
+      group   => $prometheus::group,
+      notify  => Class['::prometheus::service_reload'],
+      content => epp("${module_name}/alerts.epp"),
     }
 
+  }
+  else {
+
+    file { "${location}/${alertfile_name}":
+      ensure  => 'file',
+      owner   => $prometheus::user,
+      group   => $prometheus::group,
+      notify  => Class['::prometheus::service_reload'],
+      content => $alerts.to_yaml,
+    }
+
+  }
 }

--- a/spec/classes/prometheus_spec.rb
+++ b/spec/classes/prometheus_spec.rb
@@ -199,6 +199,60 @@ describe 'prometheus' do
           }
         end
       end
+
+      context 'with alerts configured', alerts: true do
+        [
+          {
+            alerts: [{
+              'name'         => 'alert_name',
+              'condition'    => 'up == 0',
+              'timeduration' => '5min',
+              'labels'       => [{ 'name' => 'severity', 'content' => 'woops' }],
+              'annotations'  => [{ 'name' => 'summary', 'content' => 'did a woops {{ $labels.instance }}' }]
+            }]
+          },
+          {
+            version: '2.0.0-rc.1',
+            alerts: {
+              'groups' => [{
+                'name' => 'alert.rules',
+                rules: [
+                  {
+                    'alert'       => 'alert_name',
+                    'expr'        => 'up == 0',
+                    'for'         => '5min',
+                    'labels'      => { 'severity' => 'woops' },
+                    'annotations' => {
+                      'summary' => 'did a woops {{ $labels.instance }}'
+                    }
+                  }
+                ]
+              }]
+            }
+          }
+        ].each do |parameters|
+          context "with prometheus version #{parameters[:version]}" do
+            let(:params) do
+              parameters
+            end
+
+            prom_version = parameters[:version] || '1.5.2'
+            prom_major = prom_version[0]
+
+            it {
+              is_expected.to compile
+            }
+            it {
+              is_expected.to contain_file('/etc/prometheus/alert.rules').with(
+                'ensure'  => 'file',
+                'owner'   => 'prometheus',
+                'group'   => 'prometheus',
+                'content' => File.read(fixtures('files', "prometheus#{prom_major}.alert.rules"))
+              ).that_notifies('Class[prometheus::service_reload]')
+            }
+          end
+        end
+      end
     end
   end
 end

--- a/spec/fixtures/files/prometheus1.alert.rules
+++ b/spec/fixtures/files/prometheus1.alert.rules
@@ -1,0 +1,9 @@
+ALERT alert_name
+    IF up == 0
+    FOR 5min
+    LABELS {
+            severity = "woops",
+        }
+    ANNOTATIONS {
+            summary = "did a woops {{ $labels.instance }}",
+        }

--- a/spec/fixtures/files/prometheus2.alert.rules
+++ b/spec/fixtures/files/prometheus2.alert.rules
@@ -1,0 +1,11 @@
+---
+groups:
+- name: alert.rules
+  rules:
+  - alert: alert_name
+    expr: up == 0
+    for: 5min
+    labels:
+      severity: woops
+    annotations:
+      summary: did a woops {{ $labels.instance }}


### PR DESCRIPTION
This PR adds alerts to prometheus 2.0 . I wrote this code because I ran into the same problem as issue #120 

This code should be backwards compatible, leaving all < 2.0 installations with the old epp template, and all newer prometheus installations can now use a yaml configuration hash, which gets converted to a YAML configuration file as needed according to the documentation (https://prometheus.io/docs/prometheus/2.0/migration/#recording-rules-and-alerts)

