### PR TITLE
start-stop scripts get vars from prometheus::server scope

### DIFF
--- a/templates/prometheus.debian.erb
+++ b/templates/prometheus.debian.erb
@@ -13,14 +13,14 @@
 # Do NOT "set -e"
 
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
-PATH=/usr/sbin:/usr/bin:/sbin:/bin:<%= scope.lookupvar('prometheus::bin_dir') %>
+PATH=/usr/sbin:/usr/bin:/sbin:/bin:<%= scope.lookupvar('prometheus::server::bin_dir') %>
 DESC="Prometheus monitoring framework"
 NAME=prometheus
-DAEMON=<%= scope.lookupvar('prometheus::bin_dir') %>/$NAME
+DAEMON=<%= scope.lookupvar('prometheus::server::bin_dir') %>/$NAME
 PIDFILE=/var/run/$NAME/$NAME.pid
 DAEMON_ARGS="<%= @daemon_flags.join("\n             ") %>
-             <%= scope.lookupvar('prometheus::extra_options') %>"
-USER=<%= scope.lookupvar('prometheus::user') %>
+             <%= scope.lookupvar('prometheus::server::extra_options') %>"
+USER=<%= scope.lookupvar('prometheus::server::user') %>
 SCRIPTNAME=/etc/init.d/$NAME
 
 # Exit if the package is not installed

--- a/templates/prometheus.launchd.erb
+++ b/templates/prometheus.launchd.erb
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
     <key>Label</key>             <string>io.prometheus.daemon</string>
-    <key>UserName</key>          <string><%= scope.lookupvar('prometheus::user') %></string>
-    <key>GroupName</key>         <string><%= scope.lookupvar('prometheus::group') %></string>
-<% if scope.lookupvar('prometheus::service_enable') %>
+    <key>UserName</key>          <string><%= scope.lookupvar('prometheus::server::user') %></string>
+    <key>GroupName</key>         <string><%= scope.lookupvar('prometheus::server::group') %></string>
+<% if scope.lookupvar('prometheus::server::service_enable') %>
     <key>Disabled</key>          <false/>
 <% else %>
     <key>Disabled></key>         <true/>
@@ -14,13 +14,13 @@
     <key>KeepAlive</key>         <true/>
     <key>ProgramArguments</key>
         <array>
-            <string><%= scope.lookupvar('prometheus::bin_dir') %>/prometheus</string>
+            <string><%= scope.lookupvar('prometheus::server::bin_dir') %>/prometheus</string>
             <string>agent</string>
             <%- daemon_flags.each do |flag| -%>
             <string><%= flag %></string>
             <%- end -%>
 <% require 'shellwords' %>
-<% for extra_option in Shellwords.split(scope.lookupvar('prometheus::extra_options')) %>
+<% for extra_option in Shellwords.split(scope.lookupvar('prometheus::server::extra_options')) %>
             <string><%= extra_option %></string>
 <% end %>
         </array>

--- a/templates/prometheus.sles.erb
+++ b/templates/prometheus.sles.erb
@@ -20,8 +20,8 @@
 
 rc_reset
 
-PROMETHEUS_BIN=<%= scope.lookupvar('prometheus::bin_dir') %>/prometheus
-CONFIG_FILE=<%= scope.lookupvar('prometheus::config_dir') %>/<%= scope.lookupvar('prometheus::server::configname') %>
+PROMETHEUS_BIN=<%= scope.lookupvar('prometheus::server::bin_dir') %>/prometheus
+CONFIG_FILE=<%= scope.lookupvar('prometheus::server::config_dir') %>/<%= scope.lookupvar('prometheus::server::server::configname') %>
 LOG_FILE=/var/log/prometheus
 
 
@@ -37,7 +37,7 @@ case "$1" in
         ## Start daemon with startproc(8). If this fails
         ## the return value is set appropriately by startproc.
         startproc $PROMETHEUS_BIN <%= @daemon_flags.join(" \\\n          ") %> \
-          <%= scope.lookupvar('prometheus::extra_options') %> >> "$LOG_FILE"
+          <%= scope.lookupvar('prometheus::server::extra_options') %> >> "$LOG_FILE"
 
         # Remember status and be verbose
         rc_status -v

--- a/templates/prometheus.systemd.erb
+++ b/templates/prometheus.systemd.erb
@@ -4,11 +4,11 @@ Wants=basic.target
 After=basic.target network.target
 
 [Service]
-User=<%= scope.lookupvar('prometheus::user') %>
-Group=<%= scope.lookupvar('prometheus::group') %>
-ExecStart=<%= scope.lookupvar('prometheus::bin_dir') %>/prometheus \
+User=<%= scope.lookupvar('prometheus::server::user') %>
+Group=<%= scope.lookupvar('prometheus::server::group') %>
+ExecStart=<%= scope.lookupvar('prometheus::server::bin_dir') %>/prometheus \
   <%= @daemon_flags.join(" \\\n  ") %> \
-  <%= scope.lookupvar('prometheus::extra_options') %>
+  <%= scope.lookupvar('prometheus::server::extra_options') %>
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always

--- a/templates/prometheus.sysv.erb
+++ b/templates/prometheus.sysv.erb
@@ -12,7 +12,7 @@
 # Source function library.
 . /etc/init.d/functions
 
-DAEMON=<%= scope.lookupvar('prometheus::bin_dir') %>/prometheus
+DAEMON=<%= scope.lookupvar('prometheus::server::bin_dir') %>/prometheus
 PID_FILE=/var/run/prometheus/prometheus.pid
 LOG_FILE=/var/log/prometheus
 
@@ -26,7 +26,7 @@ export GOMAXPROCS=${GOMAXPROCS:-2}
 #
 mkrundir() {
         [ ! -d /var/run/prometheus ] && mkdir -p /var/run/prometheus
-        chown <%= scope.lookupvar('prometheus::user') %> /var/run/prometheus
+        chown <%= scope.lookupvar('prometheus::server::user') %> /var/run/prometheus
 }
 
 #
@@ -38,7 +38,7 @@ mkpidfile() {
         # Create PID file if it didn't exist
         mkrundir
         [ ! -f $PID_FILE ] && pidofproc $DAEMON > $PID_FILE
-        chown <%= scope.lookupvar('prometheus::user') %> /var/run/prometheus
+        chown <%= scope.lookupvar('prometheus::server::user') %> /var/run/prometheus
         if [ $? -ne 0 ] ; then
             rm $PID_FILE
             KILLPROC_OPT=""
@@ -49,10 +49,10 @@ start() {
         echo -n "Starting prometheus: "
         mkrundir
         [ -f $PID_FILE ] && rm $PID_FILE
-        daemon --user=<%= scope.lookupvar('prometheus::user') %> \
+        daemon --user=<%= scope.lookupvar('prometheus::server::user') %> \
             --pidfile="$PID_FILE" \
             "$DAEMON" -log.format logger:stdout <%= @daemon_flags.join(" \\\n            ") %> \
-            <%= scope.lookupvar('prometheus::extra_options') %> >> "$LOG_FILE" &
+            <%= scope.lookupvar('prometheus::server::extra_options') %> >> "$LOG_FILE" &
         retcode=$?
         mkpidfile
         touch /var/lock/subsys/prometheus

--- a/templates/prometheus.upstart.erb
+++ b/templates/prometheus.upstart.erb
@@ -3,9 +3,9 @@ description "Prometheus Monitoring Framework"
 start on runlevel [2345]
 stop on runlevel [06]
 
-env PROMETHEUS=<%= scope.lookupvar('prometheus::bin_dir') %>/prometheus
-env USER=<%= scope.lookupvar('prometheus::user') %>
-env GROUP=<%= scope.lookupvar('prometheus::group') %>
+env PROMETHEUS=<%= scope.lookupvar('prometheus::server::bin_dir') %>/prometheus
+env USER=<%= scope.lookupvar('prometheus::server::user') %>
+env GROUP=<%= scope.lookupvar('prometheus::server::group') %>
 env DEFAULTS=/etc/default/prometheus
 env RUNDIR=/var/run/prometheus
 env PID_FILE=/var/run/prometheus/prometheus.pid
@@ -23,7 +23,7 @@ script
 
     export GOMAXPROCS=${GOMAXPROCS:-2}
     exec start-stop-daemon -c $USER -g $GROUP -p $PID_FILE -x $PROMETHEUS -S -- <%= @daemon_flags.join(" \\\n      ") %> \
-      <%= scope.lookupvar('prometheus::extra_options') %>
+      <%= scope.lookupvar('prometheus::server::extra_options') %>
 end script
 
 respawn


### PR DESCRIPTION
#### Pull Request (PR) description
Moving server install to prometheus::server class should also mean start-stop scripts take their parameters from this class, not the prometheus class.

#### This Pull Request (PR) fixes the following issues
Current implementation does not honour the setting like bin_dir to prometheus::server class. Which creates issues like installing from package (on Debian).

I did not open a issue myself, what I see is much like issue #62, this fix works for me when installing the server from package on Debian stretch.
 
Fixes #62 