### PR TITLE
Debian daemon template: Split and escape args to avoid quotes passed as args

### DIFF
--- a/templates/daemon.debian.erb
+++ b/templates/daemon.debian.erb
@@ -19,7 +19,7 @@ NAME=<%= @name %>
 DAEMON=<%= @bin_dir %>/<%= @bin_name %>
 PIDFILE=/var/run/$NAME/$NAME.pid
 <%- require 'shellwords' -%>
-DAEMON_ARGS=<%= Shellwords.escape(@options) %>
+DAEMON_ARGS=<%= Shellwords.split(@options).map{|x| Shellwords.escape(x)}.join('\ ') %>
 USER=<%= @user %>
 SCRIPTNAME=/etc/init.d/$NAME
 


### PR DESCRIPTION
#### Pull Request (PR) description
Split and escape args in the daemon template to avoid quotes passed as args to the exporter.
Tested with Debian 7 and apache, node, mysqld exporters.

#### This Pull Request (PR) fixes the following issue
Fixes #296