### PR TITLE
Render alerts file properly depending on prometheus version

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -77,6 +77,7 @@ class prometheus::server (
     prometheus::alerts { 'alert':
       alerts   => $alerts,
       location => $config_dir,
+      version  => $version,
     }
     $_rule_files = concat(["${config_dir}/alert.rules"], $extra_rule_files, $rule_files)
   }

--- a/spec/acceptance/prometheus_server_spec.rb
+++ b/spec/acceptance/prometheus_server_spec.rb
@@ -53,4 +53,60 @@ describe 'prometheus server basics' do
       it { is_expected.to be_listening.with('tcp6') }
     end
   end
+
+  describe 'prometheus with complex alerts and scrape configs' do
+    it 'is idempotent' do
+      pp = <<-EOS
+    class { 'prometheus::server':
+      version => '2.3.2',
+      alerts => {
+        'groups' => [
+          {
+            'name' => 'alert.rules',
+            'rules' => [
+              {
+                'alert' => 'InstanceDown',
+                'expr'  => 'up == 0',
+                'for'   => '5m',
+                'labels' => {
+                  'severity' => 'page',
+                },
+                'annotations' => {
+                  'summary'     => 'Instance {{ $labels.instance }} down',
+                  'description' => '{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes.'
+                }
+              }
+            ]
+          }
+        ]
+      },
+      scrape_configs => [
+        {
+          'job_name' => 'prometheus',
+          'scrape_interval' => '10s',
+          'scrape_timeout'  => '10s',
+          'static_configs'  => [
+            {
+              'targets' => [ 'localhost:9090' ],
+              'labels'  => { 'alias' => 'Prometheus' }
+            }
+          ]
+        }
+      ]
+    }
+    EOS
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe service('prometheus') do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
+
+    describe port(9090) do
+      it { is_expected.to be_listening.with('tcp6') }
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/voxpupuli/puppet-prometheus/issues/252

Without this change, the alerts file will always be rendered in the prometheus v1 format.