### PR TITLE
Accept `none` as valid `init_style`

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,218 +6,216 @@ class prometheus::config {
 
   $max_open_files = $prometheus::max_open_files
 
-  if $prometheus::server::init_style {
-    $prometheus_v2 = versioncmp($prometheus::server::version, '2.0.0') >= 0
+  $prometheus_v2 = versioncmp($prometheus::server::version, '2.0.0') >= 0
 
-    # Validation
-    $invalid_args = if $prometheus_v2 {
-      {
-        'alertmanager.url'                 => $prometheus::alertmanager_url,
-        'query.staleness-delta'            => $prometheus::query_staleness_delta,
-        'web.telemetry-path'               => $prometheus::web_telemetry_path,
-        'web.enable-remote-shutdown'       => $prometheus::web_enable_remote_shutdown,
-      }
+  # Validation
+  $invalid_args = if $prometheus_v2 {
+    {
+      'alertmanager.url'                 => $prometheus::alertmanager_url,
+      'query.staleness-delta'            => $prometheus::query_staleness_delta,
+      'web.telemetry-path'               => $prometheus::web_telemetry_path,
+      'web.enable-remote-shutdown'       => $prometheus::web_enable_remote_shutdown,
+    }
+  } else {
+    {
+      'web.enable-lifecycle'                    => $prometheus::web_enable_lifecycle,
+      'web.enable-admin-api'                    => $prometheus::web_enable_admin_api,
+      'web.page-title'                          => $prometheus::web_page_title,
+      'web.cors.origin'                         => $prometheus::web_cors_origin,
+      'storage.tsdb.retention.size'             => $prometheus::storage_retention_size,
+      'storage.tsdb.no-lockfile'                => $prometheus::storage_no_lockfile,
+      'storage.tsdb.allow-overlapping-blocks'   => $prometheus::storage_allow_overlapping_blocks,
+      'storage.tsdb.wal-compression'            => $prometheus::storage_wal_compression,
+      'storage.remote.flush-deadline'           => $prometheus::storage_flush_deadline,
+      'storage.remote.read-concurrent-limit'    => $prometheus::storage_read_concurrent_limit,
+      'storage.remote.read-max-bytes-in-frame'  => $prometheus::storage_read_max_bytes_in_frame,
+      'rules.alert.for-outage-tolerance'        => $prometheus::alert_for_outage_tolerance,
+      'rules.alert.for-grace-period'            => $prometheus::alert_for_grace_period,
+      'rules.alert.resend-delay'                => $prometheus::alert_resend_delay,
+      'query.lookback-delta'                    => $prometheus::query_lookback_delta,
+      'log.format'                              => $prometheus::log_format,
+    }
+  }
+
+  $invalid_options = $invalid_args
+  .filter |$key,$value| { $value or $key in $prometheus::server::extra_options}
+  .map    |$key,$value| { $key }
+
+  unless empty($invalid_options) {
+    $error_message = if $prometheus_v2 {
+      'no longer available in prometheus v2'
     } else {
-      {
-        'web.enable-lifecycle'                    => $prometheus::web_enable_lifecycle,
-        'web.enable-admin-api'                    => $prometheus::web_enable_admin_api,
-        'web.page-title'                          => $prometheus::web_page_title,
-        'web.cors.origin'                         => $prometheus::web_cors_origin,
-        'storage.tsdb.retention.size'             => $prometheus::storage_retention_size,
-        'storage.tsdb.no-lockfile'                => $prometheus::storage_no_lockfile,
-        'storage.tsdb.allow-overlapping-blocks'   => $prometheus::storage_allow_overlapping_blocks,
-        'storage.tsdb.wal-compression'            => $prometheus::storage_wal_compression,
-        'storage.remote.flush-deadline'           => $prometheus::storage_flush_deadline,
-        'storage.remote.read-concurrent-limit'    => $prometheus::storage_read_concurrent_limit,
-        'storage.remote.read-max-bytes-in-frame'  => $prometheus::storage_read_max_bytes_in_frame,
-        'rules.alert.for-outage-tolerance'        => $prometheus::alert_for_outage_tolerance,
-        'rules.alert.for-grace-period'            => $prometheus::alert_for_grace_period,
-        'rules.alert.resend-delay'                => $prometheus::alert_resend_delay,
-        'query.lookback-delta'                    => $prometheus::query_lookback_delta,
-        'log.format'                              => $prometheus::log_format,
-      }
+      'require prometheus v2; consider upgrading'
     }
+    $error = "invalid command line arguments: [${join($invalid_options, ', ')}] ${error_message}"
+    fail($error)
+  }
+  unless $prometheus_v2 {
+    if $prometheus::server::remote_read_configs != [] {
+      fail('remote_read_configs requires prometheus v2')
+    }
+    if $prometheus::server::remote_write_configs != [] {
+      fail('remote_write_configs requires prometheus v2')
+    }
+  }
+  if ($prometheus_v2 and $prometheus::log_level == 'fatal') {
+    fail('fatal is no longer a valid value in prometheus v2')
+  }
+  if versioncmp($prometheus::server::version, '2.7.0') < 0 and $prometheus::storage_retention_size {
+    fail('storage.tsdb.retention.size is only available starting in prometheus 2.7')
+  }
 
-    $invalid_options = $invalid_args
-    .filter |$key,$value| { $value or $key in $prometheus::server::extra_options}
-    .map    |$key,$value| { $key }
+  # Formatting
+  $v1_log_format = if ($prometheus::log_format == 'json') { '?json=true' } else { undef }
+  $web_page_title = if ($prometheus::web_page_title) { "\"${prometheus::web_page_title}\"" } else { undef }
+  $web_cors_origin = if ($prometheus::web_cors_origin) { "\"${prometheus::web_cors_origin}\"" } else { undef }
+  $rtntn_suffix = if versioncmp($prometheus::server::version, '2.8.0') >= 0 { '.time' } else { undef }
+  $command_line_flags = if $prometheus_v2 {
+    {
+      'config.file'                              => "${prometheus::server::config_dir}/${prometheus::server::configname}",
+      'web.listen-address'                       => $prometheus::web_listen_address,
+      'web.read-timeout'                         => $prometheus::web_read_timeout,
+      'web.max-connections'                      => $prometheus::web_max_connections,
+      'web.external-url'                         => $prometheus::server::external_url,
+      'web.route-prefix'                         => $prometheus::web_route_prefix,
+      'web.user-assets'                          => $prometheus::web_user_assets,
+      'web.enable-lifecycle'                     => $prometheus::web_enable_lifecycle,
+      'web.enable-admin-api'                     => $prometheus::web_enable_admin_api,
+      'web.console.templates'                    => "${prometheus::shared_dir}/consoles",
+      'web.console.libraries'                    => "${prometheus::shared_dir}/console_libraries",
+      'web.page-title'                           => $web_page_title,
+      'web.cors.origin'                          => $web_cors_origin,
+      'storage.tsdb.path'                        => $prometheus::server::localstorage,
+      "storage.tsdb.retention${rtntn_suffix}"    => $prometheus::server::storage_retention,
+      'storage.tsdb.retention.size'              => $prometheus::storage_retention_size,
+      'storage.tsdb.no-lockfile'                 => $prometheus::storage_no_lockfile,
+      'storage.tsdb.allow-overlapping-blocks'    => $prometheus::storage_allow_overlapping_blocks,
+      'storage.tsdb.wal-compression'             => $prometheus::storage_wal_compression,
+      'storage.remote.flush-deadline'            => $prometheus::storage_flush_deadline,
+      'storage.remote.read-sample-limit'         => $prometheus::storage_read_sample_limit,
+      'storage.remote.read-concurrent-limit'     => $prometheus::storage_read_concurrent_limit,
+      'storage.remote.read-max-bytes-in-frame'   => $prometheus::storage_read_max_bytes_in_frame,
+      'rules.alert.for-outage-tolerance'         => $prometheus::alert_for_outage_tolerance,
+      'rules.alert.for-grace-period'             => $prometheus::alert_for_grace_period,
+      'rules.alert.resend-delay'                 => $prometheus::alert_resend_delay,
+      'alertmanager.notification-queue-capacity' => $prometheus::alertmanager_notification_queue_capacity,
+      'alertmanager.timeout'                     => $prometheus::alertmanager_timeout,
+      'query.lookback-delta'                     => $prometheus::query_lookback_delta,
+      'query.timeout'                            => $prometheus::query_timeout,
+      'query.max-concurrency'                    => $prometheus::query_max_concurrency,
+      'query.max-samples'                        => $prometheus::query_max_samples,
+      'log.level'                                => $prometheus::log_level,
+      'log.format'                               => $prometheus::log_format
+    }
+  } else {
+    {
+      'config.file'                              => "${prometheus::server::config_dir}/${prometheus::server::configname}",
+      'web.listen-address'                       => $prometheus::web_listen_address,
+      'web.read-timeout'                         => $prometheus::web_read_timeout,
+      'web.max-connections'                      => $prometheus::web_max_connections,
+      'web.external-url'                         => $prometheus::server::external_url,
+      'web.route-prefix'                         => $prometheus::web_route_prefix,
+      'web.user-assets'                          => $prometheus::web_user_assets,
+      'web.console.templates'                    => "${prometheus::shared_dir}/consoles",
+      'web.console.libraries'                    => "${prometheus::shared_dir}/console_libraries",
+      'web.telemetry-path'                       => $prometheus::web_telemetry_path,
+      'web.enable-remote-shutdown'               => $prometheus::web_enable_remote_shutdown,
+      'storage.local.path'                       => $prometheus::server::localstorage,
+      'storage.local.retention'                  => $prometheus::server::storage_retention,
+      'alertmanager.notification-queue-capacity' => $prometheus::alertmanager_notification_queue_capacity,
+      'alertmanager.timeout'                     => $prometheus::alertmanager_timeout,
+      'alertmanager.url'                         => $prometheus::alertmanager_url,
+      'query.timeout'                            => $prometheus::query_timeout,
+      'query.max-concurrency'                    => $prometheus::query_max_concurrency,
+      'query.staleness-delta'                    => $prometheus::query_staleness_delta,
+      'log.level'                                => $prometheus::log_level,
+      'log.format'                               => 'logger:stdout',
+    }
+  }
 
-    unless empty($invalid_options) {
-      $error_message = if $prometheus_v2 {
-        'no longer available in prometheus v2'
-      } else {
-        'require prometheus v2; consider upgrading'
-      }
-      $error = "invalid command line arguments: [${join($invalid_options, ', ')}] ${error_message}"
-      fail($error)
+  $flag_prefix   = if ($prometheus_v2) { '--' } else { '-' }
+  $extra_options = [$prometheus::server::extra_options].filter |$opts| { $opts and $opts != '' }
+  $flags         =  $command_line_flags
+  .filter |$flag, $value| {
+    $value ? {
+      Boolean => $value,
+      String  => $value != '',
+      Undef   => false,
+      default => fail("Illegal value for ${flag} parameter")
     }
-    unless $prometheus_v2 {
-      if $prometheus::server::remote_read_configs != [] {
-        fail('remote_read_configs requires prometheus v2')
-      }
-      if $prometheus::server::remote_write_configs != [] {
-        fail('remote_write_configs requires prometheus v2')
-      }
+  }
+  .map    |$flag, $value| {
+    $value ? {
+      Boolean => "${flag_prefix}${flag}",
+      String  => "${flag_prefix}${flag}=${value}",
+      default => fail("Illegal value for ${flag} parameter")
     }
-    if ($prometheus_v2 and $prometheus::log_level == 'fatal') {
-      fail('fatal is no longer a valid value in prometheus v2')
-    }
-    if versioncmp($prometheus::server::version, '2.7.0') < 0 and $prometheus::storage_retention_size {
-        fail('storage.tsdb.retention.size is only available starting in prometheus 2.7')
-    }
+  }
+  $daemon_flags = $flags + $extra_options
 
-    # Formatting
-    $v1_log_format = if ($prometheus::log_format == 'json') { '?json=true' } else { undef }
-    $web_page_title = if ($prometheus::web_page_title) { "\"${prometheus::web_page_title}\"" } else { undef }
-    $web_cors_origin = if ($prometheus::web_cors_origin) { "\"${prometheus::web_cors_origin}\"" } else { undef }
-    $rtntn_suffix = if versioncmp($prometheus::server::version, '2.8.0') >= 0 { '.time' } else { undef }
-    $command_line_flags = if $prometheus_v2 {
-      {
-        'config.file'                              => "${prometheus::server::config_dir}/${prometheus::server::configname}",
-        'web.listen-address'                       => $prometheus::web_listen_address,
-        'web.read-timeout'                         => $prometheus::web_read_timeout,
-        'web.max-connections'                      => $prometheus::web_max_connections,
-        'web.external-url'                         => $prometheus::server::external_url,
-        'web.route-prefix'                         => $prometheus::web_route_prefix,
-        'web.user-assets'                          => $prometheus::web_user_assets,
-        'web.enable-lifecycle'                     => $prometheus::web_enable_lifecycle,
-        'web.enable-admin-api'                     => $prometheus::web_enable_admin_api,
-        'web.console.templates'                    => "${prometheus::shared_dir}/consoles",
-        'web.console.libraries'                    => "${prometheus::shared_dir}/console_libraries",
-        'web.page-title'                           => $web_page_title,
-        'web.cors.origin'                          => $web_cors_origin,
-        'storage.tsdb.path'                        => $prometheus::server::localstorage,
-        "storage.tsdb.retention${rtntn_suffix}"    => $prometheus::server::storage_retention,
-        'storage.tsdb.retention.size'              => $prometheus::storage_retention_size,
-        'storage.tsdb.no-lockfile'                 => $prometheus::storage_no_lockfile,
-        'storage.tsdb.allow-overlapping-blocks'    => $prometheus::storage_allow_overlapping_blocks,
-        'storage.tsdb.wal-compression'             => $prometheus::storage_wal_compression,
-        'storage.remote.flush-deadline'            => $prometheus::storage_flush_deadline,
-        'storage.remote.read-sample-limit'         => $prometheus::storage_read_sample_limit,
-        'storage.remote.read-concurrent-limit'     => $prometheus::storage_read_concurrent_limit,
-        'storage.remote.read-max-bytes-in-frame'   => $prometheus::storage_read_max_bytes_in_frame,
-        'rules.alert.for-outage-tolerance'         => $prometheus::alert_for_outage_tolerance,
-        'rules.alert.for-grace-period'             => $prometheus::alert_for_grace_period,
-        'rules.alert.resend-delay'                 => $prometheus::alert_resend_delay,
-        'alertmanager.notification-queue-capacity' => $prometheus::alertmanager_notification_queue_capacity,
-        'alertmanager.timeout'                     => $prometheus::alertmanager_timeout,
-        'query.lookback-delta'                     => $prometheus::query_lookback_delta,
-        'query.timeout'                            => $prometheus::query_timeout,
-        'query.max-concurrency'                    => $prometheus::query_max_concurrency,
-        'query.max-samples'                        => $prometheus::query_max_samples,
-        'log.level'                                => $prometheus::log_level,
-        'log.format'                               => $prometheus::log_format
-      }
-    } else {
-      {
-        'config.file'                              => "${prometheus::server::config_dir}/${prometheus::server::configname}",
-        'web.listen-address'                       => $prometheus::web_listen_address,
-        'web.read-timeout'                         => $prometheus::web_read_timeout,
-        'web.max-connections'                      => $prometheus::web_max_connections,
-        'web.external-url'                         => $prometheus::server::external_url,
-        'web.route-prefix'                         => $prometheus::web_route_prefix,
-        'web.user-assets'                          => $prometheus::web_user_assets,
-        'web.console.templates'                    => "${prometheus::shared_dir}/consoles",
-        'web.console.libraries'                    => "${prometheus::shared_dir}/console_libraries",
-        'web.telemetry-path'                       => $prometheus::web_telemetry_path,
-        'web.enable-remote-shutdown'               => $prometheus::web_enable_remote_shutdown,
-        'storage.local.path'                       => $prometheus::server::localstorage,
-        'storage.local.retention'                  => $prometheus::server::storage_retention,
-        'alertmanager.notification-queue-capacity' => $prometheus::alertmanager_notification_queue_capacity,
-        'alertmanager.timeout'                     => $prometheus::alertmanager_timeout,
-        'alertmanager.url'                         => $prometheus::alertmanager_url,
-        'query.timeout'                            => $prometheus::query_timeout,
-        'query.max-concurrency'                    => $prometheus::query_max_concurrency,
-        'query.staleness-delta'                    => $prometheus::query_staleness_delta,
-        'log.level'                                => $prometheus::log_level,
-        'log.format'                               => 'logger:stdout',
-      }
-    }
+  # Service files (init-files/systemd unit files) need to trigger a full service restart
+  # prometheus.yaml and associated scrape file changes should only trigger a reload (and not use $notify)
+  $notify = $prometheus::server::restart_on_change ? {
+    true    => Class['prometheus::run_service'],
+    default => undef,
+  }
 
-    $flag_prefix   = if ($prometheus_v2) { '--' } else { '-' }
-    $extra_options = [$prometheus::server::extra_options].filter |$opts| { $opts and $opts != '' }
-    $flags         =  $command_line_flags
-    .filter |$flag, $value| {
-      $value ? {
-        Boolean => $value,
-        String  => $value != '',
-        Undef   => false,
-        default => fail("Illegal value for ${flag} parameter")
+  case $prometheus::server::init_style {
+    'upstart' : {
+      file { '/etc/init/prometheus.conf':
+        ensure  => file,
+        mode    => '0444',
+        owner   => 'root',
+        group   => 'root',
+        content => template('prometheus/prometheus.upstart.erb'),
+        notify  => $notify,
+      }
+      file { '/etc/init.d/prometheus':
+        ensure => link,
+        target => '/lib/init/upstart-job',
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0755',
+        notify => $notify,
       }
     }
-    .map    |$flag, $value| {
-      $value ? {
-        Boolean => "${flag_prefix}${flag}",
-        String  => "${flag_prefix}${flag}=${value}",
-        default => fail("Illegal value for ${flag} parameter")
+    'systemd' : {
+      systemd::unit_file {'prometheus.service':
+        content => template('prometheus/prometheus.systemd.erb'),
+        notify  => $notify,
+      }
+      if versioncmp($facts['puppetversion'],'6.1.0') < 0 {
+        # Puppet 5 doesn't have https://tickets.puppetlabs.com/browse/PUP-3483
+        # and camptocamp/systemd only creates this relationship when managing the service
+        Class['systemd::systemctl::daemon_reload'] -> Class['prometheus::run_service']
       }
     }
-    $daemon_flags = $flags + $extra_options
-
-    # Service files (init-files/systemd unit files) need to trigger a full service restart
-    # prometheus.yaml and associated scrape file changes should only trigger a reload (and not use $notify)
-    $notify = $prometheus::server::restart_on_change ? {
-      true    => Class['prometheus::run_service'],
-      default => undef,
+    'sysv', 'redhat', 'debian', 'sles' : {
+      $content = $prometheus::server::init_style ? {
+        'redhat' => template('prometheus/prometheus.sysv.erb'), # redhat and sysv share the same template file
+        default  => template("prometheus/prometheus.${prometheus::server::init_style}.erb"),
+      }
+      file { '/etc/init.d/prometheus':
+        ensure  => file,
+        mode    => '0555',
+        owner   => 'root',
+        group   => 'root',
+        content => $content,
+        notify  => $notify,
+      }
     }
-
-    case $prometheus::server::init_style {
-      'upstart' : {
-        file { '/etc/init/prometheus.conf':
-          ensure  => file,
-          mode    => '0444',
-          owner   => 'root',
-          group   => 'root',
-          content => template('prometheus/prometheus.upstart.erb'),
-          notify  => $notify,
-        }
-        file { '/etc/init.d/prometheus':
-          ensure => link,
-          target => '/lib/init/upstart-job',
-          owner  => 'root',
-          group  => 'root',
-          mode   => '0755',
-          notify => $notify,
-        }
+    'launchd' : {
+      file { '/Library/LaunchDaemons/io.prometheus.daemon.plist':
+        ensure  => file,
+        mode    => '0644',
+        owner   => 'root',
+        group   => 'wheel',
+        content => template('prometheus/prometheus.launchd.erb'),
+        notify  => $notify,
       }
-      'systemd' : {
-        systemd::unit_file {'prometheus.service':
-          content => template('prometheus/prometheus.systemd.erb'),
-          notify  => $notify,
-        }
-        if versioncmp($facts['puppetversion'],'6.1.0') < 0 {
-          # Puppet 5 doesn't have https://tickets.puppetlabs.com/browse/PUP-3483
-          # and camptocamp/systemd only creates this relationship when managing the service
-          Class['systemd::systemctl::daemon_reload'] -> Class['prometheus::run_service']
-        }
-      }
-      'sysv', 'redhat', 'debian', 'sles' : {
-        $content = $prometheus::server::init_style ? {
-          'redhat' => template('prometheus/prometheus.sysv.erb'), # redhat and sysv share the same template file
-          default  => template("prometheus/prometheus.${prometheus::server::init_style}.erb"),
-        }
-        file { '/etc/init.d/prometheus':
-          ensure  => file,
-          mode    => '0555',
-          owner   => 'root',
-          group   => 'root',
-          content => $content,
-          notify  => $notify,
-        }
-      }
-      'launchd' : {
-        file { '/Library/LaunchDaemons/io.prometheus.daemon.plist':
-          ensure  => file,
-          mode    => '0644',
-          owner   => 'root',
-          group   => 'wheel',
-          content => template('prometheus/prometheus.launchd.erb'),
-          notify  => $notify,
-        }
-      }
-      default : {
-        fail("I don't know how to create an init script for style ${prometheus::server::init_style}")
-      }
+    }
+    default : {
+      fail("I don't know how to create an init script for style ${prometheus::server::init_style}")
     }
   }
 
@@ -251,7 +249,7 @@ class prometheus::config {
       file_sd_configs => [{
         files => [ "${prometheus::config_dir}/file_sd_config.d/${job_name}_*.yaml" ]
       }]
-    })
+      })
   }
 
   if versioncmp($prometheus::server::version, '2.0.0') >= 0 {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -160,8 +160,8 @@ class prometheus::config {
     default => undef,
   }
 
-  case $prometheus::server::init_style {
-    'upstart' : {
+  case $prometheus::server::init_style { # lint:ignore:case_without_default
+    'upstart': {
       file { '/etc/init/prometheus.conf':
         ensure  => file,
         mode    => '0444',
@@ -179,7 +179,7 @@ class prometheus::config {
         notify => $notify,
       }
     }
-    'systemd' : {
+    'systemd': {
       systemd::unit_file {'prometheus.service':
         content => template('prometheus/prometheus.systemd.erb'),
         notify  => $notify,
@@ -190,7 +190,7 @@ class prometheus::config {
         Class['systemd::systemctl::daemon_reload'] -> Class['prometheus::run_service']
       }
     }
-    'sysv', 'redhat', 'debian', 'sles' : {
+    'sysv', 'redhat', 'debian', 'sles': {
       $content = $prometheus::server::init_style ? {
         'redhat' => template('prometheus/prometheus.sysv.erb'), # redhat and sysv share the same template file
         default  => template("prometheus/prometheus.${prometheus::server::init_style}.erb"),
@@ -204,7 +204,7 @@ class prometheus::config {
         notify  => $notify,
       }
     }
-    'launchd' : {
+    'launchd': {
       file { '/Library/LaunchDaemons/io.prometheus.daemon.plist':
         ensure  => file,
         mode    => '0644',
@@ -214,9 +214,7 @@ class prometheus::config {
         notify  => $notify,
       }
     }
-    default : {
-      fail("I don't know how to create an init script for style ${prometheus::server::init_style}")
-    }
+    'none': {}
   }
 
   # TODO: promtool currently does not support checking the syntax of file_sd_config "includes".

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -149,11 +149,11 @@
 #  [*usershell*]
 #  if requested, we create a user for prometheus or the exporters. The default
 #  shell is nologin. It can be overwritten to any valid path.
-#  
+#
 #  CLI ==========================================================
 #  The following parameters represent system parameters invoked as command-line flags
 #  during prometheus startup. Defaults are handled by Prometheus.
-#  
+#
 #  [*web_listen_address*]
 #  --web.listen-address="0.0.0.0:9090"
 #  Address to listen on for UI, API, and telemetry.
@@ -279,7 +279,7 @@
 #  [REMOVED, v1 ONLY] -web.telemetry-path="/metrics"
 #  Path under which to expose metrics
 #
-#  [*web_enable_remote_shutdown*] 
+#  [*web_enable_remote_shutdown*]
 #  [REMOVED, v1 ONLY] -web.enable-remote-shutdown=false
 #  Enable remote service shutdown.
 #
@@ -330,7 +330,7 @@ class prometheus (
   String $service_ensure,
   Boolean $manage_service,
   Boolean $restart_on_change,
-  String[1] $init_style,
+  Prometheus::Initstyle $init_style,
   Optional[String[1]] $extra_options,
   Optional[String] $download_url,
   String $arch,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -32,7 +32,7 @@ class prometheus::server (
   String $service_ensure                                                        = $prometheus::service_ensure,
   Boolean $manage_service                                                       = $prometheus::manage_service,
   Boolean $restart_on_change                                                    = $prometheus::restart_on_change,
-  String $init_style                                                            = $prometheus::init_style,
+  Prometheus::Initstyle $init_style                                             = $prometheus::init_style,
   Optional[String[1]] $extra_options                                            = $prometheus::extra_options,
   Hash $config_hash                                                             = $prometheus::config_hash,
   Hash $config_defaults                                                         = $prometheus::config_defaults,

--- a/manifests/service_reload.pp
+++ b/manifests/service_reload.pp
@@ -7,13 +7,10 @@ class prometheus::service_reload() {
     $init_selector = $prometheus::run_service::init_selector
 
     $prometheus_reload = $prometheus::server::init_style ? {
-      'systemd' => "systemctl reload-or-restart ${init_selector}",
-      'upstart' => "service ${init_selector} reload",
-      'sysv'    => "/etc/init.d/${init_selector} reload",
-      'redhat'  => "/etc/init.d/${init_selector} reload",
-      'sles'    => "/etc/init.d/${init_selector} reload",
-      'debian'  => "/etc/init.d/${init_selector} reload",
-      'launchd' => "launchctl stop ${init_selector} && launchctl start ${init_selector}",
+      'systemd'                     => "systemctl reload-or-restart ${init_selector}",
+      /^(upstart|none)$/            => "service ${init_selector} reload",
+      /^(sysv|redhat|sles|debian)$/ => "/etc/init.d/${init_selector} reload",
+      'launchd'                     => "launchctl stop ${init_selector} && launchctl start ${init_selector}",
     }
 
     exec { 'prometheus-reload':

--- a/types/initstyle.pp
+++ b/types/initstyle.pp
@@ -1,0 +1,10 @@
+type Prometheus::Initstyle = Enum[
+  'sysv',
+  'redhat',
+  'systemd',
+  'sles',
+  'debian',
+  'launchd',
+  'upstart',
+  'none',
+]


### PR DESCRIPTION
This is a more generic alternative to the `manage_systemd_unit` part of https://github.com/voxpupuli/puppet-prometheus/pull/303.

`install_method` already accepts `none`, so I don't think it looks too wonky.