### PR TITLE
add explicit parameter for retention

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,6 +7,7 @@ class prometheus::config(
   $remote_read_configs,
   $purge = true,
   $config_template = $::prometheus::params::config_template,
+  $storage_retention = $::prometheus::params::storage_retention,
 ) {
 
   if $prometheus::init_style {
@@ -19,6 +20,7 @@ class prometheus::config(
       $daemon_flags = [
         "-config.file=${::prometheus::config_dir}/prometheus.yaml",
         "-storage.local.path=${::prometheus::localstorage}",
+        "-storage.local.retention=${storage_retention}",
         "-web.console.templates=${::prometheus::shared_dir}/consoles",
         "-web.console.libraries=${::prometheus::shared_dir}/console_libraries",
       ]
@@ -28,6 +30,7 @@ class prometheus::config(
       $daemon_flags = [
         "--config.file=${::prometheus::config_dir}/prometheus.yaml",
         "--storage.tsdb.path=${::prometheus::localstorage}",
+        "--storage.tsdb.retention=${storage_retention}",
         "--web.console.templates=${::prometheus::shared_dir}/consoles",
         "--web.console.libraries=${::prometheus::shared_dir}/console_libraries",
       ]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -108,6 +108,11 @@
 #  [*alertmanagers_config*]
 #  Prometheus managers config under alerting
 #
+#  [*storage_retention*]
+#  How long to keep timeseries data. This is given as a duration like "100h" or "14d". Until
+#  prometheus 1.8.*, only durations understood by golang's time.ParseDuration are supported. Starting
+#  with prometheus 2, durations can also be given in days, weeks and years.
+#
 # Actions:
 #
 # Requires: see Modulefile
@@ -151,6 +156,7 @@ class prometheus (
   $alerts                     = $::prometheus::params::alerts,
   Array $alert_relabel_config = $::prometheus::params::alert_relabel_config,
   Array $alertmanagers_config = $::prometheus::params::alertmanagers_config,
+  String $storage_retention   = $::prometheus::params::storage_retention,
 ) inherits prometheus::params {
 
   if( versioncmp($::prometheus::version, '1.0.0') == -1 ){
@@ -177,6 +183,7 @@ class prometheus (
     remote_read_configs => $remote_read_configs,
     purge               => $purge_config_dir,
     config_template     => $config_template,
+    storage_retention   => $storage_retention,
   }
   -> class { '::prometheus::alerts':
     location => $config_dir,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -144,6 +144,7 @@ class prometheus::params {
   $statsd_exporter_package_name = 'statsd_exporter'
   $statsd_exporter_user = 'statsd-exporter'
   $statsd_exporter_version = '0.3.0'
+  $storage_retention = '360h' # 15d; "d" suffix is only supported with prom >= 2.*
   $blackbox_exporter_user = 'blackbox-exporter'
   $blackbox_exporter_group = 'blackbox-exporter'
   $blackbox_exporter_download_extension = 'tar.gz'

--- a/spec/fixtures/files/prometheus1.debian
+++ b/spec/fixtures/files/prometheus1.debian
@@ -20,6 +20,7 @@ DAEMON=/usr/local/bin/$NAME
 PIDFILE=/var/run/$NAME/$NAME.pid
 DAEMON_ARGS="-config.file=/etc/prometheus/prometheus.yaml
              -storage.local.path=/var/lib/prometheus
+             -storage.local.retention=360h
              -web.console.templates=/usr/local/share/prometheus/consoles
              -web.console.libraries=/usr/local/share/prometheus/console_libraries
              "

--- a/spec/fixtures/files/prometheus1.systemd
+++ b/spec/fixtures/files/prometheus1.systemd
@@ -9,6 +9,7 @@ Group=prometheus
 ExecStart=/usr/local/bin/prometheus \
   -config.file=/etc/prometheus/prometheus.yaml \
   -storage.local.path=/var/lib/prometheus \
+  -storage.local.retention=360h \
   -web.console.templates=/usr/local/share/prometheus/consoles \
   -web.console.libraries=/usr/local/share/prometheus/console_libraries \
   

--- a/spec/fixtures/files/prometheus1.sysv
+++ b/spec/fixtures/files/prometheus1.sysv
@@ -53,6 +53,7 @@ start() {
             --pidfile="$PID_FILE" \
             "$DAEMON" -log.format logger:stdout -config.file=/etc/prometheus/prometheus.yaml \
             -storage.local.path=/var/lib/prometheus \
+            -storage.local.retention=360h \
             -web.console.templates=/usr/local/share/prometheus/consoles \
             -web.console.libraries=/usr/local/share/prometheus/console_libraries \
              >> "$LOG_FILE" &

--- a/spec/fixtures/files/prometheus1.upstart
+++ b/spec/fixtures/files/prometheus1.upstart
@@ -24,6 +24,7 @@ script
     export GOMAXPROCS=${GOMAXPROCS:-2}
     exec start-stop-daemon -c $USER -g $GROUP -p $PID_FILE -x $PROMETHEUS -S -- -config.file=/etc/prometheus/prometheus.yaml \
       -storage.local.path=/var/lib/prometheus \
+      -storage.local.retention=360h \
       -web.console.templates=/usr/local/share/prometheus/consoles \
       -web.console.libraries=/usr/local/share/prometheus/console_libraries \
       

--- a/spec/fixtures/files/prometheus2.debian
+++ b/spec/fixtures/files/prometheus2.debian
@@ -20,6 +20,7 @@ DAEMON=/usr/local/bin/$NAME
 PIDFILE=/var/run/$NAME/$NAME.pid
 DAEMON_ARGS="--config.file=/etc/prometheus/prometheus.yaml
              --storage.tsdb.path=/var/lib/prometheus
+             --storage.tsdb.retention=360h
              --web.console.templates=/usr/local/share/prometheus/consoles
              --web.console.libraries=/usr/local/share/prometheus/console_libraries
              "

--- a/spec/fixtures/files/prometheus2.systemd
+++ b/spec/fixtures/files/prometheus2.systemd
@@ -9,6 +9,7 @@ Group=prometheus
 ExecStart=/usr/local/bin/prometheus \
   --config.file=/etc/prometheus/prometheus.yaml \
   --storage.tsdb.path=/var/lib/prometheus \
+  --storage.tsdb.retention=360h \
   --web.console.templates=/usr/local/share/prometheus/consoles \
   --web.console.libraries=/usr/local/share/prometheus/console_libraries \
   

--- a/spec/fixtures/files/prometheus2.sysv
+++ b/spec/fixtures/files/prometheus2.sysv
@@ -53,6 +53,7 @@ start() {
             --pidfile="$PID_FILE" \
             "$DAEMON" -log.format logger:stdout --config.file=/etc/prometheus/prometheus.yaml \
             --storage.tsdb.path=/var/lib/prometheus \
+            --storage.tsdb.retention=360h \
             --web.console.templates=/usr/local/share/prometheus/consoles \
             --web.console.libraries=/usr/local/share/prometheus/console_libraries \
              >> "$LOG_FILE" &

--- a/spec/fixtures/files/prometheus2.upstart
+++ b/spec/fixtures/files/prometheus2.upstart
@@ -24,6 +24,7 @@ script
     export GOMAXPROCS=${GOMAXPROCS:-2}
     exec start-stop-daemon -c $USER -g $GROUP -p $PID_FILE -x $PROMETHEUS -S -- --config.file=/etc/prometheus/prometheus.yaml \
       --storage.tsdb.path=/var/lib/prometheus \
+      --storage.tsdb.retention=360h \
       --web.console.templates=/usr/local/share/prometheus/consoles \
       --web.console.libraries=/usr/local/share/prometheus/console_libraries \
       


### PR DESCRIPTION
This way we don't need to use `$extra_options`. Should make module slightly more newbie-friendly.

Fixes #136 

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
