### PR TITLE
use service name for redis_exporter to prevent multiple downloads of redis_exporter

### DIFF
--- a/manifests/redis_exporter.pp
+++ b/manifests/redis_exporter.pp
@@ -126,7 +126,8 @@ class prometheus::redis_exporter (
     # redis_exporter lacks.
     # TODO: patch prometheus::daemon to support custom extract directories
     $exporter_install_method = 'none'
-    file { "/opt/${service_name}-${version}.${os}-${arch}":
+    $install_dir = "/opt/${service_name}-${version}.${os}-${arch}"
+    file { $install_dir:
       ensure => 'directory',
       owner  => 'root',
       group  => 0, # 0 instead of root because OS X uses "wheel".
@@ -135,16 +136,16 @@ class prometheus::redis_exporter (
     -> archive { "/tmp/${service_name}-${version}.${download_extension}":
       ensure          => present,
       extract         => true,
-      extract_path    => "/opt/${service_name}-${version}.${os}-${arch}",
+      extract_path    => $install_dir,
       source          => $real_download_url,
       checksum_verify => false,
-      creates         => "/opt/${name}-${version}.${os}-${arch}/${name}",
+      creates         => "${install_dir}/${service_name}",
       cleanup         => true,
     }
     -> file { "${bin_dir}/${service_name}":
       ensure => link,
       notify => $notify_service,
-      target => "/opt/${service_name}-${version}.${os}-${arch}/${service_name}",
+      target => "${install_dir}/${service_name}",
       before => Prometheus::Daemon[$service_name],
     }
   } else {

--- a/spec/acceptance/redis_exporter_spec.rb
+++ b/spec/acceptance/redis_exporter_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper_acceptance'
+
+describe 'prometheus redis exporter' do
+  it 'redis_exporter works idempotently with no errors' do
+    pp = 'include prometheus::redis_exporter'
+    # Run it twice and test for idempotency
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
+  end
+
+  describe service('redis_exporter') do
+    it { is_expected.to be_running }
+    it { is_expected.to be_enabled }
+  end
+  # the class installs an the redis_exporter that listens on port 9121
+  # it should not install the prometheus server (port 9090)
+  describe port(9121) do
+    it { is_expected.to be_listening.with('tcp6') }
+  end
+  describe port(9090) do
+    it { is_expected.not_to be_listening.with('tcp6') }
+  end
+end

--- a/spec/acceptance/redis_exporter_spec.rb
+++ b/spec/acceptance/redis_exporter_spec.rb
@@ -13,11 +13,7 @@ describe 'prometheus redis exporter' do
     it { is_expected.to be_enabled }
   end
   # the class installs an the redis_exporter that listens on port 9121
-  # it should not install the prometheus server (port 9090)
   describe port(9121) do
     it { is_expected.to be_listening.with('tcp6') }
-  end
-  describe port(9090) do
-    it { is_expected.not_to be_listening.with('tcp6') }
   end
 end


### PR DESCRIPTION


<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
use service name for redis_exporter to prevent multiple downloads of redis_exporter, as described in issue #215.

I also created a $install_dir variable to prevent errors and de-duplicate some code.

 
#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
Fixes #215

Regards,

Niels