### PR TITLE
Update AlertManager daemon configuration

### DIFF
--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -208,9 +208,9 @@ class prometheus::alertmanager (
       mode   => '0755',
     }
 
-    $options = "-config.file=${prometheus::alertmanager::config_file} -storage.path=${prometheus::alertmanager::storage_path} ${prometheus::alertmanager::extra_options}"
+    $options = "--config.file=${prometheus::alertmanager::config_file} --storage.path=${prometheus::alertmanager::storage_path} ${prometheus::alertmanager::extra_options}"
   } else {
-    $options = "-config.file=${prometheus::alertmanager::config_file} ${prometheus::alertmanager::extra_options}"
+    $options = "--config.file=${prometheus::alertmanager::config_file} ${prometheus::alertmanager::extra_options}"
   }
 
   prometheus::daemon { $service_name:


### PR DESCRIPTION
Updating the alert manager configuration to use --config.file and --storage.path as it currently does not work on ubuntu 16.04. 