### PR TITLE
Add MacOS support

### DIFF
--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -1,0 +1,2 @@
+---
+prometheus::env_file_path: '/etc'

--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -224,7 +224,7 @@ define prometheus::daemon (
     file { "${env_file_path}/${name}":
       mode    => '0644',
       owner   => 'root',
-      group   => 'root',
+      group   => '0', # Darwin uses wheel
       content => template('prometheus/daemon.env.erb'),
       notify  => $notify_service,
     }

--- a/spec/defines/daemon_spec.rb
+++ b/spec/defines/daemon_spec.rb
@@ -205,7 +205,7 @@ describe 'prometheus::daemon' do
               is_expected.to contain_file('/etc/default/smurf_exporter').with(
                 'mode'    => '0644',
                 'owner'   => 'root',
-                'group'   => 'root'
+                'group'   => '0'
               ).with_content(
                 %r{SOMEVAR="42"\n}
               )
@@ -215,7 +215,7 @@ describe 'prometheus::daemon' do
               is_expected.to contain_file('/etc/sysconfig/smurf_exporter').with(
                 'mode'    => '0644',
                 'owner'   => 'root',
-                'group'   => 'root'
+                'group'   => '0'
               ).with_content(
                 %r{SOMEVAR="42"\n}
               )


### PR DESCRIPTION
#### Pull Request (PR) description
Set OS specific default for Darwin and use group id 0 insteand of root.

#### This Pull Request (PR) fixes the following issues
Fixes:
 Class[Prometheus]: expects a value for parameter 'env_file_path'
 Error: /Stage[main]/Prometheus::Node_exporter/Prometheus::Daemon[node_exporter]/File[/etc/node_exporter]/group: change from 'common' to 'root' failed: Could not find group root
