### PR TITLE
Added blackbox_exporter file capability setting

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,3 +3,4 @@ fixtures:
     archive: "https://github.com/voxpupuli/puppet-archive"
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib"
     systemd: "https://github.com/camptocamp/puppet-systemd"
+    file_capability: "https://github.com/smoeding/puppet-file_capability"

--- a/manifests/blackbox_exporter.pp
+++ b/manifests/blackbox_exporter.pp
@@ -142,6 +142,17 @@ class prometheus::blackbox_exporter (
     notify  => $notify_service,
   }
 
+  # Get all used probers into an array
+  $probers = $modules.map |$key, $value| { $value['prober'] }
+
+  # If we’re not running as root and use the ICMP prober, we need the CAP_NET_RAW capability
+  if $user != 'root' and ('icmp' in $probers) {
+    file_capability { "/opt/${service_name}-${version}.${os}-${arch}/${service_name}":
+      capability => 'cap_net_raw=ep',
+    }
+
+    File_Capability["/opt/${service_name}-${version}.${os}-${arch}/${service_name}"] ~> $notify_service
+  }
 
   prometheus::daemon { $service_name :
     install_method     => $install_method,

--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,10 @@
     {
       "name": "camptocamp/systemd",
       "version_requirement": ">= 1.1.1 < 3.0.0"
+    },
+    {
+      "name": "stm/file_capability",
+      "version_requirement": ">= 1.1.0 < 2.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/blackbox_exporter_spec.rb
+++ b/spec/classes/blackbox_exporter_spec.rb
@@ -37,6 +37,44 @@ describe 'prometheus::blackbox_exporter' do
             is_expected.to contain_file('/etc/blackbox-exporter.yaml')
             verify_contents(catalogue, '/etc/blackbox-exporter.yaml', ['---', 'modules:', '  http_2xx:', '    prober: http'])
           }
+          it { is_expected.not_to contain_file_capability('/opt/blackbox_exporter-0.6.0.linux-amd64/blackbox_exporter') }
+        end
+      end
+
+      context 'with version specified and icmp prober' do
+        let(:params) do
+          {
+            version: '0.6.0',
+            arch: 'amd64',
+            os: 'linux',
+            bin_dir: '/usr/local/bin',
+            install_method: 'url',
+            modules: {
+              'http_2xx' => {
+                'prober' => 'http'
+              },
+              'icmp' => {
+                'prober' => 'icmp'
+              }
+            }
+          }
+        end
+
+        describe 'with all defaults' do
+          it { is_expected.to contain_class('prometheus') }
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_file('/usr/local/bin/blackbox_exporter').with('target' => '/opt/blackbox_exporter-0.6.0.linux-amd64/blackbox_exporter') }
+          it { is_expected.to contain_prometheus__daemon('blackbox_exporter') }
+          it { is_expected.to contain_user('blackbox-exporter') }
+          it { is_expected.to contain_group('blackbox-exporter') }
+          it { is_expected.to contain_service('blackbox_exporter') }
+          it { is_expected.to contain_archive('/tmp/blackbox_exporter-0.6.0.tar.gz') }
+          it { is_expected.to contain_file('/opt/blackbox_exporter-0.6.0.linux-amd64/blackbox_exporter') }
+          it {
+            is_expected.to contain_file('/etc/blackbox-exporter.yaml')
+            verify_contents(catalogue, '/etc/blackbox-exporter.yaml', ['---', 'modules:', '  http_2xx:', '    prober: http'])
+          }
+          it { is_expected.to contain_file_capability('/opt/blackbox_exporter-0.6.0.linux-amd64/blackbox_exporter') }
         end
       end
     end


### PR DESCRIPTION
#### Pull Request (PR) description
When using the ICMP prober in the blackbox exporter, you need to either run as root or set the `CAP_NET_RAW` capability, see [the official docs](https://github.com/prometheus/blackbox_exporter#permissions)

I am not sure if this has to be a major release bump as it will break if you don’t have `stm/file_capability` installed or are working around this issue in your profiles currently.
 
#### This Pull Request (PR) fixes the following issues
Not being able to use the ICMP prober without additional configuration - there is no issue open for this currently.