### PR TITLE
add envvars support to daemon

### DIFF
--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -60,22 +60,24 @@ define prometheus::daemon (
   $user,
   $group,
 
-  $install_method     = $::prometheus::params::install_method,
-  $download_extension = $::prometheus::params::download_extension,
-  $os                 = $::prometheus::params::os,
-  $arch               = $::prometheus::params::arch,
-  $bin_dir            = $::prometheus::params::bin_dir,
-  $package_name       = undef,
-  $package_ensure     = 'installed',
-  $manage_user        = true,
-  $extra_groups       = [],
-  $manage_group       = true,
-  $purge              = true,
-  $options            = '',
-  $init_style         = $::prometheus::params::init_style,
-  $service_ensure     = 'running',
-  $service_enable     = true,
-  $manage_service     = true,
+  $install_method                 = $::prometheus::params::install_method,
+  $download_extension             = $::prometheus::params::download_extension,
+  $os                             = $::prometheus::params::os,
+  $arch                           = $::prometheus::params::arch,
+  $bin_dir                        = $::prometheus::params::bin_dir,
+  $package_name                   = undef,
+  $package_ensure                 = 'installed',
+  $manage_user                    = true,
+  $extra_groups                   = [],
+  $manage_group                   = true,
+  $purge                          = true,
+  $options                        = '',
+  $init_style                     = $::prometheus::params::init_style,
+  $service_ensure                 = 'running',
+  $service_enable                 = true,
+  $manage_service                 = true,
+  Hash[String, Scalar] $env_vars  = {},
+  Optional[String] $env_file_path = $::prometheus::params::env_file_path,
 ) {
 
   case $install_method {
@@ -149,7 +151,6 @@ define prometheus::daemon (
 
 
   if $init_style {
-
     case $init_style {
       'upstart' : {
         file { "/etc/init/${name}.conf":
@@ -213,6 +214,16 @@ define prometheus::daemon (
       default : {
         fail("I don't know how to create an init script for style ${init_style}")
       }
+    }
+  }
+
+  if $env_file_path != undef {
+    file { "${env_file_path}/${name}":
+      mode    => '0644',
+      owner   => 'root',
+      group   => 'root',
+      content => template('prometheus/daemon.env.erb'),
+      notify  => $notify_service,
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -192,6 +192,7 @@ class prometheus::params {
   $os = downcase($::kernel)
 
   if $::operatingsystem == 'Ubuntu' {
+    $env_file_path = '/etc/default'
     if versioncmp($::operatingsystemrelease, '8.04') < 1 {
       $init_style = 'debian'
     } elsif versioncmp($::operatingsystemrelease, '15.04') < 0 {
@@ -200,36 +201,44 @@ class prometheus::params {
       $init_style = 'systemd'
     }
   } elsif $::operatingsystem =~ /Scientific|CentOS|RedHat|OracleLinux/ {
+    $env_file_path = '/etc/sysconfig'
     if versioncmp($::operatingsystemrelease, '7.0') < 0 {
       $init_style = 'sysv'
     } else {
       $init_style  = 'systemd'
     }
   } elsif $::operatingsystem == 'Fedora' {
+    $env_file_path = '/etc/sysconfig'
     if versioncmp($::operatingsystemrelease, '12') < 0 {
       $init_style = 'sysv'
     } else {
       $init_style = 'systemd'
     }
   } elsif $::operatingsystem == 'Debian' {
+    $env_file_path = '/etc/default'
     if versioncmp($::operatingsystemrelease, '8.0') < 0 {
       $init_style = 'debian'
     } else {
       $init_style = 'systemd'
     }
   } elsif $::operatingsystem == 'Archlinux' {
+    $env_file_path = '/etc/default'
     $init_style = 'systemd'
   } elsif $::operatingsystem == 'OpenSuSE' {
+    $env_file_path = '/etc/sysconfig'
     $init_style = 'systemd'
   } elsif $::operatingsystem =~ /SLE[SD]/ {
+    $env_file_path = '/etc/sysconfig'
     if versioncmp($::operatingsystemrelease, '12.0') < 0 {
       $init_style = 'sles'
     } else {
       $init_style = 'systemd'
     }
   } elsif $::operatingsystem == 'Darwin' {
+    $env_file_path = undef
     $init_style = 'launchd'
   } elsif $::operatingsystem == 'Amazon' {
+    $env_file_path = '/etc/sysconfig'
     $init_style = 'sysv'
   } else {
     $init_style = undef

--- a/spec/defines/daemon_spec.rb
+++ b/spec/defines/daemon_spec.rb
@@ -21,7 +21,8 @@ describe 'prometheus::daemon' do
           real_download_url: 'https://github.com/prometheus/smurf_exporter/releases/v1.2.3/smurf_exporter-1.2.3.any.tar.gz',
           notify_service:    'Service[smurf_exporter]',
           user:              'smurf_user',
-          group:             'smurf_group'
+          group:             'smurf_group',
+          env_vars:          { SOMEVAR: 42 }
         }
       ].each do |parameters|
         context "with parameters #{parameters}" do
@@ -142,6 +143,28 @@ describe 'prometheus::daemon' do
           else
             it {
               is_expected.to raise_error(Puppet::Error, %r{I don.t know how to create an init script for style})
+            }
+          end
+
+          if ['debian-7-x86_64', 'ubuntu-14.04-x86_64', 'debian-8-x86_64', 'ubuntu-16.04-x86_64'].include?(os)
+            it {
+              is_expected.to contain_file('/etc/default/smurf_exporter').with(
+                'mode'    => '0644',
+                'owner'   => 'root',
+                'group'   => 'root'
+              ).with_content(
+                %r{SOMEVAR=42\n}
+              )
+            }
+          elsif ['centos-6-x86_64', 'redhat-6-x86_64', 'centos-7-x86_64', 'redhat-7-x86_64'].include?(os)
+            it {
+              is_expected.to contain_file('/etc/sysconfig/smurf_exporter').with(
+                'mode'    => '0644',
+                'owner'   => 'root',
+                'group'   => 'root'
+              ).with_content(
+                %r{SOMEVAR=42\n}
+              )
             }
           end
 

--- a/templates/daemon.env.erb
+++ b/templates/daemon.env.erb
@@ -1,0 +1,3 @@
+<% @env_vars.each do |key, value| -%>
+<%= key %>=<%= value %>
+<% end -%>

--- a/templates/daemon.launchd.erb
+++ b/templates/daemon.launchd.erb
@@ -12,6 +12,13 @@
 <% end %>
     <key>RunAtLoad</key>         <true/>
     <key>KeepAlive</key>         <true/>
+    <key>EnvironmentVariables</key>
+        <dict>
+<% @env_vars.each do |key, value| -%>
+            <key><%= key %></key>
+            <string><%= value %></string>
+<% end -%>
+        </dict>
     <key>ProgramArguments</key>
         <array>
             <string><%= @bin_dir %>/<%= @name %></string>

--- a/templates/daemon.systemd.erb
+++ b/templates/daemon.systemd.erb
@@ -6,6 +6,7 @@ After=basic.target network.target
 [Service]
 User=<%= @user %>
 Group=<%= @group %>
+EnvironmentFile=<%= @env_file_path %>/<%= @name%>
 <%- require 'shellwords' -%>
 ExecStart=<%= @bin_dir %>/<%= @name %><% for option in Shellwords.split(@options) %> \
 <%= option -%>


### PR DESCRIPTION
This adds support for providing environment variables to `prometheus::daemon` instances. This is needed for some exporters, like rabbitmq's

Fixes #150 