### PR TITLE
WIP: add labeling support for exported scrape jobs

### DIFF
--- a/manifests/apache_exporter.pp
+++ b/manifests/apache_exporter.pp
@@ -103,6 +103,7 @@ class prometheus::apache_exporter (
   Boolean $export_scrape_job              = false,
   Stdlib::Port $scrape_port               = 9117,
   String[1] $scrape_job_name              = 'apache',
+  Optional[Hash] $scrape_job_labels                                  = {},
 ) inherits prometheus {
 
   #Please provide the download_url for versions < 0.9.0
@@ -139,5 +140,6 @@ class prometheus::apache_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/beanstalkd_exporter.pp
+++ b/manifests/beanstalkd_exporter.pp
@@ -111,6 +111,7 @@ class prometheus::beanstalkd_exporter (
   Boolean $export_scrape_job          = false,
   Stdlib::Port $scrape_port           = 8080,
   String[1] $scrape_job_name          = 'beanstalkd',
+  Optional[Hash] $scrape_job_labels   = {},
 ) inherits prometheus {
 
   #Please provide the download_url for versions < 0.9.0
@@ -159,5 +160,6 @@ class prometheus::beanstalkd_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/blackbox_exporter.pp
+++ b/manifests/blackbox_exporter.pp
@@ -119,6 +119,7 @@ class prometheus::blackbox_exporter (
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9115,
   String[1] $scrape_job_name     = 'blackbox',
+  Optional[Hash] $scrape_job_labels = {},
 
 ) inherits prometheus {
 
@@ -171,5 +172,6 @@ class prometheus::blackbox_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/collectd_exporter.pp
+++ b/manifests/collectd_exporter.pp
@@ -91,6 +91,7 @@ class prometheus::collectd_exporter (
   Boolean $export_scrape_job        = false,
   Stdlib::Port $scrape_port         = 9103,
   String[1] $scrape_job_name        = 'collectd',
+  Optional[Hash] $scrape_job_labels = {},
 ) inherits prometheus {
 
   $real_download_url = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
@@ -124,5 +125,6 @@ class prometheus::collectd_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/consul_exporter.pp
+++ b/manifests/consul_exporter.pp
@@ -115,6 +115,7 @@ class prometheus::consul_exporter (
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9107,
   String[1] $scrape_job_name     = 'consul',
+  Optional[Hash] $scrape_job_labels = {},
 ) inherits prometheus {
 
   # Prometheus added a 'v' on the realease name at 0.3.0
@@ -170,5 +171,6 @@ class prometheus::consul_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -89,6 +89,7 @@ define prometheus::daemon (
   Stdlib::Host $scrape_host            = $facts['fqdn'],
   Optional[Stdlib::Port] $scrape_port  = undef,
   String[1] $scrape_job_name           = $name,
+  Optional[Hash] $scrape_job_labels    = {},
 ) {
 
   case $install_method {
@@ -266,7 +267,7 @@ define prometheus::daemon (
     @@prometheus::scrape_job { "${scrape_host}:${scrape_port}":
       job_name => $scrape_job_name,
       targets  => ["${scrape_host}:${scrape_port}"],
-      labels   => { 'alias' => $scrape_host },
+      labels   => { 'alias' => $scrape_host } + $scrape_job_labels,
     }
   }
 }

--- a/manifests/elasticsearch_exporter.pp
+++ b/manifests/elasticsearch_exporter.pp
@@ -112,6 +112,7 @@ class prometheus::elasticsearch_exporter (
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9114,
   String[1] $scrape_job_name     = 'elasticsearch',
+  Optional[Hash] $scrape_job_labels = {},
 ) inherits prometheus {
 
   #Please provide the download_url for versions < 0.9.0
@@ -154,5 +155,6 @@ class prometheus::elasticsearch_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/graphite_exporter.pp
+++ b/manifests/graphite_exporter.pp
@@ -91,6 +91,7 @@ class prometheus::graphite_exporter (
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9108,
   String[1] $scrape_job_name     = 'graphite',
+  Optional[Hash] $scrape_job_labels = {},
 ) inherits prometheus {
 
   $real_download_url = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
@@ -124,5 +125,6 @@ class prometheus::graphite_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/haproxy_exporter.pp
+++ b/manifests/haproxy_exporter.pp
@@ -99,6 +99,7 @@ class prometheus::haproxy_exporter(
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9101,
   String[1] $scrape_job_name     = 'haproxy',
+  Optional[Hash] $scrape_job_labels = {},
 ) inherits prometheus {
 
   $real_download_url = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
@@ -134,6 +135,7 @@ class prometheus::haproxy_exporter(
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 
 }

--- a/manifests/mesos_exporter.pp
+++ b/manifests/mesos_exporter.pp
@@ -103,6 +103,7 @@ class prometheus::mesos_exporter (
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9105,
   String[1] $scrape_job_name     = 'mesos',
+  Optional[Hash] $scrape_job_labels = {},
 ) inherits prometheus {
 
   $real_download_url    = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
@@ -138,5 +139,6 @@ class prometheus::mesos_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/mongodb_exporter.pp
+++ b/manifests/mongodb_exporter.pp
@@ -105,6 +105,7 @@ class prometheus::mongodb_exporter (
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9216,
   String[1] $scrape_job_name     = 'mongodb',
+  Optional[Hash] $scrape_job_labels = {},
 ) inherits prometheus {
 
   #Please provide the download_url for versions < 0.9.0
@@ -147,5 +148,6 @@ class prometheus::mongodb_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/mysqld_exporter.pp
+++ b/manifests/mysqld_exporter.pp
@@ -123,6 +123,7 @@ class prometheus::mysqld_exporter (
   Boolean $export_scrape_job                 = false,
   Stdlib::Port $scrape_port                  = 9104,
   String[1] $scrape_job_name                 = 'mysql',
+  Optional[Hash] $scrape_job_labels          = {},
 ) inherits prometheus {
 
   #Please provide the download_url for versions < 0.9.0
@@ -171,5 +172,6 @@ class prometheus::mysqld_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/nginx_vts_exporter.pp
+++ b/manifests/nginx_vts_exporter.pp
@@ -99,6 +99,7 @@ class prometheus::nginx_vts_exporter(
   Boolean $export_scrape_job          = false,
   Stdlib::Port $scrape_port           = 9913,
   String[1] $scrape_job_name          = 'nginx_vts',
+  Optional[Hash] $scrape_job_labels   = {},
 ) inherits prometheus {
 
   $real_download_url = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
@@ -134,6 +135,7 @@ class prometheus::nginx_vts_exporter(
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 
 }

--- a/manifests/node_exporter.pp
+++ b/manifests/node_exporter.pp
@@ -115,6 +115,7 @@ class prometheus::node_exporter (
   Boolean $export_scrape_job          = false,
   Stdlib::Port $scrape_port           = 9100,
   String[1] $scrape_job_name          = 'node',
+  Optional[Hash] $scrape_job_labels    = {},
   Optional[String[1]] $bin_name       = undef,
 ) inherits prometheus {
 
@@ -173,6 +174,7 @@ class prometheus::node_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
     bin_name           => $bin_name,
   }
 }

--- a/manifests/postgres_exporter.pp
+++ b/manifests/postgres_exporter.pp
@@ -126,6 +126,7 @@ class prometheus::postgres_exporter (
   Boolean $export_scrape_job                    = false,
   Stdlib::Port $scrape_port                     = 9187,
   String[1] $scrape_job_name                    = 'postgres',
+  Optional[Hash] $scrape_job_labels             = {}
 ) inherits prometheus {
 
   $release = "v${version}"
@@ -219,5 +220,6 @@ class prometheus::postgres_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/process_exporter.pp
+++ b/manifests/process_exporter.pp
@@ -98,6 +98,7 @@ class prometheus::process_exporter(
   Boolean $export_scrape_job              = false,
   Stdlib::Port $scrape_port               = 9256,
   String[1] $scrape_job_name              = 'process',
+  Optional[Hash] $scrape_job_labels       = {},
 ) inherits prometheus {
 
   $filename = "${package_name}-${version}.${os}-${arch}.${download_extension}"
@@ -143,5 +144,6 @@ class prometheus::process_exporter(
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/rabbitmq_exporter.pp
+++ b/manifests/rabbitmq_exporter.pp
@@ -131,6 +131,7 @@ class prometheus::rabbitmq_exporter (
   Boolean $export_scrape_job          = false,
   Stdlib::Port $scrape_port           = 9090,
   String[1] $scrape_job_name          = 'rabbitmq',
+  Optional[Hash] $scrape_job_labels   = {},
 ) inherits prometheus {
 
   $real_download_url    = pick($download_url, "${download_url_base}/download/v${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
@@ -177,5 +178,6 @@ class prometheus::rabbitmq_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/redis_exporter.pp
+++ b/manifests/redis_exporter.pp
@@ -110,6 +110,7 @@ class prometheus::redis_exporter (
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9121,
   String[1] $scrape_job_name     = 'redis',
+  Optional[Hash] $scrape_job_labels = {},
 ) inherits prometheus {
 
   $release = "v${version}"
@@ -180,5 +181,6 @@ class prometheus::redis_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/snmp_exporter.pp
+++ b/manifests/snmp_exporter.pp
@@ -107,6 +107,7 @@ class prometheus::snmp_exporter (
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9116,
   String[1] $scrape_job_name     = 'snmp',
+  Optional[Hash] $scrape_job_labels = {},
 ) inherits prometheus {
 
   $real_download_url = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
@@ -169,5 +170,6 @@ class prometheus::snmp_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/statsd_exporter.pp
+++ b/manifests/statsd_exporter.pp
@@ -109,6 +109,7 @@ class prometheus::statsd_exporter (
   Boolean $export_scrape_job              = false,
   Stdlib::Port $scrape_port               = 9102,
   String[1] $scrape_job_name              = 'statsd',
+  Optional[Hash] $scrape_job_labels       = {},
 ) inherits prometheus {
 
   # Prometheus added a 'v' on the realease name at 0.4.0 and changed the configuration format to yaml in 0.5.0
@@ -165,5 +166,6 @@ class prometheus::statsd_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/varnish_exporter.pp
+++ b/manifests/varnish_exporter.pp
@@ -97,6 +97,7 @@ class prometheus::varnish_exporter(
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9131,
   String[1] $scrape_job_name     = 'varnish',
+  Optional[Hash] $scrape_job_labels = {},
 ) inherits prometheus {
 
   $real_download_url = pick($download_url,"${download_url_base}/download/${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
@@ -131,5 +132,6 @@ class prometheus::varnish_exporter(
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

The previous work to collect scrape jobs (#304) was a good start, but
it really becomes powerful when you can select certain labels to apply
on the exporters.

For example, I use this to export the node roles' in the prometheus
metrics, which allows me to regroup results by role instead of by node:

```
    scrape_job_labels => {
      'classes' => join(lookup('classes', Data, 'first', []), ',')
    },
```

This is WIP because it probably needs docs strings and tests, although I'm not sure about the latter.