### PR TITLE
prometheus: harden systemd service

### DIFF
--- a/spec/fixtures/files/cli/prometheus1_all.systemd
+++ b/spec/fixtures/files/cli/prometheus1_all.systemd
@@ -32,6 +32,19 @@ ExecStart=/usr/local/bin/prometheus \
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always
+NoNewPrivileges=true
+ProtectHome=true
+ProtectSystem=full
+ProtectHostname=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+LockPersonality=true
+RestrictRealtime=yes
+RestrictNamespaces=yes
+MemoryDenyWriteExecute=yes
+PrivateDevices=yes
+CapabilityBoundingSet=
 
 [Install]
 WantedBy=multi-user.target

--- a/spec/fixtures/files/cli/prometheus1_extra.systemd
+++ b/spec/fixtures/files/cli/prometheus1_extra.systemd
@@ -18,6 +18,19 @@ ExecStart=/usr/local/bin/prometheus \
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always
+NoNewPrivileges=true
+ProtectHome=true
+ProtectSystem=full
+ProtectHostname=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+LockPersonality=true
+RestrictRealtime=yes
+RestrictNamespaces=yes
+MemoryDenyWriteExecute=yes
+PrivateDevices=yes
+CapabilityBoundingSet=
 
 [Install]
 WantedBy=multi-user.target

--- a/spec/fixtures/files/cli/prometheus2_6_retention.systemd
+++ b/spec/fixtures/files/cli/prometheus2_6_retention.systemd
@@ -16,6 +16,19 @@ ExecStart=/usr/local/bin/prometheus \
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always
+NoNewPrivileges=true
+ProtectHome=true
+ProtectSystem=full
+ProtectHostname=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+LockPersonality=true
+RestrictRealtime=yes
+RestrictNamespaces=yes
+MemoryDenyWriteExecute=yes
+PrivateDevices=yes
+CapabilityBoundingSet=
 
 [Install]
 WantedBy=multi-user.target

--- a/spec/fixtures/files/cli/prometheus2_all.systemd
+++ b/spec/fixtures/files/cli/prometheus2_all.systemd
@@ -45,6 +45,19 @@ ExecStart=/usr/local/bin/prometheus \
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always
+NoNewPrivileges=true
+ProtectHome=true
+ProtectSystem=full
+ProtectHostname=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+LockPersonality=true
+RestrictRealtime=yes
+RestrictNamespaces=yes
+MemoryDenyWriteExecute=yes
+PrivateDevices=yes
+CapabilityBoundingSet=
 
 [Install]
 WantedBy=multi-user.target

--- a/spec/fixtures/files/cli/prometheus2_extra.systemd
+++ b/spec/fixtures/files/cli/prometheus2_extra.systemd
@@ -17,6 +17,19 @@ ExecStart=/usr/local/bin/prometheus \
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always
+NoNewPrivileges=true
+ProtectHome=true
+ProtectSystem=full
+ProtectHostname=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+LockPersonality=true
+RestrictRealtime=yes
+RestrictNamespaces=yes
+MemoryDenyWriteExecute=yes
+PrivateDevices=yes
+CapabilityBoundingSet=
 
 [Install]
 WantedBy=multi-user.target

--- a/spec/fixtures/files/prometheus1.systemd
+++ b/spec/fixtures/files/prometheus1.systemd
@@ -16,6 +16,19 @@ ExecStart=/usr/local/bin/prometheus \
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always
+NoNewPrivileges=true
+ProtectHome=true
+ProtectSystem=full
+ProtectHostname=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+LockPersonality=true
+RestrictRealtime=yes
+RestrictNamespaces=yes
+MemoryDenyWriteExecute=yes
+PrivateDevices=yes
+CapabilityBoundingSet=
 
 [Install]
 WantedBy=multi-user.target

--- a/spec/fixtures/files/prometheus2.systemd
+++ b/spec/fixtures/files/prometheus2.systemd
@@ -16,6 +16,19 @@ ExecStart=/usr/local/bin/prometheus \
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always
+NoNewPrivileges=true
+ProtectHome=true
+ProtectSystem=full
+ProtectHostname=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+LockPersonality=true
+RestrictRealtime=yes
+RestrictNamespaces=yes
+MemoryDenyWriteExecute=yes
+PrivateDevices=yes
+CapabilityBoundingSet=
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/prometheus.systemd.epp
+++ b/templates/prometheus.systemd.epp
@@ -21,6 +21,19 @@ Restart=always
 <% if $max_open_files { -%>
 LimitNOFILE=<%= $max_open_files %>
 <% } -%>
+NoNewPrivileges=true
+ProtectHome=true
+ProtectSystem=full
+ProtectHostname=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+LockPersonality=true
+RestrictRealtime=yes
+RestrictNamespaces=yes
+MemoryDenyWriteExecute=yes
+PrivateDevices=yes
+CapabilityBoundingSet=
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
those hardening options are live in the Arch package since a long time. I use them as well and they work fine. Arch source: https://git.archlinux.org/svntogit/packages.git/tree/trunk/prometheus.service?h=packages/prometheus