### PR TITLE
subbing out @name in stop function with an ambiguous name.

### DIFF
--- a/templates/daemon.sysv.erb
+++ b/templates/daemon.sysv.erb
@@ -66,7 +66,7 @@ stop() {
         echo -n "Shutting down prometheus <%= @name %>: "
         mkpidfile
 
-        <%= @name %>_pid=$(cat $PID_FILE)
+        prometheus_pid=$(cat $PID_FILE)
         killproc $KILLPROC_OPT $DAEMON -INT
         retcode=$?
 
@@ -74,7 +74,7 @@ stop() {
         # early if we can.  If not, escalate to harsher signals.
         try=0
         while [ $try -lt $DELAY ]; do
-        if ! checkpid $<%= @name %>_pid ; then
+        if ! checkpid $prometheus_pid ; then
           rm -f /var/lock/subsys/<%= @name %>
           return $retcode
         fi


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The template daemon.sysv.erb creates a variable name using @name as its value.  When applying the process-exporter this variable is named process-exporter and produces the following:

$ service process-exporter stop
Shutting down prometheus process-exporter: /etc/init.d/process-exporter: line 68: process-exporter_pid=17693: command not found

Modified the variable creation to use a static name that conforms to the naming rules for variables. 
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
Fixes #311 