### PR TITLE
Make mongodb usable with newer version

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -180,6 +180,7 @@ prometheus::mongodb_exporter::package_ensure: 'latest'
 prometheus::mongodb_exporter::package_name: 'mongodb_exporter'
 prometheus::mongodb_exporter::user: 'mongodb-exporter'
 prometheus::mongodb_exporter::version: '0.3.1'
+prometheus::mongodb_exporter::use_kingpin: false
 prometheus::node_exporter::download_extension: 'tar.gz'
 prometheus::node_exporter::download_url_base: 'https://github.com/prometheus/node_exporter/releases'
 prometheus::node_exporter::extra_groups: []

--- a/manifests/mongodb_exporter.pp
+++ b/manifests/mongodb_exporter.pp
@@ -71,6 +71,11 @@
 #
 #  [*version*]
 #  The binary release version
+#
+#  [*use_kingpin*]
+#  Since version 0.7.0, the mongodb exporter uses kingpin, thus
+#  this param to define how we call the mongodb.uri in the $options
+#  https://github.com/percona/mongodb_exporter/blob/v0.7.0/CHANGELOG.md
 
 class prometheus::mongodb_exporter (
   String $cnf_uri,
@@ -82,6 +87,7 @@ class prometheus::mongodb_exporter (
   String $package_name,
   String $user,
   String $version,
+  Boolean $use_kingpin,
   Boolean $purge_config_dir      = true,
   Boolean $restart_on_change     = true,
   Boolean $service_enable        = true,
@@ -109,7 +115,12 @@ class prometheus::mongodb_exporter (
     default => undef,
   }
 
-  $options = "-mongodb.uri=${cnf_uri} ${extra_options}"
+  $flag_prefix = $use_kingpin ? {
+    true  => '--',
+    false => '-',
+  }
+
+  $options = "${flag_prefix}mongodb.uri=${cnf_uri} ${extra_options}"
 
   prometheus::daemon { 'mongodb_exporter':
     install_method     => $install_method,


### PR DESCRIPTION
Make it possible for mongodb exporter to be used even with version from 0.7.0 where breaking changes appear (see https://github.com/percona/mongodb_exporter/blob/v0.7.0/CHANGELOG.md)