### PR TITLE
Make elasticsearch usable with older version

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -101,6 +101,7 @@ prometheus::elasticsearch_exporter::package_ensure: 'latest'
 prometheus::elasticsearch_exporter::package_name: 'elasticsearch_exporter'
 prometheus::elasticsearch_exporter::user: 'elasticsearch-exporter'
 prometheus::elasticsearch_exporter::version: '1.1.0rc1'
+prometheus::elasticsearch_exporter::use_kingpin: true
 prometheus::extra_groups: []
 prometheus::global_config:
   'scrape_interval': '15s'

--- a/manifests/elasticsearch_exporter.pp
+++ b/manifests/elasticsearch_exporter.pp
@@ -77,6 +77,11 @@
 #
 #  [*version*]
 #  The binary release version
+#
+#  [*use_kingpin*]
+#  Since version 1.1.0, the elasticsearch exporter uses kingpin, thus
+#  this param to define how we call the es.uri and es.timeout in the $options
+#  https://github.com/justwatchcom/elasticsearch_exporter/blob/v1.1.0/CHANGELOG.md
 
 class prometheus::elasticsearch_exporter (
   String $cnf_uri,
@@ -89,6 +94,7 @@ class prometheus::elasticsearch_exporter (
   String $package_name,
   String $user,
   String $version,
+  Boolean $use_kingpin,
   Boolean $purge_config_dir      = true,
   Boolean $restart_on_change     = true,
   Boolean $service_enable        = true,
@@ -116,7 +122,12 @@ class prometheus::elasticsearch_exporter (
     default => undef,
   }
 
-  $options = "--es.uri=${cnf_uri} --es.timeout=${cnf_timeout} ${extra_options}"
+  $flag_prefix = $use_kingpin ? {
+    true  => '--',
+    false => '-',
+  }
+
+  $options = "${flag_prefix}es.uri=${cnf_uri} ${flag_prefix}es.timeout=${cnf_timeout} ${extra_options}"
 
   prometheus::daemon { 'elasticsearch_exporter':
     install_method     => $install_method,


### PR DESCRIPTION
Make it possible for elasticsearch exporter to be used even with version before 1.1.0 where breaking changes appear
(see https://github.com/justwatchcom/elasticsearch_exporter/blob/v1.1.0/CHANGELOG.md)

A little bit the same than what I did for mongodb exporter (https://github.com/voxpupuli/puppet-prometheus/pull/331)