### PR TITLE
Validate Alertmanager config

### DIFF
--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -175,6 +175,12 @@ class prometheus::alertmanager (
     default => undef,
   }
 
+  # Install amtool - Alertmanager validation tool
+  file {"${prometheus::server::bin_dir}/amtool":
+    ensure => link,
+    target => "/opt/${package_name}-${version}.${os}-${arch}/amtool",
+  }
+  
   file { $config_dir:
     ensure  => 'directory',
     owner   => $user,
@@ -190,7 +196,8 @@ class prometheus::alertmanager (
     mode    => $config_mode,
     content => template('prometheus/alertmanager.yaml.erb'),
     notify  => $notify_service,
-    require => File[$config_dir],
+    require => [ File["${prometheus::server::bin_dir}/amtool"], File[$config_dir] ],
+    validate_cmd => "${prometheus::bin_dir}/amtool check-config --alertmanager.url='' %",
   }
 
   if $facts['prometheus_alert_manager_running'] == 'running' {

--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -180,7 +180,7 @@ class prometheus::alertmanager (
     ensure => link,
     target => "/opt/${package_name}-${version}.${os}-${arch}/amtool",
   }
-  
+
   file { $config_dir:
     ensure  => 'directory',
     owner   => $user,

--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -175,12 +175,6 @@ class prometheus::alertmanager (
     default => undef,
   }
 
-  # Install amtool - Alertmanager validation tool
-  file {"${bin_dir}/amtool":
-    ensure => link,
-    target => "/opt/${package_name}-${version}.${os}-${arch}/amtool",
-  }
-
   file { $config_dir:
     ensure  => 'directory',
     owner   => $user,
@@ -189,15 +183,33 @@ class prometheus::alertmanager (
     recurse => $purge_config_dir,
   }
 
-  file { $config_file:
-    ensure       => present,
-    owner        => $user,
-    group        => $group,
-    mode         => $config_mode,
-    content      => template('prometheus/alertmanager.yaml.erb'),
-    notify       => $notify_service,
-    require      => File["${bin_dir}/amtool", $config_dir],
-    validate_cmd => "${bin_dir}/amtool check-config --alertmanager.url='' %",
+  if ( versioncmp($version, '0.10.0') >= 0 ) {
+    # If version >= 0.10.0 then install amtool - Alertmanager validation tool
+    file {"${bin_dir}/amtool":
+      ensure => link,
+      target => "/opt/${package_name}-${version}.${os}-${arch}/amtool",
+    }
+
+    file { $config_file:
+      ensure       => present,
+      owner        => $user,
+      group        => $group,
+      mode         => $config_mode,
+      content      => template('prometheus/alertmanager.yaml.erb'),
+      notify       => Service['alertmanager'],
+      require      => File["${bin_dir}/amtool", $config_dir],
+      validate_cmd => "${bin_dir}/amtool check-config --alertmanager.url='' %",
+    }
+  } else {
+    file { $config_file:
+      ensure       => present,
+      owner        => $user,
+      group        => $group,
+      mode         => $config_mode,
+      content      => template('prometheus/alertmanager.yaml.erb'),
+      notify       => Service['alertmanager'],
+      require      => File[$config_dir],
+    }
   }
 
   if $facts['prometheus_alert_manager_running'] == 'running' {

--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -202,13 +202,13 @@ class prometheus::alertmanager (
     }
   } else {
     file { $config_file:
-      ensure       => present,
-      owner        => $user,
-      group        => $group,
-      mode         => $config_mode,
-      content      => template('prometheus/alertmanager.yaml.erb'),
-      notify       => Service['alertmanager'],
-      require      => File[$config_dir],
+      ensure  => present,
+      owner   => $user,
+      group   => $group,
+      mode    => $config_mode,
+      content => template('prometheus/alertmanager.yaml.erb'),
+      notify  => Service['alertmanager'],
+      require => File[$config_dir],
     }
   }
 

--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -196,7 +196,7 @@ class prometheus::alertmanager (
       group        => $group,
       mode         => $config_mode,
       content      => template('prometheus/alertmanager.yaml.erb'),
-      notify       => Service['alertmanager'],
+      notify       => $notify_service,
       require      => File["${bin_dir}/amtool", $config_dir],
       validate_cmd => "${bin_dir}/amtool check-config --alertmanager.url='' %",
     }
@@ -207,7 +207,7 @@ class prometheus::alertmanager (
       group   => $group,
       mode    => $config_mode,
       content => template('prometheus/alertmanager.yaml.erb'),
-      notify  => Service['alertmanager'],
+      notify  => $notify_service,
       require => File[$config_dir],
     }
   }

--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -190,13 +190,13 @@ class prometheus::alertmanager (
   }
 
   file { $config_file:
-    ensure  => present,
-    owner   => $user,
-    group   => $group,
-    mode    => $config_mode,
-    content => template('prometheus/alertmanager.yaml.erb'),
-    notify  => $notify_service,
-    require => [ File["${prometheus::server::bin_dir}/amtool"], File[$config_dir] ],
+    ensure       => present,
+    owner        => $user,
+    group        => $group,
+    mode         => $config_mode,
+    content      => template('prometheus/alertmanager.yaml.erb'),
+    notify       => $notify_service,
+    require      => File["${prometheus::server::bin_dir}/amtool", $config_dir],
     validate_cmd => "${prometheus::bin_dir}/amtool check-config --alertmanager.url='' %",
   }
 

--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -176,7 +176,7 @@ class prometheus::alertmanager (
   }
 
   # Install amtool - Alertmanager validation tool
-  file {"${prometheus::server::bin_dir}/amtool":
+  file {"${bin_dir}/amtool":
     ensure => link,
     target => "/opt/${package_name}-${version}.${os}-${arch}/amtool",
   }
@@ -196,8 +196,8 @@ class prometheus::alertmanager (
     mode         => $config_mode,
     content      => template('prometheus/alertmanager.yaml.erb'),
     notify       => $notify_service,
-    require      => File["${prometheus::server::bin_dir}/amtool", $config_dir],
-    validate_cmd => "${prometheus::bin_dir}/amtool check-config --alertmanager.url='' %",
+    require      => File["${bin_dir}/amtool", $config_dir],
+    validate_cmd => "${bin_dir}/amtool check-config --alertmanager.url='' %",
   }
 
   if $facts['prometheus_alert_manager_running'] == 'running' {

--- a/spec/acceptance/alertmanager_spec.rb
+++ b/spec/acceptance/alertmanager_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper_acceptance'
+
+describe 'prometheus alertmanager' do
+  it 'alertmanager works idempotently with no errors' do
+    pp = 'include prometheus::alertmanager'
+    # Run it twice and test for idempotency
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
+  end
+
+  describe service('alertmanager') do
+    it { is_expected.to be_running }
+    it { is_expected.to be_enabled }
+  end
+  # the class installs an the alertmanager that listens on port 9093
+  describe port(9093) do
+    it { is_expected.to be_listening.with('tcp6') }
+  end
+end

--- a/spec/acceptance/alertmanager_spec.rb
+++ b/spec/acceptance/alertmanager_spec.rb
@@ -5,7 +5,7 @@ describe 'prometheus alertmanager' do
     pp = <<-EOS
      class { 'prometheus::alertmanager':
             version => '0.17.0',
-            extra_options => '--web.listen-address="127.0.0.1:9093"',
+            extra_options => '--web.listen-address=":9093"',
             route => { 'receiver' => 'default' },
             receivers => [
               {

--- a/spec/acceptance/alertmanager_spec.rb
+++ b/spec/acceptance/alertmanager_spec.rb
@@ -19,6 +19,7 @@ describe 'prometheus alertmanager' do
                 ]
               }
             ]
+          }
     EOS
     # Run it twice and test for idempotency
     apply_manifest(pp, catch_failures: true)

--- a/spec/acceptance/alertmanager_spec.rb
+++ b/spec/acceptance/alertmanager_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 describe 'prometheus alertmanager' do
   it 'alertmanager works idempotently with no errors' do
-    pp = "class { 'prometheus::alertmanager': }"
+    pp = 'class { "prometheus::alertmanager": version => "0.17.0", extra_options => "--web.listen-address=127.0.0.1:9093"}'
     # Run it twice and test for idempotency
     apply_manifest(pp, catch_failures: true)
     apply_manifest(pp, catch_changes: true)

--- a/spec/acceptance/alertmanager_spec.rb
+++ b/spec/acceptance/alertmanager_spec.rb
@@ -2,7 +2,24 @@ require 'spec_helper_acceptance'
 
 describe 'prometheus alertmanager' do
   it 'alertmanager works idempotently with no errors' do
-    pp = 'class { "prometheus::alertmanager": version => "0.17.0", extra_options => "--web.listen-address=127.0.0.1:9093"}'
+    pp = <<-EOS
+     class { 'prometheus::alertmanager':
+            version => '0.17.0',
+            extra_options => '--web.listen-address="127.0.0.1:9093"',
+            route => { 'receiver' => 'default' },
+            receivers => [
+              {
+                name => 'default',
+                email_configs => [
+                  send_resolved => true,
+                  to => 'test@localhost.localdomain',
+                  from => 'prometheus@localhost.localdomain',
+                  smarthost => '127.0.0.1:25',
+                  require_tls => false
+                ]
+              }
+            ]
+    EOS
     # Run it twice and test for idempotency
     apply_manifest(pp, catch_failures: true)
     apply_manifest(pp, catch_changes: true)

--- a/spec/acceptance/alertmanager_spec.rb
+++ b/spec/acceptance/alertmanager_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 describe 'prometheus alertmanager' do
   it 'alertmanager works idempotently with no errors' do
-    pp = 'include prometheus::alertmanager'
+    pp = "class { 'prometheus::alertmanager': }"
     # Run it twice and test for idempotency
     apply_manifest(pp, catch_failures: true)
     apply_manifest(pp, catch_changes: true)


### PR DESCRIPTION
Install the amtool and validate alertmanager config file prior changes.

#### Pull Request (PR) description
Validate Alertmanager config file prior changes

#### This Pull Request (PR) fixes the following issues
Alertmanager has a validation tool but it's not installed nor used by this modules until now.
