### PR TITLE
Use `--scrape_uri` instead of `-scrape_uri` for apache_exporter versions 0.8.0 and greater

### DIFF
--- a/manifests/apache_exporter.pp
+++ b/manifests/apache_exporter.pp
@@ -88,7 +88,11 @@ class prometheus::apache_exporter (
     default => undef,
   }
 
-  $options = "-scrape_uri \"${scrape_uri}\" ${extra_options}"
+  if versioncmp($version, '0.8.0') < 0 {
+    $options = "-scrape_uri \"${scrape_uri}\" ${extra_options}"
+  } else {
+    $options = "--scrape_uri \"${scrape_uri}\" ${extra_options}"
+  }
 
   prometheus::daemon { $service_name:
     install_method     => $install_method,

--- a/spec/classes/apache_exporter_spec.rb
+++ b/spec/classes/apache_exporter_spec.rb
@@ -58,6 +58,24 @@ describe 'prometheus::apache_exporter' do
           it { is_expected.to contain_file('/usr/local/bin/apache_exporter').with('target' => '/opt/apache_exporter-0.4.0.linux-amd64/apache_exporter') }
         end
       end
+
+      context 'with version 0.8.0+' do
+        let(:params) do
+          {
+            scrape_uri: 'http://127.0.0.1/server-status?auto',
+            extra_options: '--test',
+            version: '0.4.0',
+            arch: 'amd64',
+            os: 'linux',
+            bin_dir: '/usr/local/bin',
+            install_method: 'url'
+          }
+        end
+
+        describe 'uses argument prefix correctly' do
+          it { is_expected.to contain_prometheus__daemon('apache_exporter').with('options' => '--scrape_uri "http://127.0.0.1/server-status?auto" --test') }
+        end
+      end
     end
   end
 end

--- a/spec/classes/apache_exporter_spec.rb
+++ b/spec/classes/apache_exporter_spec.rb
@@ -64,7 +64,7 @@ describe 'prometheus::apache_exporter' do
           {
             scrape_uri: 'http://127.0.0.1/server-status?auto',
             extra_options: '--test',
-            version: '0.4.0',
+            version: '0.8.0',
             arch: 'amd64',
             os: 'linux',
             bin_dir: '/usr/local/bin',


### PR DESCRIPTION
#### Pull Request (PR) description
This will use `--scrape_uri` instead of `-scrape_uri` for apache_exporter versions `0.8.0` and greater.

#### This Pull Request (PR) fixes the following issues
Fixes #442

