### PR TITLE
Add `scrape_job_labels` parameter to exporters

### DIFF
--- a/manifests/apache_exporter.pp
+++ b/manifests/apache_exporter.pp
@@ -103,6 +103,7 @@ class prometheus::apache_exporter (
   Boolean $export_scrape_job              = false,
   Stdlib::Port $scrape_port               = 9117,
   String[1] $scrape_job_name              = 'apache',
+  Optional[Hash] $scrape_job_labels       = undef,
 ) inherits prometheus {
 
   #Please provide the download_url for versions < 0.9.0
@@ -139,5 +140,6 @@ class prometheus::apache_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/beanstalkd_exporter.pp
+++ b/manifests/beanstalkd_exporter.pp
@@ -111,6 +111,7 @@ class prometheus::beanstalkd_exporter (
   Boolean $export_scrape_job          = false,
   Stdlib::Port $scrape_port           = 8080,
   String[1] $scrape_job_name          = 'beanstalkd',
+  Optional[Hash] $scrape_job_labels   = undef,
 ) inherits prometheus {
 
   #Please provide the download_url for versions < 0.9.0
@@ -159,5 +160,6 @@ class prometheus::beanstalkd_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/blackbox_exporter.pp
+++ b/manifests/blackbox_exporter.pp
@@ -119,7 +119,7 @@ class prometheus::blackbox_exporter (
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9115,
   String[1] $scrape_job_name     = 'blackbox',
-
+  Optional[Hash] $scrape_job_labels = undef,
 ) inherits prometheus {
 
   # Prometheus added a 'v' on the release name at 0.1.0 of blackbox
@@ -171,5 +171,6 @@ class prometheus::blackbox_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/collectd_exporter.pp
+++ b/manifests/collectd_exporter.pp
@@ -91,6 +91,7 @@ class prometheus::collectd_exporter (
   Boolean $export_scrape_job        = false,
   Stdlib::Port $scrape_port         = 9103,
   String[1] $scrape_job_name        = 'collectd',
+  Optional[Hash] $scrape_job_labels = undef,
 ) inherits prometheus {
 
   $real_download_url = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
@@ -124,5 +125,6 @@ class prometheus::collectd_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/consul_exporter.pp
+++ b/manifests/consul_exporter.pp
@@ -115,6 +115,7 @@ class prometheus::consul_exporter (
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9107,
   String[1] $scrape_job_name     = 'consul',
+  Optional[Hash] $scrape_job_labels = undef,
 ) inherits prometheus {
 
   # Prometheus added a 'v' on the realease name at 0.3.0
@@ -170,5 +171,6 @@ class prometheus::consul_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -89,6 +89,7 @@ define prometheus::daemon (
   Stdlib::Host $scrape_host            = $facts['fqdn'],
   Optional[Stdlib::Port] $scrape_port  = undef,
   String[1] $scrape_job_name           = $name,
+  Hash $scrape_job_labels              = { 'alias' => $scrape_host },
   Stdlib::Absolutepath $usershell      = $prometheus::usershell,
 ) {
 
@@ -121,14 +122,14 @@ define prometheus::daemon (
         }
       }
       file { "/opt/${name}-${version}.${os}-${arch}/${name}":
-          owner => 'root',
-          group => 0, # 0 instead of root because OS X uses "wheel".
-          mode  => '0555',
+        owner => 'root',
+        group => 0, # 0 instead of root because OS X uses "wheel".
+        mode  => '0555',
       }
       -> file { "${bin_dir}/${name}":
-          ensure => link,
-          notify => $notify_service,
-          target => "/opt/${name}-${version}.${os}-${arch}/${name}",
+        ensure => link,
+        notify => $notify_service,
+        target => "/opt/${name}-${version}.${os}-${arch}/${name}",
       }
     }
     'package': {
@@ -269,7 +270,7 @@ define prometheus::daemon (
     @@prometheus::scrape_job { "${scrape_host}:${scrape_port}":
       job_name => $scrape_job_name,
       targets  => ["${scrape_host}:${scrape_port}"],
-      labels   => { 'alias' => $scrape_host },
+      labels   => $scrape_job_labels,
     }
   }
 }

--- a/manifests/elasticsearch_exporter.pp
+++ b/manifests/elasticsearch_exporter.pp
@@ -112,6 +112,7 @@ class prometheus::elasticsearch_exporter (
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9114,
   String[1] $scrape_job_name     = 'elasticsearch',
+  Optional[Hash] $scrape_job_labels = undef,
 ) inherits prometheus {
 
   #Please provide the download_url for versions < 0.9.0
@@ -154,5 +155,6 @@ class prometheus::elasticsearch_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/graphite_exporter.pp
+++ b/manifests/graphite_exporter.pp
@@ -91,6 +91,7 @@ class prometheus::graphite_exporter (
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9108,
   String[1] $scrape_job_name     = 'graphite',
+  Optional[Hash] $scrape_job_labels = undef,
 ) inherits prometheus {
 
   $real_download_url = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
@@ -124,5 +125,6 @@ class prometheus::graphite_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/haproxy_exporter.pp
+++ b/manifests/haproxy_exporter.pp
@@ -99,6 +99,7 @@ class prometheus::haproxy_exporter(
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9101,
   String[1] $scrape_job_name     = 'haproxy',
+  Optional[Hash] $scrape_job_labels = undef,
 ) inherits prometheus {
 
   $real_download_url = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
@@ -134,6 +135,7 @@ class prometheus::haproxy_exporter(
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 
 }

--- a/manifests/mesos_exporter.pp
+++ b/manifests/mesos_exporter.pp
@@ -103,6 +103,7 @@ class prometheus::mesos_exporter (
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9105,
   String[1] $scrape_job_name     = 'mesos',
+  Optional[Hash] $scrape_job_labels = undef,
 ) inherits prometheus {
 
   $real_download_url    = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
@@ -138,5 +139,6 @@ class prometheus::mesos_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/mongodb_exporter.pp
+++ b/manifests/mongodb_exporter.pp
@@ -105,6 +105,7 @@ class prometheus::mongodb_exporter (
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9216,
   String[1] $scrape_job_name     = 'mongodb',
+  Optional[Hash] $scrape_job_labels = undef,
 ) inherits prometheus {
 
   #Please provide the download_url for versions < 0.9.0
@@ -147,5 +148,6 @@ class prometheus::mongodb_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/mysqld_exporter.pp
+++ b/manifests/mysqld_exporter.pp
@@ -120,6 +120,7 @@ class prometheus::mysqld_exporter (
   Boolean $export_scrape_job                 = false,
   Stdlib::Port $scrape_port                  = 9104,
   String[1] $scrape_job_name                 = 'mysql',
+  Optional[Hash] $scrape_job_labels          = undef,
 ) inherits prometheus {
 
   #Please provide the download_url for versions < 0.9.0
@@ -179,5 +180,6 @@ class prometheus::mysqld_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/nginx_vts_exporter.pp
+++ b/manifests/nginx_vts_exporter.pp
@@ -99,6 +99,7 @@ class prometheus::nginx_vts_exporter(
   Boolean $export_scrape_job          = false,
   Stdlib::Port $scrape_port           = 9913,
   String[1] $scrape_job_name          = 'nginx_vts',
+  Optional[Hash] $scrape_job_labels   = undef,
 ) inherits prometheus {
 
   $real_download_url = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
@@ -134,6 +135,7 @@ class prometheus::nginx_vts_exporter(
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 
 }

--- a/manifests/node_exporter.pp
+++ b/manifests/node_exporter.pp
@@ -6,7 +6,6 @@
 #  [*arch*]
 #  Architecture (amd64 or i386)
 #
-
 #  [*bin_dir*]
 #  Directory where binaries are located
 #
@@ -115,6 +114,7 @@ class prometheus::node_exporter (
   Boolean $export_scrape_job          = false,
   Stdlib::Port $scrape_port           = 9100,
   String[1] $scrape_job_name          = 'node',
+  Optional[Hash] $scrape_job_labels   = undef,
   Optional[String[1]] $bin_name       = undef,
 ) inherits prometheus {
 
@@ -173,6 +173,7 @@ class prometheus::node_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
     bin_name           => $bin_name,
   }
 }

--- a/manifests/postgres_exporter.pp
+++ b/manifests/postgres_exporter.pp
@@ -126,6 +126,7 @@ class prometheus::postgres_exporter (
   Boolean $export_scrape_job                    = false,
   Stdlib::Port $scrape_port                     = 9187,
   String[1] $scrape_job_name                    = 'postgres',
+  Optional[Hash] $scrape_job_labels             = undef,
 ) inherits prometheus {
 
   $release = "v${version}"
@@ -219,5 +220,6 @@ class prometheus::postgres_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/process_exporter.pp
+++ b/manifests/process_exporter.pp
@@ -98,6 +98,7 @@ class prometheus::process_exporter(
   Boolean $export_scrape_job              = false,
   Stdlib::Port $scrape_port               = 9256,
   String[1] $scrape_job_name              = 'process',
+  Optional[Hash] $scrape_job_labels       = undef,
 ) inherits prometheus {
 
   $filename = "${package_name}-${version}.${os}-${arch}.${download_extension}"
@@ -143,5 +144,6 @@ class prometheus::process_exporter(
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/rabbitmq_exporter.pp
+++ b/manifests/rabbitmq_exporter.pp
@@ -131,6 +131,7 @@ class prometheus::rabbitmq_exporter (
   Boolean $export_scrape_job          = false,
   Stdlib::Port $scrape_port           = 9090,
   String[1] $scrape_job_name          = 'rabbitmq',
+  Optional[Hash] $scrape_job_labels   = undef,
 ) inherits prometheus {
 
   $real_download_url    = pick($download_url, "${download_url_base}/download/v${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
@@ -177,5 +178,6 @@ class prometheus::rabbitmq_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/redis_exporter.pp
+++ b/manifests/redis_exporter.pp
@@ -6,7 +6,6 @@
 #  [*arch*]
 #  Architecture (amd64 or i386)
 #
-
 #  [*bin_dir*]
 #  Directory where binaries are located
 #
@@ -110,6 +109,7 @@ class prometheus::redis_exporter (
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9121,
   String[1] $scrape_job_name     = 'redis',
+  Optional[Hash] $scrape_job_labels = undef,
 ) inherits prometheus {
 
   $release = "v${version}"
@@ -185,5 +185,6 @@ class prometheus::redis_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/snmp_exporter.pp
+++ b/manifests/snmp_exporter.pp
@@ -107,6 +107,7 @@ class prometheus::snmp_exporter (
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9116,
   String[1] $scrape_job_name     = 'snmp',
+  Optional[Hash] $scrape_job_labels = undef,
 ) inherits prometheus {
 
   $real_download_url = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
@@ -169,5 +170,6 @@ class prometheus::snmp_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/statsd_exporter.pp
+++ b/manifests/statsd_exporter.pp
@@ -109,6 +109,7 @@ class prometheus::statsd_exporter (
   Boolean $export_scrape_job              = false,
   Stdlib::Port $scrape_port               = 9102,
   String[1] $scrape_job_name              = 'statsd',
+  Optional[Hash] $scrape_job_labels       = undef,
 ) inherits prometheus {
 
   # Prometheus added a 'v' on the realease name at 0.4.0 and changed the configuration format to yaml in 0.5.0
@@ -165,5 +166,6 @@ class prometheus::statsd_exporter (
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/manifests/varnish_exporter.pp
+++ b/manifests/varnish_exporter.pp
@@ -97,6 +97,7 @@ class prometheus::varnish_exporter(
   Boolean $export_scrape_job     = false,
   Stdlib::Port $scrape_port      = 9131,
   String[1] $scrape_job_name     = 'varnish',
+  Optional[Hash] $scrape_job_labels = undef,
 ) inherits prometheus {
 
   $real_download_url = pick($download_url,"${download_url_base}/download/${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
@@ -131,5 +132,6 @@ class prometheus::varnish_exporter(
     export_scrape_job  => $export_scrape_job,
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
+    scrape_job_labels  => $scrape_job_labels,
   }
 }

--- a/spec/defines/daemon_spec.rb
+++ b/spec/defines/daemon_spec.rb
@@ -236,9 +236,43 @@ describe 'prometheus::daemon' do
             subject { exported_resources }
 
             it {
-              is_expected.to contain_prometheus__scrape_job('localhost:1234')
+              is_expected.to contain_prometheus__scrape_job('localhost:1234').with(
+                'labels' => {
+                  'alias' => 'localhost'
+                }
+              )
             }
           end
+        end
+      end
+      context 'with scrape_job_labels specified' do
+        let(:params) do
+          {
+            version:           '1.2.3',
+            real_download_url: 'https://github.com/prometheus/smurf_exporter/releases/v1.2.3/smurf_exporter-1.2.3.any.tar.gz',
+            notify_service:    'Service[smurf_exporter]',
+            user:              'smurf_user',
+            group:             'smurf_group',
+            env_vars:          { SOMEVAR: 42 },
+            bin_dir:           '/usr/local/bin',
+            install_method:    'url',
+            export_scrape_job: true,
+            scrape_host:       'localhost',
+            scrape_port:       1234,
+            scrape_job_labels: { 'instance' => 'smurf1' }
+          }
+        end
+
+        context 'exported resources' do
+          subject { exported_resources }
+
+          it {
+            is_expected.to contain_prometheus__scrape_job('localhost:1234').with(
+              'labels' => {
+                'instance' => 'smurf1'
+              }
+            )
+          }
         end
       end
     end


### PR DESCRIPTION
Allow users to override the default `alias` label which is set on the
exported scrape_jobs.