### PR TITLE
Fixes for prometheus::dellhw_exporter not working as is

### DIFF
--- a/manifests/dellhw_exporter.pp
+++ b/manifests/dellhw_exporter.pp
@@ -86,7 +86,7 @@ class prometheus::dellhw_exporter (
   }
 
   $real_omreport_path = "--collectors-omreport=${omreport_path}"
-  $real_scrape_port = "--web-listen-address=${scrape_port}"
+  $real_scrape_port = "--web-listen-address=:${scrape_port}"
   $options = join([$extra_options, $real_omreport_path, $real_scrape_port], ' ')
 
   prometheus::daemon { $service_name:

--- a/manifests/dellhw_exporter.pp
+++ b/manifests/dellhw_exporter.pp
@@ -49,7 +49,7 @@
 #  The file path to the omReport executable (default "/opt/dell/srvadmin/bin/omreport")
 class prometheus::dellhw_exporter (
   String[1] $download_extension           = 'tar.gz',
-  String[1] $download_url_base            = 'https://github.com/galexrt/dellhw-exporter/releases',
+  String[1] $download_url_base            = 'https://github.com/galexrt/dellhw_exporter/releases',
   Array[String] $extra_groups             = [],
   String[1] $group                        = 'dellhw-exporter',
   String[1] $package_ensure               = 'present',

--- a/spec/acceptance/dellhw_exporter_spec.rb
+++ b/spec/acceptance/dellhw_exporter_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper_acceptance'
+
+describe 'prometheus dellhw_exporter' do
+  it 'dellhw_exporter works idempotently with no errors' do
+    pp = 'include prometheus::dellhw_exporter'
+    # Run it twice and test for idempotency
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
+  end
+
+  describe service('dellhw_exporter') do
+    it { is_expected.to be_running }
+    it { is_expected.to be_enabled }
+  end
+
+  describe port(9137) do
+    it { is_expected.to be_listening.with('tcp6') }
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description

Hello, 

I tested the newly added dellhw_exporter and couldn't make it work without some small changes, the current base url returns a 404 and the service cannot be launched because it tries to bind on the port only. 

This PR fixes those two problems, the code has been tested.


