### PR TITLE
prohibit empty service_provider fact

### DIFF
--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -162,71 +162,69 @@ define prometheus::daemon (
   }
 
 
-  if $init_style {
-    case $init_style {
-      'upstart' : {
-        file { "/etc/init/${name}.conf":
-          mode    => '0444',
-          owner   => 'root',
-          group   => 'root',
-          content => template('prometheus/daemon.upstart.erb'),
-          notify  => $notify_service,
-        }
-        file { "/etc/init.d/${name}":
-          ensure => link,
-          target => '/lib/init/upstart-job',
-          owner  => 'root',
-          group  => 'root',
-          mode   => '0755',
-        }
+  case $init_style {
+    'upstart' : {
+      file { "/etc/init/${name}.conf":
+        mode    => '0444',
+        owner   => 'root',
+        group   => 'root',
+        content => template('prometheus/daemon.upstart.erb'),
+        notify  => $notify_service,
       }
-      'systemd' : {
-        include 'systemd'
-        systemd::unit_file {"${name}.service":
-          content => template('prometheus/daemon.systemd.erb'),
-          notify  => $notify_service,
-        }
+      file { "/etc/init.d/${name}":
+        ensure => link,
+        target => '/lib/init/upstart-job',
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0755',
       }
-      # service_provider returns redhat on CentOS using sysv, https://tickets.puppetlabs.com/browse/PUP-5296
-      'sysv','redhat' : {
-        file { "/etc/init.d/${name}":
-          mode    => '0555',
-          owner   => 'root',
-          group   => 'root',
-          content => template('prometheus/daemon.sysv.erb'),
-          notify  => $notify_service,
-        }
+    }
+    'systemd' : {
+      include 'systemd'
+      systemd::unit_file {"${name}.service":
+        content => template('prometheus/daemon.systemd.erb'),
+        notify  => $notify_service,
       }
-      'debian' : {
-        file { "/etc/init.d/${name}":
-          mode    => '0555',
-          owner   => 'root',
-          group   => 'root',
-          content => template('prometheus/daemon.debian.erb'),
-          notify  => $notify_service,
-        }
+    }
+    # service_provider returns redhat on CentOS using sysv, https://tickets.puppetlabs.com/browse/PUP-5296
+    'sysv','redhat' : {
+      file { "/etc/init.d/${name}":
+        mode    => '0555',
+        owner   => 'root',
+        group   => 'root',
+        content => template('prometheus/daemon.sysv.erb'),
+        notify  => $notify_service,
       }
-      'sles' : {
-        file { "/etc/init.d/${name}":
-          mode    => '0555',
-          owner   => 'root',
-          group   => 'root',
-          content => template('prometheus/daemon.sles.erb'),
-          notify  => $notify_service,
-        }
+    }
+    'debian' : {
+      file { "/etc/init.d/${name}":
+        mode    => '0555',
+        owner   => 'root',
+        group   => 'root',
+        content => template('prometheus/daemon.debian.erb'),
+        notify  => $notify_service,
       }
-      'launchd' : {
-        file { "/Library/LaunchDaemons/io.${name}.daemon.plist":
-          mode    => '0644',
-          owner   => 'root',
-          group   => 'wheel',
-          content => template('prometheus/daemon.launchd.erb'),
-          notify  => $notify_service,
-        }
+    }
+    'sles' : {
+      file { "/etc/init.d/${name}":
+        mode    => '0555',
+        owner   => 'root',
+        group   => 'root',
+        content => template('prometheus/daemon.sles.erb'),
+        notify  => $notify_service,
       }
-      default : {
-        fail("I don't know how to create an init script for style ${init_style}")
+    }
+    'launchd' : {
+      file { "/Library/LaunchDaemons/io.${name}.daemon.plist":
+        mode    => '0644',
+        owner   => 'root',
+        group   => 'wheel',
+        content => template('prometheus/daemon.launchd.erb'),
+        notify  => $notify_service,
       }
+    }
+    default : {
+      fail("I don't know how to create an init script for style ${init_style}")
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -179,7 +179,7 @@ class prometheus (
   String $service_ensure,
   Boolean $manage_service,
   Boolean $restart_on_change,
-  String $init_style,
+  String[1] $init_style,
   Optional[String[1]] $extra_options,
   Optional[String] $download_url,
   String $arch,


### PR DESCRIPTION
This module depends on the variable `prometheus::init_style` being set
to a string. The default is the `service_provider` fact from stdlib.
To enforce this, we set the minimal string length for
`prometheus::init_style`.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
