### PR TITLE
Fix duplicate command line options in SysV script

### DIFF
--- a/templates/prometheus.sysv.erb
+++ b/templates/prometheus.sysv.erb
@@ -52,7 +52,7 @@ start() {
         daemon --user=<%= scope.lookupvar('prometheus::server::user') %> \
             --pidfile="$PID_FILE" \
             "$DAEMON" <%= @daemon_flags.join(" \\\n            ") %> \
-            <%= scope.lookupvar('prometheus::server::extra_options') %> >> "$LOG_FILE" &
+             >> "$LOG_FILE" &
         retcode=$?
         mkpidfile
         touch /var/lock/subsys/prometheus


### PR DESCRIPTION
Fixes a duplication error in the prometheus SysV template; `$prometheus::server::extra_options` is already concatenated onto `$daemon_flags` and so will get written to the file twice, sometimes causing start issues:

```
Error parsing commandline arguments: flag 'web.external-url' cannot be repeated
```