### PR TITLE
Use kingpin flags for Alertmanager

### DIFF
--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -208,9 +208,9 @@ class prometheus::alertmanager (
       mode   => '0755',
     }
 
-    $options = "-config.file=${prometheus::alertmanager::config_file} -storage.path=${prometheus::alertmanager::storage_path} ${prometheus::alertmanager::extra_options}"
+    $options = "--config.file=${prometheus::alertmanager::config_file} --storage.path=${prometheus::alertmanager::storage_path} ${prometheus::alertmanager::extra_options}"
   } else {
-    $options = "-config.file=${prometheus::alertmanager::config_file} ${prometheus::alertmanager::extra_options}"
+    $options = "--config.file=${prometheus::alertmanager::config_file} ${prometheus::alertmanager::extra_options}"
   }
 
   prometheus::daemon { $service_name:


### PR DESCRIPTION
Alertmanager switched to kingpin flags in the latest release, [0.13.0](https://github.com/prometheus/alertmanager/blob/master/CHANGELOG.md#0130--2018-01-12). This change is required to update Alertmanager to this version.

Confirmed 0.8.0 and 0.12.0 still work with kingpin flags.