### PR TITLE
Add CentOS 8 & RHEL 8 support

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -8,5 +8,6 @@
     - set: debian8-64
     - set: debian9-64
     - set: centos7-64
+    - set: centos8-64
 spec/spec_helper.rb:
   spec_overrides: "require 'spec_helper_methods'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,14 @@ matrix:
     bundler_args: --without development release
     env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos8-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos8-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
 branches:
   only:
   - master

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group :system_tests do
     gem 'beaker-rspec',  :require => false
   end
   gem 'serverspec',                         :require => false
-  gem 'beaker-hostgenerator', '>= 1.1.22',  :require => false
+  gem 'beaker-hostgenerator', '>= 1.1.42',  :require => false
   gem 'beaker-docker',                      :require => false
   gem 'beaker-puppet',                      :require => false
   gem 'beaker-puppet_install_helper',       :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :system_tests do
   if beaker_version = ENV['BEAKER_VERSION']
     gem 'beaker', *location_for(beaker_version)
   else
-    gem 'beaker', '>= 4.2.0', :require => false
+    gem 'beaker', '>= 4.8.0', :require => false
   end
   if beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION']
     gem 'beaker-rspec', *location_for(beaker_rspec_version)

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :system_tests do
   if beaker_version = ENV['BEAKER_VERSION']
     gem 'beaker', *location_for(beaker_version)
   else
-    gem 'beaker', '>= 4.8.0', :require => false
+    gem 'beaker', '>= 4.2.0', :require => false
   end
   if beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION']
     gem 'beaker-rspec', *location_for(beaker_rspec_version)

--- a/metadata.json
+++ b/metadata.json
@@ -41,14 +41,16 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {

--- a/spec/classes/prometheus_spec.rb
+++ b/spec/classes/prometheus_spec.rb
@@ -116,7 +116,7 @@ describe 'prometheus' do
                 'content' => File.read(fixtures('files', "prometheus#{prom_major}.sysv"))
               )
             }
-          elsif ['centos-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'redhat-7-x86_64', 'ubuntu-16.04-x86_64', 'ubuntu-18.04-x86_64', 'archlinux-5-x86_64'].include?(os)
+          elsif ['centos-7-x86_64', 'centos-8-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'ubuntu-16.04-x86_64', 'ubuntu-18.04-x86_64', 'archlinux-5-x86_64'].include?(os)
             # init_style = 'systemd'
 
             it { is_expected.to contain_class('systemd') }

--- a/spec/defines/daemon_spec.rb
+++ b/spec/defines/daemon_spec.rb
@@ -134,7 +134,7 @@ describe 'prometheus::daemon' do
                 )
               }
             end
-          elsif ['centos-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'redhat-7-x86_64', 'ubuntu-16.04-x86_64', 'ubuntu-18.04-x86_64', 'archlinux-5-x86_64'].include?(os)
+          elsif ['centos-7-x86_64', 'centos-8-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'ubuntu-16.04-x86_64', 'ubuntu-18.04-x86_64', 'archlinux-5-x86_64'].include?(os)
             # init_style = 'systemd'
 
             it { is_expected.to contain_class('systemd') }

--- a/spec/spec_helper_methods.rb
+++ b/spec/spec_helper_methods.rb
@@ -23,6 +23,8 @@ def os_specific_facts(facts)
       { service_provider: 'sysv' }
     when '7'
       { service_provider: 'systemd' }
+    when '8'
+      { service_provider: 'systemd' }
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds support for CentOS 8 & RHEL 8. Basically I adapted earlier PRs for Debian 9 & Ubuntu 18.04.
Probably need to wait a while until `puppet/archive`, `puppetlabs/stdlib` and `camptocamp/systemd` also support these OS.

#### This Pull Request (PR) fixes the following issues
None
