### PR TITLE
Add support for Google Cloud gs storage

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -8278,3 +8278,8 @@ The Prometheus::Uri data type.
 
 Alias of `Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl, Prometheus::S3Uri]`
 
+### `Prometheus::GsUri`
+
+The Prometheus::GsUri data type.
+
+Alias of `Pattern[/^gs:\/\//]`

--- a/spec/type_aliases/gsuri_spec.rb
+++ b/spec/type_aliases/gsuri_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'Prometheus::GsUri' do
+  describe 'accepts case-sensitive google cloud services gs uris' do
+    [
+      'gs://bucket-name/path',
+      'gs://bucket/path/to/file.txt'
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.to allow_value(value) }
+      end
+    end
+  end
+
+  describe 'rejects other values' do
+    [
+      '',
+      'GS://bucket-name/path',
+      3,
+      'gs:/bucket-name/path',
+      'gs//bucket-name/path',
+      'gs:bucket-name/path',
+      'gs-bucket-name/path'
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.not_to allow_value(value) }
+      end
+    end
+  end
+end

--- a/types/gsuri.pp
+++ b/types/gsuri.pp
@@ -1,0 +1,1 @@
+type Prometheus::GsUri = Pattern[/^gs:\/\//]

--- a/types/uri.pp
+++ b/types/uri.pp
@@ -2,4 +2,5 @@ type Prometheus::Uri = Variant[
   Stdlib::HTTPUrl,
   Stdlib::HTTPSUrl,
   Prometheus::S3Uri,
+  Prometheus::GsUri,
 ]


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This PR adds support for puppet-prometheus to utilize source urls from google cloud storage (requires stdlib v6.1.0 or newer

#### This Pull Request (PR) fixes the following issues
No issue has been filed for this PR.
