### PR TITLE
pushgateway: use correct CPU architecture & add acceptance tests

### DIFF
--- a/manifests/pushgateway.pp
+++ b/manifests/pushgateway.pp
@@ -90,7 +90,7 @@ class prometheus::pushgateway (
   String $os                     = $prometheus::os,
   String $extra_options          = '',
   Optional[String] $download_url = undef,
-  String $arch                   = $prometheus::arch,
+  String[1] $arch                = $prometheus::real_arch,
   String $bin_dir                = $prometheus::bin_dir,
 ) inherits prometheus {
 

--- a/spec/acceptance/pushgateway_spec.rb
+++ b/spec/acceptance/pushgateway_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper_acceptance'
+
+describe 'prometheus pushgateway' do
+  it 'pushgateway works idempotently with no errors' do
+    pp = 'include prometheus::pushgateway'
+    # Run it twice and test for idempotency
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
+  end
+
+  describe service('pushgateway') do
+    it { is_expected.to be_running }
+    it { is_expected.to be_enabled }
+  end
+
+  describe port(9091) do
+    it { is_expected.to be_listening.with('tcp6') }
+  end
+
+  describe 'pushgateway update from 0.4.0 to 0.8.0' do
+    it 'is idempotent' do
+      pp = "class{'prometheus::pushgateway': version => '0.4.0'}"
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe service('pushgateway') do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
+
+    describe port(9091) do
+      it { is_expected.to be_listening.with('tcp6') }
+    end
+    it 'is idempotent' do
+      pp = "class{'prometheus::pushgateway': version => '0.8.0'}"
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe service('pushgateway') do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
+
+    describe port(9091) do
+      it { is_expected.to be_listening.with('tcp6') }
+    end
+  end
+end


### PR DESCRIPTION
In the past, this class relied on the actual architecture reported by
facter, not by the normalized version from our main class. On CentOS,
under certain conditions, this will not work and report x86_64 instead
of amd64. This is the bugfix for https://github.com/voxpupuli/puppet-prometheus/pull/341

Without this fix, the acceptance tests won't work.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
