### PR TITLE
Allow extract_path to be modified

### DIFF
--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -37,6 +37,8 @@
 #  Should puppet manage the service? (default true)
 # @param extract_command
 #  Custom command passed to the archive resource to extract the downloaded archive.
+# @param extract_path
+#  Path where to find extracted binary
 # @param archive_bin_path
 #  Path to the binary in the downloaded archive.
 # @param init_style
@@ -69,6 +71,7 @@ define prometheus::daemon (
   Hash[String, Scalar] $env_vars          = {},
   Optional[String] $env_file_path         = $prometheus::env_file_path,
   Optional[String[1]] $extract_command    = $prometheus::extract_command,
+  Stdlib::Absolutepath $extract_path      = '/opt',
   Stdlib::Absolutepath $archive_bin_path   = "/opt/${name}-${version}.${os}-${arch}/${name}",
   Boolean $export_scrape_job              = false,
   Stdlib::Host $scrape_host               = $facts['networking']['fqdn'],
@@ -97,7 +100,7 @@ define prometheus::daemon (
         archive { "/tmp/${name}-${version}.${download_extension}":
           ensure          => present,
           extract         => true,
-          extract_path    => '/opt',
+          extract_path    => $extract_path,
           source          => $real_download_url,
           checksum_verify => false,
           creates         => $archive_bin_path,

--- a/spec/defines/daemon_spec.rb
+++ b/spec/defines/daemon_spec.rb
@@ -83,6 +83,14 @@ describe 'prometheus::daemon' do
             )
           }
 
+          context 'with overidden extract_path' do
+            let(:params) do
+              parameters.merge(extract_path: '/opt/foo')
+            end
+
+            it { is_expected.to contain_archive("/tmp/smurf_exporter-#{parameters[:version]}.tar.gz").with_extract_path('/opt/foo') }
+          end
+
           # prometheus::config
           if ['debian-7-x86_64'].include?(os)
             # init_style = 'debian'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Remove hardcoded `extract_path`.  I ran into a few exporters where the binary is all that is extracted from tar.gz so necessary to create the extract path directory in profile then set this new parameter to that value.

Good example: https://github.com/ribbybibby/ssl_exporter/releases
