### PR TITLE
Update network denendency in daemon systemd template

### DIFF
--- a/templates/daemon.systemd.erb
+++ b/templates/daemon.systemd.erb
@@ -1,8 +1,8 @@
 # THIS FILE IS MANAGED BY PUPPET
 [Unit]
 Description=Prometheus <%= @name %>
-Wants=basic.target
-After=basic.target network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 User=<%= @user %>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

The config for services in puppet-prometheus module listen on 0.0.0.0 by default. However, when config listens to private IP,
services will fail to start because "After=network.target" doesn't ensure network interface up. It's safer to use "After=network-online.target"


#### This Pull Request (PR) fixes the following issues

No issue has been filed for this PR.