### PR TITLE
Support reloading alertmanager rather than restarting

### DIFF
--- a/spec/classes/alertmanager_spec.rb
+++ b/spec/classes/alertmanager_spec.rb
@@ -32,10 +32,27 @@ describe 'prometheus::alertmanager' do
         end
         describe 'config file contents' do
           it {
-            is_expected.to contain_file('/etc/alertmanager/alertmanager.yaml')
+            is_expected.to contain_file('/etc/alertmanager/alertmanager.yaml').with_notify('Service[alertmanager]')
             verify_contents(catalogue, '/etc/alertmanager/alertmanager.yaml', ['---', 'global:', '  smtp_smarthost: localhost:25', '  smtp_from: alertmanager@localhost'])
           }
         end
+        describe 'service reload' do
+          it {
+            is_expected.to contain_exec('alertmanager-reload').with(
+              # 'command'     => 'systemctl reload alertmanager',
+              'path'        => ['/usr/bin', '/bin', '/usr/sbin', '/sbin'],
+              'refreshonly' => true
+            )
+          }
+        end
+      end
+
+      context 'when reload_on_change => true' do
+        let(:params) { { reload_on_change: true } }
+
+        it {
+          is_expected.to contain_file('/etc/alertmanager/alertmanager.yaml').with_notify('Exec[alertmanager-reload]')
+        }
       end
 
       context 'with manage_config => false' do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Make it possible to reload alertmanager on config changes rather than restart the daemon.

I've noticed that alertmanager will re-send many alerts with long repeat intervals on restart, so figured a reload maybe avoids this.  This is implemented just like the prometheus daemon reload logic. The changes to unit files and other service files will still trigger a restart.
