### PR TITLE
Fix scrape job file names to ensure job_name is prefix

### DIFF
--- a/manifests/scrape_job.pp
+++ b/manifests/scrape_job.pp
@@ -24,7 +24,7 @@ define prometheus::scrape_job (
       labels  => $labels,
     },
   ])
-  file { "${collect_dir}/${name}.yaml":
+  file { "${collect_dir}/${job_name}_${name}.yaml":
     ensure  => file,
     owner   => 'root',
     group   => $prometheus::group,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
This fixes a regression from 829aa4e043893e5535e38f083caedc5702ec27ba.  Basically I have dozens of profile classes that do things like this:

```puppet
  @@prometheus::scrape_job { "${facts['networking']['fqdn']}-${name}":
    job_name => 'tcp-probe',
    targets  => $targets,
    labels   => {
      'host' => $facts['networking']['hostname'],
      'cluster' => lookup('prometheus_cluster'),
      'environment' => lookup('prometheus_environment'),
      'service' => $name,
      'module' => $module,
      'role'  => $role,
    }
  }
```

Before the referenced commit, this worked, now the filename lacks the `job_name` prefix and thus never picked up by prometheus.  If the job_name is going to be hardcoded prefix in `prometheus::config` class then I think this module should always ensure scrape jobs have the job name as prefix.