### PR TITLE
Refactor statsd_exporter class to support version >= 0.5.0; bump from 0.3.0->0.8.0

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -227,19 +227,12 @@ prometheus::statsd_exporter::download_extension: 'tar.gz'
 prometheus::statsd_exporter::download_url_base: 'https://github.com/prometheus/statsd_exporter/releases'
 prometheus::statsd_exporter::extra_groups: []
 prometheus::statsd_exporter::group: 'statsd-exporter'
-prometheus::statsd_exporter::mapping_config_path: '/etc/statsd_mappings.conf'
-prometheus::statsd_exporter::maps:
-  - 'map': 'test.dispatcher.*.*.*'
-    'name': 'dispatcher_events_total'
-    'labels':
-      'processor': '$prometheus::1'
-      'action': '$prometheus::2'
-      'outcome': '$prometheus::3'
-      'job': 'test_dispatcher'
+prometheus::statsd_exporter::mapping_config_path: '/etc/statsd-exporter-mapping.yaml'
+prometheus::statsd_exporter::mappings: []
 prometheus::statsd_exporter::package_ensure: 'latest'
 prometheus::statsd_exporter::package_name: 'statsd_exporter'
 prometheus::statsd_exporter::user: 'statsd-exporter'
-prometheus::statsd_exporter::version: '0.3.0'
+prometheus::statsd_exporter::version: '0.8.0'
 prometheus::storage_retention: '360h' # 15d; "d" suffix is only supported with prom >= 2.*
 prometheus::blackbox_exporter::user: 'blackbox-exporter'
 prometheus::blackbox_exporter::group: 'blackbox-exporter'

--- a/manifests/statsd_exporter.pp
+++ b/manifests/statsd_exporter.pp
@@ -88,7 +88,7 @@ class prometheus::statsd_exporter (
   Stdlib::Absolutepath $mapping_config_path,
   String $package_ensure,
   String $package_name,
-  Array[Hash] $statsd_maps,
+  Array[Hash] $mappings,
   String $user,
   String $version,
   String $arch                                                       = $prometheus::real_arch,
@@ -108,25 +108,34 @@ class prometheus::statsd_exporter (
   Optional[Variant[Stdlib::HTTPSUrl, Stdlib::HTTPUrl]] $download_url = undef,
 ) inherits prometheus {
 
-  $real_download_url    = pick($download_url,"${download_url_base}/download/${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
+  # Prometheus added a 'v' on the realease name at 0.4.0 and changed the configuration format to yaml in 0.5.0
+  if versioncmp ($version, '0.5.0') == -1 {
+    fail("I only support statsd_exporter version '0.5.0' or higher")
+  }
+
+  $real_download_url = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
+
   $notify_service = $restart_on_change ? {
     true    => Service['statsd_exporter'],
     default => undef,
   }
-
-  $extra_statsd_maps = hiera_array('prometheus::statsd_exporter::statsd_maps',[])
-  $real_statsd_maps = concat($extra_statsd_maps, $prometheus::statsd_exporter::statsd_maps)
 
   file { $mapping_config_path:
     ensure  => 'file',
     mode    => $config_mode,
     owner   => $user,
     group   => $group,
-    content => template('prometheus/statsd_mapping.conf.erb'),
+    content => template('prometheus/statsd_mapping.yaml.erb'),
     notify  => $notify_service,
   }
 
-  $options = "-statsd.mapping-config=\'${prometheus::statsd_exporter::mapping_config_path}\' ${prometheus::statsd_exporter::extra_options}"
+  # Switched to POSIX like flags in version 0.7.0
+  if versioncmp ($version, '0.7.0') >= 0 {
+    $option_prefix = '--'
+  } else {
+    $option_prefix = '-'
+  }
+  $options = "${option_prefix}statsd.mapping-config=\'${prometheus::statsd_exporter::mapping_config_path}\' ${prometheus::statsd_exporter::extra_options}"
 
   prometheus::daemon { 'statsd_exporter':
     install_method     => $install_method,

--- a/manifests/statsd_exporter.pp
+++ b/manifests/statsd_exporter.pp
@@ -125,7 +125,7 @@ class prometheus::statsd_exporter (
     mode    => $config_mode,
     owner   => $user,
     group   => $group,
-    content => template('prometheus/statsd_mapping.yaml.erb'),
+    content => to_yaml({ mappings => $mappings }),
     notify  => $notify_service,
   }
 

--- a/spec/acceptance/statsd_exporter_spec.rb
+++ b/spec/acceptance/statsd_exporter_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper_acceptance'
+
+describe 'prometheus statsd exporter' do
+  it 'statsd_exporter works idempotently with no errors' do
+    pp = 'include prometheus::statsd_exporter'
+    # Run it twice and test for idempotency
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
+  end
+
+  describe 'prometheus statsd exporter version 0.5.0' do
+    it ' statsd_exporter installs with version 0.5.0' do
+      pp = "class {'prometheus::statsd_exporter': version => '0.5.0' }"
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+    describe process('statsd_exporter') do
+      its(:args) { is_expected.to match %r{\ -statsd.mapping-config} }
+    end
+    describe service('statsd_exporter') do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
+    describe port(9102) do
+      it { is_expected.to be_listening.with('tcp6') }
+    end
+    describe port(9125) do
+      it { is_expected.to be_listening.with('udp6') }
+    end
+  end
+
+  describe 'prometheus statsd exporter version 0.7.0' do
+    it ' statsd_exporter installs with version 0.7.0' do
+      pp = "class {'prometheus::statsd_exporter': version => '0.7.0' }"
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+    describe process('statsd_exporter') do
+      its(:args) { is_expected.to match %r{\ --statsd.mapping-config} }
+    end
+    describe service('statsd_exporter') do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
+    describe port(9102) do
+      it { is_expected.to be_listening.with('tcp6') }
+    end
+    describe port(9125) do
+      it { is_expected.to be_listening.with('udp6') }
+    end
+  end
+end

--- a/spec/classes/statsd_exporter_spec.rb
+++ b/spec/classes/statsd_exporter_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+
+describe 'prometheus::statsd_exporter' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge(os_specific_facts(facts))
+      end
+
+      context 'with version specified' do
+        let(:params) do
+          {
+            version: '0.8.0',
+            arch: 'amd64',
+            os: 'linux',
+            bin_dir: '/usr/local/bin',
+            install_method: 'url',
+            mappings: [
+              {
+                match: 'test.dispatcher.*.*.*',
+                name: 'dispatcher_events_total',
+                labels: {
+                  processor: '$1',
+                  action: '$2',
+                  outcome: '$3',
+                  job: 'test_dispatcher'
+                }
+              },
+              {
+                match: '*.signup.*.*',
+                name: 'signup_events_total',
+                labels: {
+                  provider: '$2',
+                  outcome: '$3',
+                  job: '${1}_server'
+                }
+              }
+            ]
+          }
+        end
+
+        it { is_expected.to contain_archive('/tmp/statsd_exporter-0.8.0.tar.gz') }
+
+        describe 'compile manifest' do
+          it { is_expected.to compile.with_all_deps }
+        end
+
+        describe 'install correct binary' do
+          it { is_expected.to contain_file('/usr/local/bin/statsd_exporter').with('target' => '/opt/statsd_exporter-0.8.0.linux-amd64/statsd_exporter') }
+        end
+
+        describe 'required resources' do
+          it { is_expected.to contain_prometheus__daemon('statsd_exporter').with(options: "--statsd.mapping-config='/etc/statsd-exporter-mapping.yaml' ") }
+          it { is_expected.to contain_user('statsd-exporter') }
+          it { is_expected.to contain_group('statsd-exporter') }
+          it { is_expected.to contain_service('statsd_exporter') }
+        end
+
+        describe 'mapping config file' do
+          it {
+            is_expected.to contain_file('/etc/statsd-exporter-mapping.yaml').with(
+              'ensure'  => 'file',
+              'owner'   => 'statsd-exporter',
+              'group'   => 'statsd-exporter',
+              'mode'    => '0660',
+              'notify'  => 'Service[statsd_exporter]',
+              'content' => <<-YAML.gsub(%r{^\s+\|}, '')
+                |---
+                |mappings:
+                |- match: test.dispatcher.*.*.*
+                |  name: dispatcher_events_total
+                |  labels:
+                |    processor: "$1"
+                |    action: "$2"
+                |    outcome: "$3"
+                |    job: test_dispatcher
+                |- match: "*.signup.*.*"
+                |  name: signup_events_total
+                |  labels:
+                |    provider: "$2"
+                |    outcome: "$3"
+                |    job: "${1}_server"
+              YAML
+            )
+          }
+        end
+      end
+
+      context 'with older version that does not support posix like option flags specified' do
+        let(:params) do
+          {
+            version: '0.6.0',
+            arch: 'amd64',
+            os: 'linux',
+            bin_dir: '/usr/local/bin',
+            install_method: 'url'
+          }
+        end
+
+        describe 'compile manifest' do
+          it { is_expected.to compile.with_all_deps }
+        end
+
+        it { is_expected.to contain_prometheus__daemon('statsd_exporter').with(options: "-statsd.mapping-config='/etc/statsd-exporter-mapping.yaml' ") }
+      end
+    end
+  end
+end

--- a/templates/statsd_mapping.conf.erb
+++ b/templates/statsd_mapping.conf.erb
@@ -1,7 +1,0 @@
-<%- @real_statsd_maps.sort!{ |a,b| b[:name] <=> a[:name] }.each do |metric| -%>
-<%= metric['map'] %>
-name="<%= metric['name'] %>"
-<% metric['labels'].sort.each do |key, value| -%>
-<%= key %>="<%= value %>"
-<% end %>
-<%- end -%>

--- a/templates/statsd_mapping.yaml.erb
+++ b/templates/statsd_mapping.yaml.erb
@@ -1,3 +1,0 @@
-<% require 'yaml' -%>
-<% full_config = { 'mappings'=>@mappings } -%>
-<%= full_config.to_yaml -%>

--- a/templates/statsd_mapping.yaml.erb
+++ b/templates/statsd_mapping.yaml.erb
@@ -1,0 +1,3 @@
+<% require 'yaml' -%>
+<% full_config = { 'mappings'=>@mappings } -%>
+<%= full_config.to_yaml -%>


### PR DESCRIPTION
Signed-off-by: Wiebe Verweij <wiebe@wiebelt.nl>

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Refactor statsd_exporter class to support version >= 0.5.0

#### This Pull Request (PR) fixes the following issues
Fixes #248 