### PR TITLE
Giving just an array is not enough to manage process-exporter

### DIFF
--- a/manifests/process_exporter.pp
+++ b/manifests/process_exporter.pp
@@ -54,6 +54,7 @@ class prometheus::process_exporter(
   String $version,
   Stdlib::Absolutepath $config_path,
   Array $watched_processes                = [],
+  Optional[Hash] $hash_watched_processes  = undef,
   Boolean $purge_config_dir               = true,
   Boolean $restart_on_change              = true,
   Boolean $service_enable                 = true,
@@ -82,12 +83,17 @@ class prometheus::process_exporter(
     default => undef,
   }
 
+  $config_path_content = $hash_watched_processes ? {
+    undef   => template('prometheus/process-exporter.yaml.erb'),
+    default => $watched_processes.to_yaml,
+  }
+
   file { $config_path:
     ensure  => 'file',
     mode    => $config_mode,
     owner   => $user,
     group   => $group,
-    content => template('prometheus/process-exporter.yaml.erb'),
+    content => $config_path_content,
     notify  => $notify_service,
   }
 

--- a/manifests/process_exporter.pp
+++ b/manifests/process_exporter.pp
@@ -43,6 +43,31 @@
 #  User which runs the service
 # @param version
 #  The binary release version
+# @param hash_watched_processes
+#  A hash of processes to monitor with the ability to pass different options
+#  Don't set if you want to use only the Array version of it (watched_processes)
+# @watched_processes
+#  A list of processes to monitor
+#  Has no effect if hash_watched_processes is set
+# @example Usage with hash_watched_processes
+#  class { 'prometheus::process_exporter':
+#    version                => '0.6.0',
+#    arch                   => 'amd64',
+#    os                     => 'linux',
+#    bin_dir                => '/usr/local/bin',
+#    install_method         => 'url',
+#    hash_watched_processes => {
+#     'process_names' => [
+#       {
+#         'name'    => "{{.Matches}}",
+#         'cmdline' => [".*process1.*"]
+#       },
+#       {
+#         'name'    => "{{.Matches}}",
+#         'cmdline' => [".*process2.*"]
+#       }
+#     ]
+#   }
 class prometheus::process_exporter(
   String $download_extension,
   Prometheus::Uri $download_url_base,

--- a/manifests/process_exporter.pp
+++ b/manifests/process_exporter.pp
@@ -54,7 +54,7 @@ class prometheus::process_exporter(
   String $version,
   Stdlib::Absolutepath $config_path,
   Array $watched_processes                = [],
-  Optional[Hash] $hash_watched_processes  = undef,
+  Hash $hash_watched_processes            = {},
   Boolean $purge_config_dir               = true,
   Boolean $restart_on_change              = true,
   Boolean $service_enable                 = true,
@@ -83,9 +83,10 @@ class prometheus::process_exporter(
     default => undef,
   }
 
-  $config_path_content = $hash_watched_processes ? {
-    undef   => template('prometheus/process-exporter.yaml.erb'),
-    default => $watched_processes.to_yaml,
+  if $hash_watched_processes.empty() {
+    $config_path_content = template('prometheus/process-exporter.yaml.erb')
+  } else {
+    $config_path_content = $hash_watched_processes.to_yaml
   }
 
   file { $config_path:

--- a/spec/classes/process_exporter_spec.rb
+++ b/spec/classes/process_exporter_spec.rb
@@ -33,6 +33,29 @@ describe 'prometheus::process_exporter' do
           it { is_expected.to contain_file('/usr/local/bin/process-exporter').with('target' => '/opt/process-exporter-0.2.4.linux-amd64/process-exporter') }
         end
       end
+
+      context 'with has_watched_processes specified' do
+        let(:params) do
+          {
+            hash_watched_processes: {
+              'process_names' => [
+                {
+                  'name'    => "{{.Matches}}",
+                  'cmdline' => [".*process1.*"]
+                },
+                {
+                  'name'    => "{{.Matches}}",
+                  'cmdline' => [".*process2.*"]
+                }
+              ]
+            }
+          }
+        end
+
+        describe 'has config_path file with expected content' do
+          it { is_expected.to contain_file('/etc/process-exporter.yaml').with_content(File.read(fixtures('files', 'process-exporter.yaml'))) }
+        end
+      end
     end
   end
 end

--- a/spec/fixtures/files/process-exporter.yaml
+++ b/spec/fixtures/files/process-exporter.yaml
@@ -1,0 +1,8 @@
+---
+process_names:
+- name: "{{.Matches}}"
+  cmdline:
+  - ".*process1.*"
+- name: "{{.Matches}}"
+  cmdline:
+  - ".*process2.*"


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Giving just an array is not enough to manage process-exporter's full capacity of monitoring processes, this PR aims to add a new variable which can use a Hash instead
The Hash gives more flexibility