### PR TITLE
Remove double quotes from source_labels value with gsub

### DIFF
--- a/templates/prometheus.yaml.erb
+++ b/templates/prometheus.yaml.erb
@@ -22,7 +22,7 @@ if @prometheus_v2
 end
  -%>
 <%= if @prometheus_v2
-full_config.to_yaml
+full_config.to_yaml().gsub(/source_labels: ".+?"/) { |x| x.gsub('"', '') }
 else
 full_config.to_yaml(options = {:line_width => -1}).gsub(/source_labels: ".+?"/) { |x| x.gsub('"', '') }
 end


### PR DESCRIPTION
#### Pull Request (PR) description
The value in source_labels have to be without quotes, but sometimes you
have to use brackets in the value and puppet surrounds it with double
quotes.

So we need to replace the double quotes with nothing in the template
