### PR TITLE
180 rule files param

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -200,9 +200,7 @@ prometheus::beanstalkd_exporter::mapping_config: '/etc/beanstalkd-exporter-mappi
 prometheus::beanstalkd_exporter::config: '/etc/beanstalkd-exporter.conf'
 prometheus::package_ensure: 'latest'
 prometheus::package_name: 'prometheus'
-prometheus::alertfile_name: 'alert'
-prometheus::rule_files:
-  - "$prometheus::{config_dir}/$prometheus::{alertfile_name}.rules"
+prometheus::rule_files: []
 prometheus::scrape_configs:
   - 'job_name': 'prometheus'
     'scrape_interval': '10s'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -78,10 +78,10 @@ class prometheus::server (
       alerts   => $alerts,
       location => $config_dir,
     }
-    $_rule_files = concat(["${config_dir}/alert.rules"], $extra_rule_files)
+    $_rule_files = concat(["${config_dir}/alert.rules"], $extra_rule_files, $rule_files)
   }
   else {
-    $_rule_files = $extra_rule_files
+    $_rule_files = concat($extra_rule_files, $rule_files)
   }
   contain prometheus::install
   contain prometheus::config

--- a/spec/classes/prometheus_spec.rb
+++ b/spec/classes/prometheus_spec.rb
@@ -7,7 +7,7 @@ describe 'prometheus' do
         facts.merge(os_specific_facts(facts))
       end
 
-      [{ manage_prometheus_server: true, version: '2.0.0-rc.1', bin_dir: '/usr/local/bin', install_method: 'url', rule_files: ['/etc/prometheus/rules.d/*.rules'], }].each do |parameters|
+      [{ manage_prometheus_server: true, version: '2.0.0-rc.1', bin_dir: '/usr/local/bin', install_method: 'url', rule_files: ['/etc/prometheus/rules.d/*.rules']}].each do |parameters|
         context "with parameters #{parameters}" do
           let(:params) do
             parameters

--- a/spec/classes/prometheus_spec.rb
+++ b/spec/classes/prometheus_spec.rb
@@ -7,7 +7,7 @@ describe 'prometheus' do
         facts.merge(os_specific_facts(facts))
       end
 
-      [{ manage_prometheus_server: true, version: '2.0.0-rc.1', bin_dir: '/usr/local/bin', install_method: 'url' }].each do |parameters|
+      [{ manage_prometheus_server: true, version: '2.0.0-rc.1', bin_dir: '/usr/local/bin', install_method: 'url', rule_files: ['/etc/prometheus/rules.d/*.rules'], }].each do |parameters|
         context "with parameters #{parameters}" do
           let(:params) do
             parameters

--- a/spec/classes/prometheus_spec.rb
+++ b/spec/classes/prometheus_spec.rb
@@ -7,7 +7,7 @@ describe 'prometheus' do
         facts.merge(os_specific_facts(facts))
       end
 
-      [{ manage_prometheus_server: true, version: '2.0.0-rc.1', bin_dir: '/usr/local/bin', install_method: 'url', rule_files: ['/etc/prometheus/rules.d/*.rules']}].each do |parameters|
+      [{ manage_prometheus_server: true, version: '2.0.0-rc.1', bin_dir: '/usr/local/bin', install_method: 'url', rule_files: ['/etc/prometheus/rules.d/*.rules'] }].each do |parameters|
         context "with parameters #{parameters}" do
           let(:params) do
             parameters

--- a/spec/fixtures/files/prometheus1.yaml
+++ b/spec/fixtures/files/prometheus1.yaml
@@ -4,7 +4,8 @@ global:
   evaluation_interval: 15s
   external_labels:
     monitor: master
-rule_files: []
+rule_files:
+- "$prometheus::{config_dir}/$prometheus::{alertfile_name}.rules"
 scrape_configs:
 - job_name: prometheus
   scrape_interval: 10s

--- a/spec/fixtures/files/prometheus1.yaml
+++ b/spec/fixtures/files/prometheus1.yaml
@@ -5,7 +5,7 @@ global:
   external_labels:
     monitor: master
 rule_files:
-- "$prometheus::{config_dir}/$prometheus::{alertfile_name}.rules"
+- "/etc/prometheus/rules.d/*.rules"
 scrape_configs:
 - job_name: prometheus
   scrape_interval: 10s

--- a/spec/fixtures/files/prometheus2.yaml
+++ b/spec/fixtures/files/prometheus2.yaml
@@ -4,7 +4,8 @@ global:
   evaluation_interval: 15s
   external_labels:
     monitor: master
-rule_files: []
+rule_files:
+- "$prometheus::{config_dir}/$prometheus::{alertfile_name}.rules"
 scrape_configs:
 - job_name: prometheus
   scrape_interval: 10s

--- a/spec/fixtures/files/prometheus2.yaml
+++ b/spec/fixtures/files/prometheus2.yaml
@@ -5,7 +5,7 @@ global:
   external_labels:
     monitor: master
 rule_files:
-- "$prometheus::{config_dir}/$prometheus::{alertfile_name}.rules"
+- "/etc/prometheus/rules.d/*.rules"
 scrape_configs:
 - job_name: prometheus
   scrape_interval: 10s


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes an issue where `prometheus::rule_files` param was never used to populate configuration as it was not included when combining `extra_alerts` and `alerts` params.

#### This Pull Request (PR) fixes the following issues
Fixes #180 
