### PR TITLE
fix duplicate key in data/defaults.yaml

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -108,7 +108,6 @@ prometheus::global_config:
   'external_labels':
     'monitor': 'master'
 prometheus::group: 'prometheus'
-prometheus::install_method: 'url'
 prometheus::localstorage: '/var/lib/prometheus'
 prometheus::manage_config: true
 prometheus::mesos_exporter::server_type: 'master'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Fixes duplicate key `prometheus::install_method` in data/defaults.yaml

#### This Pull Request (PR) fixes the following issues
n.a.
