### PR TITLE
Execute systemctl daemon-reload before restarting daemons

### DIFF
--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -171,6 +171,11 @@ define prometheus::daemon (
         content => template('prometheus/daemon.systemd.erb'),
         notify  => $notify_service,
       }
+      # Puppet 5 doesn't have https://tickets.puppetlabs.com/browse/PUP-3483
+      # and camptocamp/systemd only creates this relationship when managing the service
+      if $manage_service and versioncmp($facts['puppetversion'],'6.1.0') < 0 {
+        Class['systemd::systemctl::daemon_reload'] -> Service[$name]
+      }
     }
     # service_provider returns redhat on CentOS using sysv, https://tickets.puppetlabs.com/browse/PUP-5296
     'sysv','redhat': {

--- a/spec/defines/daemon_spec.rb
+++ b/spec/defines/daemon_spec.rb
@@ -149,6 +149,10 @@ describe 'prometheus::daemon' do
               )
             }
 
+            if Gem::Version.new(facts[:puppetversion]) < Gem::Version.new('6.1.0')
+              it { is_expected.to contain_class('systemd::systemctl::daemon_reload').that_comes_before('Service[smurf_exporter]') }
+            end
+
             context 'with overidden bin_name' do
               let(:params) do
                 parameters.merge(bin_name: 'notsmurf_exporter')


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Ensure that `systemctl daemon-reload` is executed before attempting to restart daemon services. This mimics what's already done for the main prometheus daemon on systemd systems.
