### PR TITLE
upgrade stdlib dependancy to minium 4.25.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.20.0 < 5.0.0"
+      "version_requirement": ">= 4.25.0 < 5.0.0"
     },
     {
       "name": "camptocamp/systemd",


### PR DESCRIPTION

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

upgrade stdlib dependancy to minium 4.25.0 since mysqld_exporter uses Stdlib::Port, which is introduced in this version.

<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->

Fixes #206 
