### PR TITLE
Add quotes around the command to `daemon`

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -7,6 +7,7 @@
     - set: ubuntu1804-64
     - set: debian8-64
     - set: debian9-64
+    - set: centos6-64
     - set: centos7-64
 spec/spec_helper.rb:
   spec_overrides: "require 'spec_helper_methods'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,14 @@ matrix:
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos6-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos6-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
     env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
   - rvm: 2.5.3

--- a/spec/defines/daemon_spec.rb
+++ b/spec/defines/daemon_spec.rb
@@ -116,7 +116,7 @@ describe 'prometheus::daemon' do
                 'owner'   => 'root',
                 'group'   => 'root'
               ).with_content(
-                %r{daemon --user=smurf_user \\\n            --pidfile="\$PID_FILE" \\\n            "\$DAEMON" '' >> "\$LOG_FILE" 2>&1 &}
+                %r{daemon --user=smurf_user \\\n            --pidfile="\$PID_FILE" \\\n            "'\$DAEMON' '' >> '\$LOG_FILE' 2>&1 &"}
               )
             }
 

--- a/templates/daemon.sysv.erb
+++ b/templates/daemon.sysv.erb
@@ -52,7 +52,7 @@ start() {
         daemon --user=<%= @user %> \
             --pidfile="$PID_FILE" \
             <%- require 'shellwords' -%>
-            "$DAEMON" <%= Shellwords.escape(@options) %> >> "$LOG_FILE" 2>&1 &
+            "'$DAEMON' <%= Shellwords.escape(@options) %> >> '$LOG_FILE' 2>&1 &"
         retcode=$?
         sleep 1
         mkpidfile


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add quotes around the command passed to `daemon`, causing it to start successfully and with a parent process id of 1 on CentOS 6 / SysV init.

As it is, `/var/log/node_exporter` will need to have the owner changed to match the `node-exporter` user if it already exists.  On my systems, this was previously owned by `root`.

#### This Pull Request (PR) fixes the following issues
Fixes #293 
