### PR TITLE
Link the amtool only if it is installed via direct download.

### DIFF
--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -183,7 +183,7 @@ class prometheus::alertmanager (
     recurse => $purge_config_dir,
   }
 
-  if ( versioncmp($version, '0.10.0') >= 0 ) {
+  if (( versioncmp($version, '0.10.0') >= 0 ) and ( $install_method == 'url' )) {
     # If version >= 0.10.0 then install amtool - Alertmanager validation tool
     file {"${bin_dir}/amtool":
       ensure => link,


### PR DESCRIPTION
#### Pull Request (PR) description
Only link /usr/bin/amtool if install_method is 'url'

#### This Pull Request (PR) fixes the following issues
Fixes #327
