### PR TITLE
Archlinux: update prometheus 2.2.0->2.10.0

### DIFF
--- a/data/Archlinux.yaml
+++ b/data/Archlinux.yaml
@@ -1,5 +1,5 @@
 ---
-prometheus::version: '2.2.0'
+prometheus::version: '2.10.0'
 prometheus::install_method: 'package'
 prometheus::bin_dir: '/usr/bin'
 prometheus::env_file_path: '/etc/default'


### PR DESCRIPTION
This isn't labled as backwards incompatible because the package manager on Archlinux ignores versions. This is more for a documentational purpose.