### PR TITLE
source_labels and module must be unquoted

### DIFF
--- a/templates/prometheus.yaml.erb
+++ b/templates/prometheus.yaml.erb
@@ -22,7 +22,7 @@ if @prometheus_v2
 end
  -%>
 <%= if @prometheus_v2
-full_config.to_yaml
+full_config.to_yaml.gsub(/(module|source_labels): ".+?"/) { |x| x.gsub('"', '') }
 else
 full_config.to_yaml(options = {:line_width => -1}).gsub(/source_labels: ".+?"/) { |x| x.gsub('"', '') }
 end


### PR DESCRIPTION
for example source_labels:

bad:

```
 relabel_configs:
  - source_labels: "['__meta_consul_service']"
    regex: "(.*)"
    target_label: service
    replacement: "$1"
```

good:

```
 relabel_configs:
  - source_labels: ['__meta_consul_service']
    regex: "(.*)"
    target_label: service
    replacement: "$1"
```

and blackbox_exporter:

bad:

```
- job_name: http_check
  metrics_path: "/probe"
  params:
    module: "[http_2xx]"
```

good:

```
- job_name: http_check
  metrics_path: "/probe"
  params:
    module: [http_2xx]
```