### PR TITLE
Allow filtering scrape jobs by nodes

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -238,7 +238,12 @@ class prometheus::config {
 
     $job_name = $job_definition['job_name']
 
-    Prometheus::Scrape_job <<| job_name == $job_name |>> {
+    $node_tag = $prometheus::server::collect_tag ? {
+      Undef   => 'prometheus::scrape_job',
+      default => $prometheus::server::collect_tag,
+    }
+
+    Prometheus::Scrape_job <<| job_name == $job_name and tag == $node_tag |>> {
       collect_dir => "${prometheus::config_dir}/file_sd_config.d",
       notify      => Class['::prometheus::service_reload'],
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,6 +89,8 @@
 #  If omitted, relevant URL components will be derived automatically.
 # @param extract_command
 #  Custom command passed to the archive resource to extract the downloaded archive.
+# @param collect_tag
+#  Only collect scrape jobs tagged with this label. Allowing to split jobs over multiple prometheuses.
 # @param collect_scrape_jobs
 #  Array of scrape_configs. Format, e.g.:
 #  - job_name: some_exporter
@@ -283,6 +285,7 @@ class prometheus (
   String[1] $os                                                                 = downcase($facts['kernel']),
   Optional[Variant[Stdlib::HTTPUrl, Stdlib::Unixpath, String[1]]] $external_url = undef,
   Optional[Array[Hash[String[1], Any]]] $collect_scrape_jobs                    = [],
+  Optional[String[1]] $collect_tag                                              = undef,
   Optional[Integer] $max_open_files                                             = undef,
   String[1] $configname                                                         = 'prometheus.yaml',
   Boolean $service_enable                                                       = true,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -45,6 +45,7 @@ class prometheus::server (
   Boolean $manage_config                                                        = $prometheus::manage_config,
   Optional[Variant[Stdlib::HTTPurl, Stdlib::Unixpath, String[1]]] $external_url = $prometheus::external_url,
   Optional[Array[Hash[String[1], Any]]] $collect_scrape_jobs                    = $prometheus::collect_scrape_jobs,
+  Optional[String[1]] $collect_tag                                              = $prometheus::collect_tag,
   Optional[Integer] $max_open_files                                             = $prometheus::max_open_files,
   Stdlib::Absolutepath $usershell                                               = $prometheus::usershell,
 ) inherits prometheus {


### PR DESCRIPTION
This works but I'm not entirely happy with the interface it has. 

An alternative would be to make the tag part of the `collect_scrape_jobs` hash


=====

Currently jobs are collected by `job_name`, this works well if you want
to run one big prometheus instance but when you want to run more you
have to get creative with job names.

With this you can add tags to the `*_exporter` to specify which
prometheus instance (or instances) should scrape this exporter.

```puppet
class { "prometheus::node_exporter":
  tag               => ['apple', 'banana'],
  export_scrape_job => true,
}
```
