### PR TITLE
revert to older facts syntax to keep compatibility with 4.8

### DIFF
--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -86,7 +86,7 @@ define prometheus::daemon (
   Optional[String] $env_file_path      = $prometheus::env_file_path,
   Optional[String[1]] $extract_command = $prometheus::extract_command,
   Boolean $export_scrape_job           = false,
-  Stdlib::Host $scrape_host            = $facts['networking']['fqdn'],
+  Stdlib::Host $scrape_host            = $facts['fqdn'],
   Optional[Stdlib::Port] $scrape_port  = undef,
   String[1] $scrape_job_name           = $name,
   Hash $scrape_job_labels              = { 'alias' => $scrape_host },


### PR DESCRIPTION
This module is actually compatible with the 4.8 puppet release: I have
been running it fine on such stretch without problems. This is the
first time such breakage is actually introduced and I think it's
rather unfortunate.

Let's see if we can revert that change without causing too much trouble.
