### PR TITLE
change default inhibit_rules to reflect previous params.pp config

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -15,13 +15,13 @@ prometheus::alertmanager::global:
 prometheus::alertmanager::group: 'alertmanager'
 prometheus::alertmanager::inhibit_rules:
   - 'source_match':
-    'severity': 'critical'
-  - 'target_match':
-    'severity': 'warning'
-  - 'equal':
-    - 'alertname'
-    - 'cluster'
-    - 'service'
+      'severity': 'critical'
+    'target_match':
+      'severity': 'warning'
+    'equal':
+      - 'alertname'
+      - 'cluster'
+      - 'service'
 prometheus::alertmanager::package_ensure: 'latest'
 prometheus::alertmanager::package_name: 'alertmanager'
 prometheus::alertmanager::receivers:


### PR DESCRIPTION
While starting to use alertmanager i noticed the default inhibit_rules cause alertmanager to not start whith this error:

level=error ts=2018-04-05T10:32:22.8118108Z caller=main.go:278 msg="Loading configuration file failed" file=/etc/alertmanager/alertmanager.yaml err="unknown fields in inhibit rule: severity"

i have changed the default inhibit_rules to reflect the previous rules in (former) params.pp

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
