### PR TITLE
remove dependency on camptocamp/systemd

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,4 +2,3 @@ fixtures:
   repositories:
     archive: "https://github.com/voxpupuli/puppet-archive"
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib"
-    systemd: "https://github.com/camptocamp/puppet-systemd"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -179,7 +179,11 @@ class prometheus::config {
       }
     }
     'systemd': {
-      systemd::unit_file {'prometheus.service':
+      file { '/etc/systemd/system/prometheus.service':
+        mode    => '0644',
+        owner   => 'root',
+        group   => 'root',
+        notify  => $notify,
         content => epp("${module_name}/prometheus.systemd.epp", {
           'user'           => $prometheus::server::user,
           'group'          => $prometheus::server::group,
@@ -187,12 +191,15 @@ class prometheus::config {
           'max_open_files' => $max_open_files,
           'bin_dir'        => $prometheus::server::bin_dir,
         }),
-        notify  => $notify,
+      }
+      exec { 'prometheus-systemd-reload':
+        command     => 'systemctl daemon-reload',
+        path        => [ '/usr/bin', '/bin', '/usr/sbin' ],
+        refreshonly => true,
       }
       if versioncmp($facts['puppetversion'],'6.1.0') < 0 {
         # Puppet 5 doesn't have https://tickets.puppetlabs.com/browse/PUP-3483
-        # and camptocamp/systemd only creates this relationship when managing the service
-        Class['systemd::systemctl::daemon_reload'] -> Class['prometheus::run_service']
+        Exec['prometheus-systemd-reload'] -> Class['prometheus::run_service']
       }
     }
     'sysv', 'redhat', 'debian', 'sles': {

--- a/metadata.json
+++ b/metadata.json
@@ -15,10 +15,6 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.25.0 < 7.0.0"
-    },
-    {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 1.1.1 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
remove the dependency on the camptocamp systemd module which is incompatible with other modules like eyp/systemd

note this was already discussed in https://github.com/voxpupuli/puppet-prometheus/pull/90 a while ago.
But even after these many years the systemd module usage here is still as minimal as it was before so I though I try to get the usage removed to allow the prometheus module to be used by more environments without a fork.