### PR TITLE
haproxy: default to version 0.9.0 + use long option

### DIFF
--- a/manifests/haproxy_exporter.pp
+++ b/manifests/haproxy_exporter.pp
@@ -104,7 +104,7 @@ class prometheus::haproxy_exporter(
     default => undef,
   }
 
-  $options = "-haproxy.scrape-uri=\"${cnf_scrape_uri}\" ${extra_options}"
+  $options = "--haproxy.scrape-uri=\"${cnf_scrape_uri}\" ${extra_options}"
 
   prometheus::daemon { 'haproxy_exporter':
     install_method     => $install_method,


### PR DESCRIPTION
Starting with the following commit in https://github.com/prometheus/haproxy_exporter:

| commit cb544ab842c398242fc5e22053da49dda3058aa0
| Author: Calle Pettersson <cpettsson@gmail.com>
| Date:   Sat Aug 12 13:17:26 2017 +0100
|
|     Switch to kingpin

it's no longer "-haproxy.scrape-uri=" but
"--haproxy.scrape-uri=" instead (and the
short option isn't supported anymore, failing
with "error: unknown short flag '-a', try --help").

The relevant change is included in haproxy_exporter releases
starting with >=v0.8.0, so while at it default to the latest
stable version 0.9.0.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
