### PR TITLE
Bugfix on prometheus daemon

### DIFF
--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -107,10 +107,16 @@ define prometheus::daemon (
           before          => File["/opt/${name}-${version}.${os}-${arch}/${name}"],
         }
       } else {
-        archive { "/tmp/${name}-${version}.${download_extension}":
+        file { "/opt/${name}-${version}.${os}-${arch}":
+          ensure => directory,
+          owner  => 'root',
+          group  => 0, # 0 instead of root because OS X uses "wheel".
+          mode   => '0755',
+        }
+        -> archive { "/tmp/${name}-${version}.${download_extension}":
           ensure          => present,
           extract         => true,
-          extract_path    => '/opt',
+          extract_path    => "/opt/${name}-${version}.${os}-${arch}",
           source          => $real_download_url,
           checksum_verify => false,
           creates         => "/opt/${name}-${version}.${os}-${arch}/${name}",

--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -162,7 +162,7 @@ define prometheus::daemon (
   }
 
 
-  if $init_style {
+  if $init_style != '' {
     case $init_style {
       'upstart' : {
         file { "/etc/init/${name}.conf":

--- a/spec/defines/daemon_spec.rb
+++ b/spec/defines/daemon_spec.rb
@@ -45,7 +45,7 @@ describe 'prometheus::daemon' do
             is_expected.to contain_archive("/tmp/smurf_exporter-#{parameters[:version]}.tar.gz").with(
               'ensure'          => 'present',
               'extract'         => true,
-              'extract_path'    => '/opt',
+              'extract_path'    => "/opt/smurf_exporter-#{parameters[:version]}.#{prom_os}-#{prom_arch}",
               'source'          => params[:real_download_url],
               'checksum_verify' => false,
               'creates'         => "/opt/smurf_exporter-#{parameters[:version]}.#{prom_os}-#{prom_arch}/smurf_exporter",


### PR DESCRIPTION
if init_style is never evaluated to false as the type is a String
in the case `install_method` is 'url' but you pass a `download_extension`, you would also need the directory to be present so moved the block one level up to fix that and change `extract_path` to the right place