### PR TITLE
Fix misleading example of hieradata usage in blackbox_exporter

### DIFF
--- a/manifests/blackbox_exporter.pp
+++ b/manifests/blackbox_exporter.pp
@@ -79,7 +79,7 @@
 # details of the format: https://github.com/prometheus/blackbox_exporter/blob/master/CONFIGURATION.md
 #
 # ---
-# prometheus::blackbox::exporter::modules:
+# prometheus::blackbox_exporter::modules:
 #   simple_ssl:
 #     prober: http
 #     timeout: 10s


### PR DESCRIPTION
Documentation change only, fix example hieradata key 

prometheus::blackbox::exporter::modules

to the correct

prometheus::blackbox_exporter::modules
