### PR TITLE
pushgateway: update 0.4.0->0.8.0 & enhance unit tests

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -155,7 +155,7 @@ prometheus::pushgateway::group: 'pushgateway'
 prometheus::pushgateway::package_ensure: 'latest'
 prometheus::pushgateway::package_name: 'pushgateway'
 prometheus::pushgateway::user: 'pushgateway'
-prometheus::pushgateway::version: '0.4.0'
+prometheus::pushgateway::version: '0.8.0'
 prometheus::rabbitmq_exporter::download_extension: 'tar.gz'
 prometheus::rabbitmq_exporter::download_url_base: 'https://github.com/kbudde/rabbitmq_exporter/releases'
 prometheus::rabbitmq_exporter::extra_groups: []

--- a/spec/classes/pushgateway_spec.rb
+++ b/spec/classes/pushgateway_spec.rb
@@ -20,6 +20,7 @@ describe 'prometheus::pushgateway' do
 
         describe 'install correct binary' do
           it { is_expected.to contain_file('/usr/local/bin/pushgateway').with('target' => '/opt/pushgateway-0.4.0.linux-amd64/pushgateway') }
+          it { is_expected.to compile.with_all_deps }
         end
       end
     end


### PR DESCRIPTION
Depends on https://github.com/voxpupuli/puppet-prometheus/pull/338