### PR TITLE
use web.external-url configuration

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -15,6 +15,7 @@ prometheus::bin_dir: '/usr/local/bin'
 prometheus::version: '1.5.2'
 prometheus::install_method: 'url'
 prometheus::manage_prometheus_server: false
+prometheus::external_url: ''
 prometheus::alert_relabel_config: []
 prometheus::alertmanagers_config: []
 prometheus::alertmanager::config_dir: '/etc/alertmanager'

--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -15,7 +15,6 @@ prometheus::bin_dir: '/usr/local/bin'
 prometheus::version: '1.5.2'
 prometheus::install_method: 'url'
 prometheus::manage_prometheus_server: false
-prometheus::external_url: ''
 prometheus::alert_relabel_config: []
 prometheus::alertmanagers_config: []
 prometheus::alertmanager::config_dir: '/etc/alertmanager'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -30,6 +30,7 @@ class prometheus::config {
         "--storage.tsdb.retention=${prometheus::server::storage_retention}",
         "--web.console.templates=${prometheus::server::shared_dir}/consoles",
         "--web.console.libraries=${prometheus::server::shared_dir}/console_libraries",
+        "--web.external-url='${prometheus::server::external_url}'",
       ]
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,6 +125,11 @@
 #  prometheus 1.8.*, only durations understood by golang's time.ParseDuration are supported. Starting
 #  with prometheus 2, durations can also be given in days, weeks and years.
 #
+#  [*external_url*]
+#  The URL under which Alertmanager is externally reachable (for example, if Alertmanager is served
+#  via a reverse proxy). Used for generating relative and absolute links back to Alertmanager itself.
+#  If omitted, relevant URL components will be derived automatically.
+#
 # Actions:
 #
 # Requires: see Modulefile
@@ -174,6 +179,7 @@ class prometheus (
   Hash $config_hash     = {},
   Hash $config_defaults = {},
   String $os            = downcase($facts['kernel']),
+  Variant[Stdlib::HTTPUrl, Stdlib::Unixpath, String[0]] $external_url,
 ) {
 
   case $arch {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -179,7 +179,7 @@ class prometheus (
   Hash $config_hash     = {},
   Hash $config_defaults = {},
   String $os            = downcase($facts['kernel']),
-  Variant[Stdlib::HTTPUrl, Stdlib::Unixpath, String[0]] $external_url,
+  Variant[Stdlib::HTTPUrl, Stdlib::Unixpath, String[0]] $external_url = '',
 ) {
 
   case $arch {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -42,6 +42,7 @@ class prometheus::server (
   Boolean $manage_group                                         = $prometheus::manage_group,
   Boolean $purge_config_dir                                     = $prometheus::purge_config_dir,
   Boolean $manage_user                                          = $prometheus::manage_user,
+  Variant[Stdlib::HTTPurl, Stdlib::Unixpath, String[0]] $external_url = $prometheus::external_url,
 ) inherits prometheus {
 
   if( versioncmp($version, '1.0.0') == -1 ){

--- a/spec/fixtures/files/prometheus2.debian
+++ b/spec/fixtures/files/prometheus2.debian
@@ -23,6 +23,7 @@ DAEMON_ARGS="--config.file=/etc/prometheus/prometheus.yaml
              --storage.tsdb.retention=360h
              --web.console.templates=/usr/local/share/prometheus/consoles
              --web.console.libraries=/usr/local/share/prometheus/console_libraries
+             --web.external-url=''
              "
 USER=prometheus
 SCRIPTNAME=/etc/init.d/$NAME

--- a/spec/fixtures/files/prometheus2.systemd
+++ b/spec/fixtures/files/prometheus2.systemd
@@ -12,6 +12,7 @@ ExecStart=/usr/local/bin/prometheus \
   --storage.tsdb.retention=360h \
   --web.console.templates=/usr/local/share/prometheus/consoles \
   --web.console.libraries=/usr/local/share/prometheus/console_libraries \
+  --web.external-url='' \
   
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process

--- a/spec/fixtures/files/prometheus2.sysv
+++ b/spec/fixtures/files/prometheus2.sysv
@@ -56,6 +56,7 @@ start() {
             --storage.tsdb.retention=360h \
             --web.console.templates=/usr/local/share/prometheus/consoles \
             --web.console.libraries=/usr/local/share/prometheus/console_libraries \
+            --web.external-url='' \
              >> "$LOG_FILE" &
         retcode=$?
         mkpidfile

--- a/spec/fixtures/files/prometheus2.upstart
+++ b/spec/fixtures/files/prometheus2.upstart
@@ -27,6 +27,7 @@ script
       --storage.tsdb.retention=360h \
       --web.console.templates=/usr/local/share/prometheus/consoles \
       --web.console.libraries=/usr/local/share/prometheus/console_libraries \
+      --web.external-url='' \
       
 end script
 


### PR DESCRIPTION
- first commit, misses parameter spec testing
- maybe needed for alertmanager, too

implements #232

