### PR TITLE
if $purge_config_dir=true, force-manage config_dir

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -93,5 +93,6 @@ class prometheus::install {
     mode    => $prometheus::server::config_mode,
     purge   => $prometheus::server::purge_config_dir,
     recurse => $prometheus::server::purge_config_dir,
+    force   => $prometheus::server::purge_config_dir,
   }
 }

--- a/spec/classes/prometheus_spec.rb
+++ b/spec/classes/prometheus_spec.rb
@@ -156,7 +156,8 @@ describe 'prometheus' do
               'owner'   => 'root',
               'group'   => 'prometheus',
               'purge'   => true,
-              'recurse' => true
+              'recurse' => true,
+              'force'   => true
             )
           }
 


### PR DESCRIPTION
if `$config_dir` - _e.g. /etc/prometheus_ - contains sub-directories and `$purge_config_dir=true`, then Puppet issues warnings about not being able to remove these sub-directories (see output below).

I've added the force-parameter to the file-resource - by keep using the value for `$purge_config_dir` for it.

```
Warning: /Stage[main]/Prometheus::Install/File[/etc/prometheus/console_libraries]: Could not back up file of type directory
Notice: /Stage[main]/Prometheus::Install/File[/etc/prometheus/console_libraries]: Not removing directory; use 'force' to override
Notice: /Stage[main]/Prometheus::Install/File[/etc/prometheus/console_libraries]/ensure: removed
Warning: /Stage[main]/Prometheus::Install/File[/etc/prometheus/consoles]: Could not back up file of type directory
Notice: /Stage[main]/Prometheus::Install/File[/etc/prometheus/consoles]: Not removing directory; use 'force' to override
Notice: /Stage[main]/Prometheus::Install/File[/etc/prometheus/consoles]/ensure: removed
```