### PR TITLE
daemon: explicitly pass provider to service

### DIFF
--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -223,9 +223,10 @@ define prometheus::daemon (
 
   if $manage_service == true {
     service { $name:
-      ensure => $service_ensure,
-      name   => $init_selector,
-      enable => $service_enable,
+      ensure   => $service_ensure,
+      name     => $init_selector,
+      enable   => $service_enable,
+      provider => $init_style,
     }
   }
 }

--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -221,12 +221,18 @@ define prometheus::daemon (
     default   => $name,
   }
 
+  $real_provider = $init_style ? {
+    'sles'  => 'redhat',  # mimics puppet's default behaviour
+    'sysv'  => 'redhat',  # all currently used cases for 'sysv' are redhat-compatible
+    default => $init_style,
+  }
+
   if $manage_service == true {
     service { $name:
       ensure   => $service_ensure,
       name     => $init_selector,
       enable   => $service_enable,
-      provider => $init_style,
+      provider => $real_provider,
     }
   }
 }


### PR DESCRIPTION
This ensures puppet doesn't incorrectly detect the service provider in some circumstances (e.g. if a systemd unit is disabled).
It also has the side-effect of enabling us to actually meaningfully override the provider (until now, setting $init_style would not propagate to the service, so puppet would try to detect the system provider even if you attempted to pass a different one)

fixes #132

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
