### PR TITLE
Allow hiding of prom config file

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -67,6 +67,7 @@ prometheus::alertmanager::version: '0.18.0'
 prometheus::alerts: {}
 prometheus::config_dir: '/etc/prometheus'
 prometheus::config_mode: '0640'
+prometheus::config_show_diff: true
 prometheus::config_template: 'prometheus/prometheus.yaml.erb'
 prometheus::consul_exporter::consul_health_summary: true
 prometheus::consul_exporter::consul_server: 'localhost:8500'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -269,6 +269,7 @@ class prometheus::config {
       group        => $prometheus::server::group,
       mode         => $prometheus::server::config_mode,
       notify       => Class['prometheus::service_reload'],
+      show_diff    => $prometheus::config_show_diff,
       content      => template($prometheus::server::config_template),
       validate_cmd => "${prometheus::server::bin_dir}/promtool ${cfg_verify_cmd} %",
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -209,6 +209,8 @@
 # @param log_format
 #  --log.format=logfmt
 #  Output format of log messages. One of: [logfmt, json]
+# @param config_show_diff
+#  Whether to show prometheus configuration file diff in the Puppet logs.
 class prometheus (
   String $user,
   String $group,
@@ -291,6 +293,7 @@ class prometheus (
   Boolean $manage_group                                                         = true,
   Boolean $purge_config_dir                                                     = true,
   Boolean $manage_user                                                          = true,
+  Boolean $config_show_diff                                                     = true,
 ) {
 
   case $arch {

--- a/spec/classes/prometheus_spec.rb
+++ b/spec/classes/prometheus_spec.rb
@@ -170,12 +170,13 @@ describe 'prometheus' do
 
           it {
             is_expected.to contain_file('prometheus.yaml').with(
-              'ensure'  => 'file',
-              'path'    => configpath,
-              'owner'   => 'root',
-              'group'   => 'prometheus',
-              'mode'    => '0640',
-              'content' => File.read(fixtures('files', "prometheus#{prom_major}.yaml"))
+              'ensure'    => 'file',
+              'path'      => configpath,
+              'owner'     => 'root',
+              'group'     => 'prometheus',
+              'mode'      => '0640',
+              'show_diff' => true,
+              'content'   => File.read(fixtures('files', "prometheus#{prom_major}.yaml"))
             ).that_notifies('Class[prometheus::service_reload]')
           }
 
@@ -300,11 +301,12 @@ describe 'prometheus' do
             it { is_expected.to compile.with_all_deps }
             it {
               is_expected.to contain_file('prometheus.yaml').with(
-                'ensure'  => 'file',
-                'path'    => configpath,
-                'owner'   => 'root',
-                'group'   => 'prometheus',
-                'content' => %r{http://domain.tld/path}
+                'ensure'    => 'file',
+                'path'      => configpath,
+                'owner'     => 'root',
+                'group'     => 'prometheus',
+                'show_diff' => true,
+                'content'   => %r{http://domain.tld/path}
               )
             }
           end
@@ -329,6 +331,36 @@ describe 'prometheus' do
 
             it {
               is_expected.not_to contain_file(configpath)
+            }
+          end
+        end
+      end
+
+      context 'with config_show_diff set' do
+        [
+          {
+            manage_prometheus_server: true,
+            config_show_diff: true
+          },
+          {
+            manage_prometheus_server: true,
+            config_show_diff: false
+          }
+        ].each do |parameters|
+          context "to #{parameters[:config_show_diff]}" do
+            let(:params) do
+              parameters
+            end
+
+            it { is_expected.to compile.with_all_deps }
+            it {
+              is_expected.to contain_file('prometheus.yaml').with(
+                'ensure'    => 'file',
+                'path'      => configpath,
+                'owner'     => 'root',
+                'group'     => 'prometheus',
+                'show_diff' => parameters[:config_show_diff]
+              )
             }
           end
         end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This PR makes it possible to hide the prometheus configuration file diff. 
Since the prom configuration file can contain sensitive data (e.g., in the `basic_auth`), keeping the diff out of the logs can be valuable.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
n/a