### PR TITLE
Use more compatible STDERR/STDOUT redirection syntax in sysv init script

### DIFF
--- a/spec/defines/daemon_spec.rb
+++ b/spec/defines/daemon_spec.rb
@@ -104,7 +104,7 @@ describe 'prometheus::daemon' do
                 'owner'   => 'root',
                 'group'   => 'root'
               ).with_content(
-                %r{daemon --user=smurf_user \\\n            --pidfile="\$PID_FILE" \\\n            "\$DAEMON" '' &>> "\$LOG_FILE" &}
+                %r{daemon --user=smurf_user \\\n            --pidfile="\$PID_FILE" \\\n            "\$DAEMON" '' >> "\$LOG_FILE" 2>&1 &}
               )
             }
           elsif ['centos-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'redhat-7-x86_64', 'ubuntu-16.04-x86_64', 'ubuntu-18.04-x86_64', 'archlinux-4-x86_64'].include?(os)

--- a/templates/daemon.sysv.erb
+++ b/templates/daemon.sysv.erb
@@ -52,7 +52,7 @@ start() {
         daemon --user=<%= @user %> \
             --pidfile="$PID_FILE" \
             <%- require 'shellwords' -%>
-            "$DAEMON" <%= Shellwords.escape(@options) %> &>> "$LOG_FILE" &
+            "$DAEMON" <%= Shellwords.escape(@options) %> >> "$LOG_FILE" 2>&1 &
         retcode=$?
         sleep 1
         mkpidfile


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The current stdout/stderr redirection syntax `&>> $LOG_FILE` is incompatible with bash < 4.0 and might be a BASH only thing. Using a more classic `>> $LOG_FILE 2>&1` has the same effect while being more compatible with older shells (e.g. BASH 3.x on CentOS 5) 

#### This Pull Request (PR) fixes the following issues
https://github.com/voxpupuli/puppet-prometheus/pull/223#commitcomment-30428964