### PR TITLE
Add prometheus node-exporter name for Ubuntu

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,3 +1,4 @@
 ---
 prometheus::env_file_path: '/etc/default'
 prometheus::usershell: '/usr/sbin/nologin'
+prometheus::node_exporter::package_name: 'prometheus-node-exporter'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add package `prometheus-node-exporter` package name for Debian. 

#### This Pull Request (PR) fixes the following issues
Installation on Ubuntu 18.04 
