### PR TITLE
add LimitNOFILE to prometheus server unit

### DIFF
--- a/spec/fixtures/files/prometheus1.systemd
+++ b/spec/fixtures/files/prometheus1.systemd
@@ -12,7 +12,6 @@ ExecStart=/usr/local/bin/prometheus \
   -storage.local.retention=360h \
   -web.console.templates=/usr/local/share/prometheus/consoles \
   -web.console.libraries=/usr/local/share/prometheus/console_libraries \
-
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always

--- a/spec/fixtures/files/prometheus1.systemd
+++ b/spec/fixtures/files/prometheus1.systemd
@@ -12,10 +12,11 @@ ExecStart=/usr/local/bin/prometheus \
   -storage.local.retention=360h \
   -web.console.templates=/usr/local/share/prometheus/consoles \
   -web.console.libraries=/usr/local/share/prometheus/console_libraries \
-  
+
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always
+LimitNOFILE=1000000
 
 [Install]
 WantedBy=multi-user.target

--- a/spec/fixtures/files/prometheus2.systemd
+++ b/spec/fixtures/files/prometheus2.systemd
@@ -12,7 +12,6 @@ ExecStart=/usr/local/bin/prometheus \
   --storage.tsdb.retention=360h \
   --web.console.templates=/usr/local/share/prometheus/consoles \
   --web.console.libraries=/usr/local/share/prometheus/console_libraries \
-
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always

--- a/spec/fixtures/files/prometheus2.systemd
+++ b/spec/fixtures/files/prometheus2.systemd
@@ -12,10 +12,11 @@ ExecStart=/usr/local/bin/prometheus \
   --storage.tsdb.retention=360h \
   --web.console.templates=/usr/local/share/prometheus/consoles \
   --web.console.libraries=/usr/local/share/prometheus/console_libraries \
-  
+
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always
+LimitNOFILE=1000000
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/prometheus.systemd.erb
+++ b/templates/prometheus.systemd.erb
@@ -12,6 +12,7 @@ ExecStart=<%= scope.lookupvar('prometheus::server::bin_dir') %>/prometheus \
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always
+LimitNOFILE=1000000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
As a Brian Brazil [said](https://www.robustperception.io/dealing-with-too-many-open-files) nofile limit should be set to an large value, one billion as example.
I think that we should set this in service unit because of any other ways may not work unlike systemd.