### PR TITLE
alertmanager - Add flag for managing the config file

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -19,6 +19,7 @@ prometheus::extract_command: ~
 prometheus::alert_relabel_config: []
 prometheus::alertmanagers_config: []
 prometheus::alertmanager::config_dir: '/etc/alertmanager'
+prometheus::alertmanager::manage_config: true
 prometheus::alertmanager::config_file: "%{hiera('prometheus::alertmanager::config_dir')}/alertmanager.yaml"
 prometheus::alertmanager::download_extension: 'tar.gz'
 prometheus::alertmanager::download_url_base: 'https://github.com/prometheus/alertmanager/releases'

--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -150,6 +150,7 @@ class prometheus::alertmanager (
   String $service_name           = 'alertmanager',
   Boolean $restart_on_change     = true,
   Boolean $purge_config_dir      = true,
+  Boolean $manage_config         = true,
   String $init_style             = $prometheus::init_style,
   String $install_method         = $prometheus::install_method,
   Boolean $manage_group          = true,
@@ -190,25 +191,30 @@ class prometheus::alertmanager (
       target => "/opt/${package_name}-${version}.${os}-${arch}/amtool",
     }
 
-    file { $config_file:
-      ensure       => present,
-      owner        => $user,
-      group        => $group,
-      mode         => $config_mode,
-      content      => template('prometheus/alertmanager.yaml.erb'),
-      notify       => $notify_service,
-      require      => File["${bin_dir}/amtool", $config_dir],
-      validate_cmd => "${bin_dir}/amtool check-config --alertmanager.url='' %",
+    if $manage_config {
+      file { $config_file:
+        ensure       => present,
+        owner        => $user,
+        group        => $group,
+        mode         => $config_mode,
+        content      => template('prometheus/alertmanager.yaml.erb'),
+        notify       => $notify_service,
+        require      => File["${bin_dir}/amtool", $config_dir],
+        validate_cmd => "${bin_dir}/amtool check-config --alertmanager.url='' %",
+      }
     }
   } else {
-    file { $config_file:
-      ensure  => present,
-      owner   => $user,
-      group   => $group,
-      mode    => $config_mode,
-      content => template('prometheus/alertmanager.yaml.erb'),
-      notify  => $notify_service,
-      require => File[$config_dir],
+
+    if $manage_config {
+      file { $config_file:
+        ensure  => present,
+        owner   => $user,
+        group   => $group,
+        mode    => $config_mode,
+        content => template('prometheus/alertmanager.yaml.erb'),
+        notify  => $notify_service,
+        require => File[$config_dir],
+      }
     }
   }
 

--- a/spec/classes/alertmanager_spec.rb
+++ b/spec/classes/alertmanager_spec.rb
@@ -37,6 +37,29 @@ describe 'prometheus::alertmanager' do
           }
         end
       end
+
+      context 'with manage_config => false' do
+        [
+          {
+            version: '0.9.0',
+            manage_config: false
+          },
+          {
+            version: '0.18.0',
+            manage_config: false
+          }
+        ].each do |parameters|
+          context "with alertmanager verions #{parameters[:version]}" do
+            let(:params) do
+              parameters
+            end
+
+            it {
+              is_expected.not_to contain_file('/etc/alertmanager/alertmanager.yaml')
+            }
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Add new flag `prometheus::alertmanager::manage_config` for alertmanager.

This will give the user the option not have the `prometheus::alertmanager::config_file` managed by this module.

*motivation for this change* 
We have a process outside of puppet that holds configuration information for alertmanager. 


 

#### This Pull Request (PR) fixes the following issues

Not fixing an open issue, happy to open an issue for tracking if required.


This pull request is based on the work by @bastelfreak & @erilane in https://github.com/voxpupuli/puppet-prometheus/pull/319