### PR TITLE
issue #306: Fix broken startup scripts

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -5,7 +5,7 @@ prometheus::service_ensure: 'running'
 prometheus::manage_service: true
 prometheus::restart_on_change: true
 prometheus::init_style: '%{facts.service_provider}'
-prometheus::extra_options: ''
+prometheus::extra_options: ~
 prometheus::download_url: ~
 prometheus::arch: '%{facts.architecture}'
 prometheus::manage_group: true

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,7 +14,7 @@ class prometheus::config {
       if $prometheus::server::remote_write_configs != [] {
         fail('remote_write_configs requires prometheus 2.X')
       }
-      $daemon_flags = [
+      $_daemon_flags = [
         '-log.format logger:stdout',
         "-config.file=${prometheus::server::config_dir}/${prometheus::server::configname}",
         "-storage.local.path=${prometheus::server::localstorage}",
@@ -22,6 +22,11 @@ class prometheus::config {
         "-web.console.templates=${prometheus::shared_dir}/consoles",
         "-web.console.libraries=${prometheus::shared_dir}/console_libraries",
       ]
+      if $prometheus::server::extra_options {
+        $daemon_flags = $_daemon_flags + $prometheus::server::extra_options
+      } else {
+        $daemon_flags = $_daemon_flags
+      }
     } else {
       # helper variable indicating prometheus version, so we can use on this information in the template
       $prometheus_v2 = true
@@ -32,10 +37,16 @@ class prometheus::config {
         "--web.console.templates=${prometheus::server::shared_dir}/consoles",
         "--web.console.libraries=${prometheus::server::shared_dir}/console_libraries",
       ]
+
       if $prometheus::server::external_url {
-        $daemon_flags = $daemon_flags_basic + "--web.external-url=${prometheus::server::external_url}"
+        $_daemon_flags = $daemon_flags_basic + "--web.external-url=${prometheus::server::external_url}"
       } else {
-        $daemon_flags = $daemon_flags_basic
+        $_daemon_flags = $daemon_flags_basic
+      }
+      if $prometheus::server::extra_options {
+        $daemon_flags = $_daemon_flags + $prometheus::server::extra_options
+      } else {
+        $daemon_flags = $_daemon_flags
       }
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -169,7 +169,7 @@ class prometheus (
   Boolean $manage_service,
   Boolean $restart_on_change,
   String $init_style,
-  String $extra_options,
+  Optional[String[1]] $extra_options,
   Optional[String] $download_url,
   String $arch,
   Boolean $manage_group,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -33,7 +33,7 @@ class prometheus::server (
   Boolean $manage_service                                                       = $prometheus::manage_service,
   Boolean $restart_on_change                                                    = $prometheus::restart_on_change,
   String $init_style                                                            = $prometheus::init_style,
-  String $extra_options                                                         = $prometheus::extra_options,
+  Optional[String[1]] $extra_options                                            = $prometheus::extra_options,
   Hash $config_hash                                                             = $prometheus::config_hash,
   Hash $config_defaults                                                         = $prometheus::config_defaults,
   String $os                                                                    = $prometheus::os,

--- a/spec/fixtures/files/prometheus2.systemd
+++ b/spec/fixtures/files/prometheus2.systemd
@@ -1,3 +1,4 @@
+# THIS FILE IS MANAGED BY PUPPET
 [Unit]
 Description=Prometheus Monitoring framework
 Wants=basic.target
@@ -11,8 +12,7 @@ ExecStart=/usr/local/bin/prometheus \
   --storage.tsdb.path=/var/lib/prometheus \
   --storage.tsdb.retention=360h \
   --web.console.templates=/usr/local/share/prometheus/consoles \
-  --web.console.libraries=/usr/local/share/prometheus/console_libraries \
-  
+  --web.console.libraries=/usr/local/share/prometheus/console_libraries
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always

--- a/spec/fixtures/files/prometheus2.upstart
+++ b/spec/fixtures/files/prometheus2.upstart
@@ -26,8 +26,7 @@ script
       --storage.tsdb.path=/var/lib/prometheus \
       --storage.tsdb.retention=360h \
       --web.console.templates=/usr/local/share/prometheus/consoles \
-      --web.console.libraries=/usr/local/share/prometheus/console_libraries \
-      
+      --web.console.libraries=/usr/local/share/prometheus/console_libraries
 end script
 
 respawn

--- a/templates/prometheus.systemd.erb
+++ b/templates/prometheus.systemd.erb
@@ -1,3 +1,4 @@
+# THIS FILE IS MANAGED BY PUPPET
 [Unit]
 Description=Prometheus Monitoring framework
 Wants=basic.target
@@ -7,8 +8,7 @@ After=basic.target network.target
 User=<%= scope.lookupvar('prometheus::server::user') %>
 Group=<%= scope.lookupvar('prometheus::server::group') %>
 ExecStart=<%= scope.lookupvar('prometheus::server::bin_dir') %>/prometheus \
-  <%= @daemon_flags.join(" \\\n  ") %> \
-  <%= scope.lookupvar('prometheus::server::extra_options') %>
+  <%= @daemon_flags.join(" \\\n  ") %>
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always

--- a/templates/prometheus.upstart.erb
+++ b/templates/prometheus.upstart.erb
@@ -22,8 +22,7 @@ script
     [ -e $DEFAULTS ] && . $DEFAULTS
 
     export GOMAXPROCS=${GOMAXPROCS:-2}
-    exec start-stop-daemon --chuid $USER --group $GROUP --pidfile $PID_FILE --exec $PROMETHEUS --start -- <%= @daemon_flags.join(" \\\n      ") %> \
-      <%= scope.lookupvar('prometheus::server::extra_options') %>
+    exec start-stop-daemon --chuid $USER --group $GROUP --pidfile $PID_FILE --exec $PROMETHEUS --start -- <%= @daemon_flags.join(" \\\n      ") %>
 end script
 
 respawn


### PR DESCRIPTION
Our init scripts sometimes contain a trailing `\` after the last
argument. Some might lead to wrong parsing.

Fixes #306
Replaces #307

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
