### PR TITLE
Fix prometheus not restarting after config changes on systemd based systems

### DIFF
--- a/manifests/scrape_job.pp
+++ b/manifests/scrape_job.pp
@@ -31,7 +31,7 @@ define prometheus::scrape_job (
     },
   ])
   file { "${collect_dir}/${job_name}_${name}.yaml":
-    ensure  => present,
+    ensure  => file,
     owner   => 'root',
     group   => $prometheus::group,
     mode    => $prometheus::config_mode,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -94,6 +94,6 @@ class prometheus::server (
 
   Class['prometheus::install']
   -> Class['prometheus::config']
-  -> Class['prometheus::run_service']
+  -> Class['prometheus::run_service'] # Note: config must *not* be configured here to notify run_service.  Some resources in config.pp need to notify service_reload instead
   -> Class['prometheus::service_reload']
 }

--- a/spec/classes/prometheus_spec.rb
+++ b/spec/classes/prometheus_spec.rb
@@ -185,7 +185,7 @@ describe 'prometheus' do
 
           it {
             is_expected.to contain_file('prometheus.yaml').with(
-              'ensure'  => 'present',
+              'ensure'  => 'file',
               'path'    => '/etc/prometheus/prometheus.yaml',
               'owner'   => 'root',
               'group'   => 'prometheus',
@@ -296,7 +296,7 @@ describe 'prometheus' do
             }
             it {
               is_expected.to contain_file('prometheus.yaml').with(
-                'ensure'  => 'present',
+                'ensure'  => 'file',
                 'path'    => '/etc/prometheus/prometheus.yaml',
                 'owner'   => 'root',
                 'group'   => 'prometheus',


### PR DESCRIPTION
The [unreliable](https://puppet.com/docs/puppet/5.5/lang_defaults.html#behavior) resource default
```
File{
  notify => Class['prometheus::run_service']
}
```
is replaced by a `$notify` variable that is set on the relevant file
resources *and* `systemd::unit_file`.  Some care was needed to make sure
the reload behaviour wasn't broken.  ie If the configuration change is
just a new scrape job that is collected, the service should only be
reloaded, not restarted.

Fixes #382

This PR supersedes https://github.com/voxpupuli/puppet-prometheus/pull/383