### PR TITLE
Feature update to newest elasticsearch exporter version: 1.0.2rc1 -> 1.1.0rc1

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -82,7 +82,7 @@ prometheus::elasticsearch_exporter::group: 'elasticsearch-exporter'
 prometheus::elasticsearch_exporter::package_ensure: 'latest'
 prometheus::elasticsearch_exporter::package_name: 'elasticsearch_exporter'
 prometheus::elasticsearch_exporter::user: 'elasticsearch-exporter'
-prometheus::elasticsearch_exporter::version: '1.0.2rc1'
+prometheus::elasticsearch_exporter::version: '1.1.0rc1'
 prometheus::extra_groups: []
 prometheus::global_config:
   'scrape_interval': '15s'

--- a/manifests/elasticsearch_exporter.pp
+++ b/manifests/elasticsearch_exporter.pp
@@ -113,7 +113,7 @@ class prometheus::elasticsearch_exporter (
     default => undef,
   }
 
-  $options = "-es.uri=${cnf_uri} -es.timeout=${cnf_timeout} ${extra_options}"
+  $options = "--es.uri=${cnf_uri} --es.timeout=${cnf_timeout} ${extra_options}"
 
   prometheus::daemon { 'elasticsearch_exporter':
     install_method     => $install_method,


### PR DESCRIPTION
This pull request allows the puppet-prometheus project to use the newest available elasticsearch_exporter.