### PR TITLE
allow to set prometheus server config filename

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -1,4 +1,5 @@
 ---
+prometheus::configname: 'prometheus.yaml'
 prometheus::bin_dir: '/usr/local/bin'
 prometheus::version: '1.5.2'
 prometheus::install_method: 'url'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,7 +15,7 @@ class prometheus::config {
         fail('remote_write_configs requires prometheus 2.X')
       }
       $daemon_flags = [
-        "-config.file=${prometheus::server::config_dir}/prometheus.yaml",
+        "-config.file=${prometheus::server::config_dir}/${prometheus::server::configname}",
         "-storage.local.path=${prometheus::server::localstorage}",
         "-storage.local.retention=${prometheus::server::storage_retention}",
         "-web.console.templates=${prometheus::shared_dir}/consoles",
@@ -25,7 +25,7 @@ class prometheus::config {
       # helper variable indicating prometheus version, so we can use on this information in the template
       $prometheus_v2 = true
       $daemon_flags = [
-        "--config.file=${prometheus::server::config_dir}/prometheus.yaml",
+        "--config.file=${prometheus::server::config_dir}/${prometheus::server::configname}",
         "--storage.tsdb.path=${prometheus::server::localstorage}",
         "--storage.tsdb.retention=${prometheus::server::storage_retention}",
         "--web.console.templates=${prometheus::server::shared_dir}/consoles",
@@ -112,7 +112,7 @@ class prometheus::config {
 
   file { 'prometheus.yaml':
     ensure       => present,
-    path         => "${prometheus::server::config_dir}/prometheus.yaml",
+    path         => "${prometheus::server::config_dir}/${prometheus::server::configname}",
     owner        => $prometheus::server::user,
     group        => $prometheus::server::group,
     mode         => $prometheus::server::config_mode,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,9 @@
 #
 # Parameters:
 #
+#  [*configname*]
+#  the name of the configfile, defaults to prometheus.yaml or prometheus.yml on most operating systems
+#
 #  [*manage_user*]
 #  Whether to create user for prometheus or rely on external code for that
 #
@@ -129,6 +132,7 @@
 # Sample Usage:
 #
 class prometheus (
+  String $configname,
   String $user,
   String $group,
   Array $extra_groups,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,6 +1,7 @@
 # class to manage the actual prometheus server
 # this is a private class that gets called from the init.pp
 class prometheus::server (
+  String $configname                                            = $prometheus::configname,
   String $user                                                  = $prometheus::user,
   String $group                                                 = $prometheus::group,
   Array $extra_groups                                           = $prometheus::extra_groups,

--- a/templates/prometheus.sles.erb
+++ b/templates/prometheus.sles.erb
@@ -21,7 +21,7 @@
 rc_reset
 
 PROMETHEUS_BIN=<%= scope.lookupvar('prometheus::bin_dir') %>/prometheus
-CONFIG_FILE=<%= scope.lookupvar('prometheus::config_dir') %>/prometheus.yaml
+CONFIG_FILE=<%= scope.lookupvar('prometheus::config_dir') %>/<%= scope.lookupvar('prometheus::server::configname') %>
 LOG_FILE=/var/log/prometheus
 
 


### PR DESCRIPTION
The default in the module is `prometheus.yaml`. However, upstream prefers `prometheus.yml`.  We want to give contributors the option to configure the name to stay equal with upstream. We won't change the default in the module (now) because that would be a breaking change.