### PR TITLE
Use puppet internals to determine the state of the alert_manager

### DIFF
--- a/lib/facter/alert_manager_running.rb
+++ b/lib/facter/alert_manager_running.rb
@@ -1,5 +1,9 @@
+require 'puppet'
+
+service = Puppet::Type.type(:service).new(name: 'alert_manager')
+
 Facter.add('prometheus_alert_manager_running') do
   setcode do
-    Facter::Core::Execution.execute('puppet resource service alert_manager 2>&1').scan('running')[0]
+    service.provider.status == :running
   end
 end


### PR DESCRIPTION
When the PATH has not been set up system wide to include puppet, thhe
prometheus_alert_manager_running fact throws errors in the logs. By
using puppet internals, we get the same information without going
through an 'external' execution.
