### PR TITLE
Add config mode to config_dir creation

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -90,6 +90,7 @@ class prometheus::install {
     ensure  => 'directory',
     owner   => 'root',
     group   => $prometheus::server::group,
+    mode    => $prometheus::server::config_mode,
     purge   => $prometheus::server::purge_config_dir,
     recurse => $prometheus::server::purge_config_dir,
   }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Fixes the issues introduced by #324 around the permissions of the config directory itself.

#### This Pull Request (PR) fixes the following issues
An issue with the ability to read from the default directory was created when #324 was merged. The Prometheus group ended up with no permissions to read anything in the default config directory, which caused the service to fail starting up. This PR fixes that.
