### PR TITLE
consul_exporter improvement for version 0.4.0 and above

### DIFF
--- a/manifests/consul_exporter.pp
+++ b/manifests/consul_exporter.pp
@@ -122,7 +122,11 @@ class prometheus::consul_exporter (
   $real_download_url = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
 
   if $consul_health_summary {
-    $real_consul_health_summary = '-consul.health-summary'
+    if versioncmp ($version, '0.4.0') == -1 {
+      $real_consul_health_summary = '-consul.health-summary'
+    } else {
+      $real_consul_health_summary = '--consul.health-summary'
+    }
   } else {
     $real_consul_health_summary = ''
   }
@@ -132,7 +136,11 @@ class prometheus::consul_exporter (
     default => undef,
   }
 
-  $options = "-consul.server=${consul_server} ${real_consul_health_summary} -web.listen-address=${web_listen_address} -web.telemetry-path=${web_telemetry_path} -log.level=${log_level} ${extra_options}"
+  if versioncmp ($version, '0.4.0') == -1 {
+    $options = "-consul.server=${consul_server} ${real_consul_health_summary} -web.listen-address=${web_listen_address} -web.telemetry-path=${web_telemetry_path} -log.level=${log_level} ${extra_options}"
+  } else {
+    $options = "--consul.server=${consul_server} ${real_consul_health_summary} --web.listen-address=${web_listen_address} --web.telemetry-path=${web_telemetry_path} --log.level=${log_level} ${extra_options}"
+  }
 
   prometheus::daemon { 'consul_exporter':
     install_method     => $install_method,

--- a/spec/acceptance/consul_exporter_spec.rb
+++ b/spec/acceptance/consul_exporter_spec.rb
@@ -1,0 +1,28 @@
+#require 'spec_helper_acceptance'
+
+describe 'prometheus consul exporter' do
+  it 'consul_exporter works idempotently with no errors' do
+    end
+    pp = 'include prometheus::consul_exporter'
+    # Run it twice and test for idempotency
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
+  end
+
+  describe 'prometheus consul exporter version 0.3.0' do
+    it ' consul_exporter installs with version 0.3.0' do
+      pp = "class {'prometheus::consul_exporter': version => '0.3.0' }"
+      apply_manifest(pp, catch_failures: true)
+    end
+    describe process('consul_exporter') do
+      its(:args) { is_expected.to match %r{\ -consul.server} }
+  end
+
+  describe 'prometheus consul exporter version 0.4.0' do
+    it ' consul_exporter installs with version 0.4.0' do
+      pp = "class {'prometheus::consul_exporter': version => '0.4.0' }"
+      apply_manifest(pp, catch_failures: true)
+    end
+    describe process('consul_exporter') do
+      its(:args) { is_expected.to match %r{\ --consul.server} }
+  end

--- a/spec/acceptance/consul_exporter_spec.rb
+++ b/spec/acceptance/consul_exporter_spec.rb
@@ -11,6 +11,7 @@ describe 'prometheus consul exporter' do
   describe 'prometheus consul exporter version 0.3.0' do
     it ' consul_exporter installs with version 0.3.0' do
       pp = "class {'prometheus::consul_exporter': version => '0.3.0' }"
+      # Run it twice and test for idempotency
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
     end
@@ -22,6 +23,7 @@ describe 'prometheus consul exporter' do
   describe 'prometheus consul exporter version 0.4.0' do
     it ' consul_exporter installs with version 0.4.0' do
       pp = "class {'prometheus::consul_exporter': version => '0.4.0' }"
+      # Run it twice and test for idempotency
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
     end
@@ -30,4 +32,3 @@ describe 'prometheus consul exporter' do
     end
   end
 end
-

--- a/spec/acceptance/consul_exporter_spec.rb
+++ b/spec/acceptance/consul_exporter_spec.rb
@@ -1,8 +1,7 @@
-#require 'spec_helper_acceptance'
+require 'spec_helper_acceptance'
 
 describe 'prometheus consul exporter' do
   it 'consul_exporter works idempotently with no errors' do
-    end
     pp = 'include prometheus::consul_exporter'
     # Run it twice and test for idempotency
     apply_manifest(pp, catch_failures: true)
@@ -13,16 +12,22 @@ describe 'prometheus consul exporter' do
     it ' consul_exporter installs with version 0.3.0' do
       pp = "class {'prometheus::consul_exporter': version => '0.3.0' }"
       apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
     end
     describe process('consul_exporter') do
       its(:args) { is_expected.to match %r{\ -consul.server} }
+    end
   end
 
   describe 'prometheus consul exporter version 0.4.0' do
     it ' consul_exporter installs with version 0.4.0' do
       pp = "class {'prometheus::consul_exporter': version => '0.4.0' }"
       apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
     end
     describe process('consul_exporter') do
       its(:args) { is_expected.to match %r{\ --consul.server} }
+    end
   end
+end
+

--- a/spec/acceptance/postgres_exporter_spec.rb
+++ b/spec/acceptance/postgres_exporter_spec.rb
@@ -1,4 +1,4 @@
-#require 'spec_helper_acceptance'
+require 'spec_helper_acceptance'
 
 describe 'prometheus postgres exporter' do
   it 'postgres_exporter works idempotently with no errors' do

--- a/spec/acceptance/postgres_exporter_spec.rb
+++ b/spec/acceptance/postgres_exporter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper_acceptance'
+#require 'spec_helper_acceptance'
 
 describe 'prometheus postgres exporter' do
   it 'postgres_exporter works idempotently with no errors' do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

With the release of version 0.4.0 of the consul exporter, the single dashes ( - ) has been changed to   double dashes ( -- ). 
( [CHANGE] Adopt standard Prometheus flags library (mostly double dashes)) [#66](https://github.com/prometheus/consul_exporter/pull/66)

For the manifest consul_exporter.pp the following improvements have been made:
- A versioncmp has been added to the $consul_health_summary variable. If the version of consul exporter is lower than 0.4.0, it wil use the consul.health-summary flag with a single dash. For versions of 0.4.0 or higher it will use the double dash.
- A versioncmp has been added to the $options variable, for the same reason as above.

#### This Pull Request (PR) fixes the following issues

n/a

