### PR TITLE
make config files readonly to daemons

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -74,7 +74,7 @@ prometheus::alertmanager::user: 'alertmanager'
 prometheus::alertmanager::version: '0.18.0'
 prometheus::alerts: {}
 prometheus::config_dir: '/etc/prometheus'
-prometheus::config_mode: '0660'
+prometheus::config_mode: '0640'
 prometheus::config_template: 'prometheus/prometheus.yaml.erb'
 prometheus::consul_exporter::consul_health_summary: true
 prometheus::consul_exporter::consul_server: 'localhost:8500'

--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -178,7 +178,7 @@ class prometheus::alertmanager (
 
   file { $config_dir:
     ensure  => 'directory',
-    owner   => $user,
+    owner   => 'root',
     group   => $group,
     purge   => $purge_config_dir,
     recurse => $purge_config_dir,
@@ -194,7 +194,7 @@ class prometheus::alertmanager (
     if $manage_config {
       file { $config_file:
         ensure       => present,
-        owner        => $user,
+        owner        => 'root',
         group        => $group,
         mode         => $config_mode,
         content      => template('prometheus/alertmanager.yaml.erb'),
@@ -208,7 +208,7 @@ class prometheus::alertmanager (
     if $manage_config {
       file { $config_file:
         ensure  => present,
-        owner   => $user,
+        owner   => 'root',
         group   => $group,
         mode    => $config_mode,
         content => template('prometheus/alertmanager.yaml.erb'),

--- a/manifests/alerts.pp
+++ b/manifests/alerts.pp
@@ -19,7 +19,7 @@ define prometheus::alerts (
   if ( versioncmp($version, '2.0.0') < 0 ){
     file { "${location}/${name}.rules":
       ensure       => 'file',
-      owner        => $user,
+      owner        => 'root',
       group        => $group,
       notify       => Class['prometheus::service_reload'],
       content      => epp("${module_name}/alerts.epp", {'alerts' => $alerts}),
@@ -31,7 +31,7 @@ define prometheus::alerts (
   else {
     file { "${location}/${name}.rules":
       ensure       => 'file',
-      owner        => $user,
+      owner        => 'root',
       group        => $group,
       notify       => Class['prometheus::service_reload'],
       content      => $alerts.to_yaml,

--- a/manifests/blackbox_exporter.pp
+++ b/manifests/blackbox_exporter.pp
@@ -139,7 +139,7 @@ class prometheus::blackbox_exporter (
 
   file { $config_file:
     ensure  => present,
-    owner   => $user,
+    owner   => 'root',
     group   => $group,
     mode    => $config_mode,
     content => template('prometheus/blackbox_exporter.yaml.erb'),

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -165,7 +165,7 @@ class prometheus::config {
     file { 'prometheus.yaml':
       ensure       => present,
       path         => "${prometheus::server::config_dir}/${prometheus::server::configname}",
-      owner        => $prometheus::server::user,
+      owner        => 'root',
       group        => $prometheus::server::group,
       mode         => $prometheus::server::config_mode,
       notify       => Class['prometheus::service_reload'],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -86,7 +86,7 @@ class prometheus::install {
   }
   file { $prometheus::server::config_dir:
     ensure  => 'directory',
-    owner   => $prometheus::server::user,
+    owner   => 'root',
     group   => $prometheus::server::group,
     purge   => $prometheus::server::purge_config_dir,
     recurse => $prometheus::server::purge_config_dir,

--- a/manifests/scrape_job.pp
+++ b/manifests/scrape_job.pp
@@ -32,7 +32,7 @@ define prometheus::scrape_job (
   ])
   file { "${collect_dir}/${job_name}_${name}.yaml":
     ensure  => present,
-    owner   => $prometheus::user,
+    owner   => 'root',
     group   => $prometheus::group,
     mode    => $prometheus::config_mode,
     content => "# this file is managed by puppet; changes will be overwritten\n${config}",

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -63,7 +63,7 @@ class prometheus::server (
 
   file { "${config_dir}/rules":
     ensure => 'directory',
-    owner  => $user,
+    owner  => 'root',
     group  => $group,
     mode   => $config_mode,
   }

--- a/manifests/snmp_exporter.pp
+++ b/manifests/snmp_exporter.pp
@@ -135,7 +135,7 @@ class prometheus::snmp_exporter (
 
   file { $config_file:
     ensure  => present,
-    owner   => $user,
+    owner   => 'root',
     group   => $group,
     mode    => $config_mode,
     content => $_content,

--- a/manifests/statsd_exporter.pp
+++ b/manifests/statsd_exporter.pp
@@ -126,7 +126,7 @@ class prometheus::statsd_exporter (
   file { $mapping_config_path:
     ensure  => 'file',
     mode    => $config_mode,
-    owner   => $user,
+    owner   => 'root',
     group   => $group,
     content => to_yaml({ mappings => $mappings }),
     notify  => $notify_service,

--- a/spec/classes/prometheus_spec.rb
+++ b/spec/classes/prometheus_spec.rb
@@ -174,7 +174,7 @@ describe 'prometheus' do
           it {
             is_expected.to contain_file('/etc/prometheus').with(
               'ensure'  => 'directory',
-              'owner'   => 'prometheus',
+              'owner'   => 'root',
               'group'   => 'prometheus',
               'purge'   => true,
               'recurse' => true
@@ -185,9 +185,9 @@ describe 'prometheus' do
             is_expected.to contain_file('prometheus.yaml').with(
               'ensure'  => 'present',
               'path'    => '/etc/prometheus/prometheus.yaml',
-              'owner'   => 'prometheus',
+              'owner'   => 'root',
               'group'   => 'prometheus',
-              'mode'    => '0660',
+              'mode'    => '0640',
               'content' => File.read(fixtures('files', "prometheus#{prom_major}.yaml"))
             ).that_notifies('Class[prometheus::service_reload]')
           }
@@ -265,7 +265,7 @@ describe 'prometheus' do
             it {
               is_expected.to contain_file('/etc/prometheus/alert.rules').with(
                 'ensure'  => 'file',
-                'owner'   => 'prometheus',
+                'owner'   => 'root',
                 'group'   => 'prometheus',
                 'content' => File.read(fixtures('files', "prometheus#{prom_major}.alert.rules"))
               ).that_notifies('Class[prometheus::service_reload]')
@@ -296,7 +296,7 @@ describe 'prometheus' do
               is_expected.to contain_file('prometheus.yaml').with(
                 'ensure'  => 'present',
                 'path'    => '/etc/prometheus/prometheus.yaml',
-                'owner'   => 'prometheus',
+                'owner'   => 'root',
                 'group'   => 'prometheus',
                 'content' => %r{http://domain.tld/path}
               )

--- a/spec/classes/snmp_exporter_spec.rb
+++ b/spec/classes/snmp_exporter_spec.rb
@@ -23,9 +23,9 @@ describe 'prometheus::snmp_exporter' do
           it {
             is_expected.to contain_file('/etc/snmp-exporter.yaml').with(
               'ensure'  => 'present',
-              'owner'   => 'snmp-exporter',
+              'owner'   => 'root',
               'group'   => 'snmp-exporter',
-              'mode'    => '0660',
+              'mode'    => '0640',
               'content' => nil,
               'source'  => 'file:/opt/snmp_exporter-0.6.0.linux-amd64/snmp.yml',
               'require' => 'File[/opt/snmp_exporter-0.6.0.linux-amd64/snmp_exporter]',

--- a/spec/classes/statsd_exporter_spec.rb
+++ b/spec/classes/statsd_exporter_spec.rb
@@ -60,9 +60,9 @@ describe 'prometheus::statsd_exporter' do
           it {
             is_expected.to contain_file('/etc/statsd-exporter-mapping.yaml').with(
               'ensure'  => 'file',
-              'owner'   => 'statsd-exporter',
+              'owner'   => 'root',
               'group'   => 'statsd-exporter',
-              'mode'    => '0660',
+              'mode'    => '0640',
               'notify'  => 'Service[statsd_exporter]',
               'content' => <<-YAML.gsub(%r{^\s+\|}, '')
                 |---

--- a/spec/defines/alerts_spec.rb
+++ b/spec/defines/alerts_spec.rb
@@ -69,7 +69,7 @@ describe 'prometheus::alerts' do
           it {
             is_expected.to contain_file('/etc/prometheus/rules/extra_alerts.rules').with(
               'ensure'  => 'file',
-              'owner'   => 'prometheus',
+              'owner'   => 'root',
               'group'   => 'prometheus',
               'content' => File.read(fixtures('files', "prometheus#{prom_major}.alert.rules"))
             ) # .that_notifies('Class[prometheus::service_reload]')


### PR DESCRIPTION
#### Pull Request (PR) description

It's bad practice to allow daemons to modify their own config
files. This pattern seems to be common across this module, and I
cannot think of a good reason why, as there is little chance (say) an
exporter should have to modify its own config file.

This reverts the policy by ensuring only minimal permissions are set
on config files and directories deployed by Puppet. Only two
directories are writable after this change:

 * /var/lib/prometheus
 * /usr/local/share/prometheus

And I'm not even sure about the latter.

#### This Pull Request (PR) fixes the following issues

No issue was filed, but this problem was identified while working on the Debian packaging PR (#303) because the permissions on the files deployed by the Debian package would be broken.