### PR TITLE
Fix Archive creates definition

### DIFF
--- a/manifests/redis_exporter.pp
+++ b/manifests/redis_exporter.pp
@@ -137,7 +137,7 @@ class prometheus::redis_exporter (
       extract_path    => "/opt/${service_name}-${version}.${os}-${arch}",
       source          => $real_download_url,
       checksum_verify => false,
-      creates         => "/opt/${name}-${version}.${os}-${arch}/${name}",
+      creates         => "/opt/${service_name}-${version}.${os}-${arch}/${service_name}",
       cleanup         => true,
     }
     -> file { "${bin_dir}/${service_name}":

--- a/templates/prometheus.systemd.erb
+++ b/templates/prometheus.systemd.erb
@@ -12,6 +12,7 @@ ExecStart=<%= scope.lookupvar('prometheus::bin_dir') %>/prometheus \
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always
+LimitNOFILE=1000000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Because of typo, archive resource tries to uses directory like `/opt/prometheus::redis_exporter-0.15.0.linux-amd64/prometheus::redis_exporter` instead of `/opt/redis_exporter-0.15.0.linux-amd64`.

This was produced endless message
```
Notice: /Stage[main]/Prometheus::Redis_exporter/Archive[/tmp/redis_exporter-0.15.0.tar.gz]/creates: creates changed 'archive not extracted' to extracting in /opt/redis_exporter-0.15.0.linux-amd64 to create /opt/prometheus::redis_exporter-0.15.0.linux-amd64/prometheus::redis_exporter
```

I changed variable name to the correct one.