### PR TITLE
[minor] change default alerts to empty hash

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class prometheus::params {
   $alertmanager_templates = [ "${alertmanager_config_dir}/*.tmpl" ]
   $alertmanager_user = 'alertmanager'
   $alertmanager_version = '0.5.1'
-  $alerts = []
+  $alerts = {}
   $bin_dir = '/usr/local/bin'
   $config_dir = '/etc/prometheus'
   $config_mode = '0660'


### PR DESCRIPTION
This should fix `promtool` parsing problems for prometheus 2.* and empty alert files. Behaviour for 1.* should remain unchanged.

Fixes #143

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
