### PR TITLE
Redirect SDTERR to SDTOUT for logfile

### DIFF
--- a/spec/defines/daemon_spec.rb
+++ b/spec/defines/daemon_spec.rb
@@ -104,7 +104,7 @@ describe 'prometheus::daemon' do
                 'owner'   => 'root',
                 'group'   => 'root'
               ).with_content(
-                %r{daemon --user=smurf_user \\\n            --pidfile="\$PID_FILE" \\\n            "\$DAEMON" '' >> "\$LOG_FILE" &}
+                %r{daemon --user=smurf_user \\\n            --pidfile="\$PID_FILE" \\\n            "\$DAEMON" '' &>> "\$LOG_FILE" &}
               )
             }
           elsif ['centos-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'redhat-7-x86_64', 'ubuntu-16.04-x86_64', 'archlinux-4-x86_64'].include?(os)

--- a/templates/daemon.sysv.erb
+++ b/templates/daemon.sysv.erb
@@ -52,7 +52,7 @@ start() {
         daemon --user=<%= @user %> \
             --pidfile="$PID_FILE" \
             <%- require 'shellwords' -%>
-            "$DAEMON" <%= Shellwords.escape(@options) %> >> "$LOG_FILE" &
+            "$DAEMON" <%= Shellwords.escape(@options) %> &>> "$LOG_FILE" &
         retcode=$?
         sleep 1
         mkpidfile


### PR DESCRIPTION
Prometheus writes is logging into to SDTERR and as a result its not
captured in the current logfile.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
