### PR TITLE
process-exporter: Add Option to provide config as hash

### DIFF
--- a/spec/classes/process_exporter_spec.rb
+++ b/spec/classes/process_exporter_spec.rb
@@ -33,6 +33,29 @@ describe 'prometheus::process_exporter' do
           it { is_expected.to contain_file('/usr/local/bin/process-exporter').with('target' => '/opt/process-exporter-0.2.4.linux-amd64/process-exporter') }
         end
       end
+
+      context 'with has_watched_processes specified' do
+        let(:params) do
+          {
+            hash_watched_processes: {
+              'process_names' => [
+                {
+                  'name'    => '{{.Matches}}',
+                  'cmdline' => ['.*process1.*']
+                },
+                {
+                  'name'    => '{{.Matches}}',
+                  'cmdline' => ['.*process2.*']
+                }
+              ]
+            }
+          }
+        end
+
+        describe 'has config_path file with expected content' do
+          it { is_expected.to contain_file('/etc/process-exporter.yaml').with_content(File.read(fixtures('files', 'process-exporter.yaml'))) }
+        end
+      end
     end
   end
 end

--- a/spec/fixtures/files/process-exporter.yaml
+++ b/spec/fixtures/files/process-exporter.yaml
@@ -1,0 +1,8 @@
+---
+process_names:
+- name: "{{.Matches}}"
+  cmdline:
+  - ".*process1.*"
+- name: "{{.Matches}}"
+  cmdline:
+  - ".*process2.*"


### PR DESCRIPTION
Giving just an array is not enough to manage process-exporter's
full capacity of monitoring processes, this PR aims to add a
new variable which can use a Hash instead.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
