### PR TITLE
remove version path splitting for process exporter

### DIFF
--- a/manifests/process_exporter.pp
+++ b/manifests/process_exporter.pp
@@ -97,13 +97,7 @@ class prometheus::process_exporter(
   Stdlib::Absolutepath $bin_dir                                      = $prometheus::bin_dir,
 ) inherits prometheus {
 
-  # Prometheus removed a dot on the realease name at 0.2.0
-  if versioncmp ($version, '0.2.0') >= 0 {
-    $filename = "${package_name}-${version}${os}_${arch}.${download_extension}"
-  }
-  else {
-    $filename = "${package_name}-${version}.${os}-${arch}.${download_extension}"
-  }
+  $filename = "${package_name}-${version}.${os}-${arch}.${download_extension}"
   $real_download_url = pick($download_url,"${download_url_base}/download/v${version}/${filename}")
   $notify_service = $restart_on_change ? {
     true    => Service['process-exporter'],


### PR DESCRIPTION
process exporter has moved to a consitent file name
e.g. process-exporter-0.4.0.linux-amd64.tar.gz
also see https://github.com/ncabatoff/process-exporter/releases

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
