### PR TITLE
Add support for armv6 and amrv5

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -186,6 +186,8 @@ class prometheus (
     'x86_64', 'amd64': { $real_arch = 'amd64' }
     'i386':            { $real_arch = '386'   }
     'armv7l':          { $real_arch = 'armv7' }
+    'armv6l':          { $real_arch = 'armv6' }
+    'armv5l':          { $real_arch = 'armv5' }
     default:           {
       fail("Unsupported kernel architecture: ${arch}")
     }


### PR DESCRIPTION
Signed-off-by: Wiebe Verweij <wiebe@wiebelt.nl>

Add support for armv6 and amrv5, used by older raspberry pi models for example.