### PR TITLE
Daemon: create env files only if required

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -8398,7 +8398,7 @@ Default value: `{}`
 
 ##### `env_file_path`
 
-Data type: `Optional[String]`
+Data type: `Stdlib::Absolutepath`
 
 
 

--- a/manifests/bird_exporter.pp
+++ b/manifests/bird_exporter.pp
@@ -47,6 +47,8 @@
 #  User which runs the service
 # @param version
 #  The binary release version
+# @param env_vars
+#  hash with custom environment variables thats passed to the exporter via init script / unit file
 #
 # @see https://github.com/czerwonk/bird_exporter
 #
@@ -82,6 +84,7 @@ class prometheus::bird_exporter (
   String[1] $scrape_job_name              = 'bird',
   Optional[Hash] $scrape_job_labels       = undef,
   Optional[String[1]] $bin_name           = undef,
+  Hash[String[1], Scalar] $env_vars       = {},
 ) inherits prometheus {
   $real_download_url = pick($download_url,"${download_url_base}/download/${version}/${package_name}-${version}_${os}_${arch}")
 
@@ -118,5 +121,6 @@ class prometheus::bird_exporter (
     scrape_job_name    => $scrape_job_name,
     scrape_job_labels  => $scrape_job_labels,
     bin_name           => $bin_name,
+    env_vars           => $env_vars,
   }
 }

--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -68,8 +68,8 @@ define prometheus::daemon (
   Stdlib::Ensure::Service $service_ensure = 'running',
   Boolean $service_enable                 = true,
   Boolean $manage_service                 = true,
-  Hash[String, Scalar] $env_vars          = {},
-  Optional[String] $env_file_path         = $prometheus::env_file_path,
+  Hash[String[1], Scalar] $env_vars       = {},
+  Stdlib::Absolutepath $env_file_path     = $prometheus::env_file_path,
   Optional[String[1]] $extract_command    = $prometheus::extract_command,
   Stdlib::Absolutepath $extract_path      = '/opt',
   Stdlib::Absolutepath $archive_bin_path  = "/opt/${name}-${version}.${os}-${arch}/${name}",
@@ -215,7 +215,7 @@ define prometheus::daemon (
     'none': {}
   }
 
-  if $env_file_path != undef {
+  unless $env_vars.empty {
     file { "${env_file_path}/${name}":
       mode    => '0644',
       owner   => 'root',

--- a/spec/classes/apache_exporter_spec.rb
+++ b/spec/classes/apache_exporter_spec.rb
@@ -8,6 +8,24 @@ describe 'prometheus::apache_exporter' do
       end
 
       context 'with all defaults' do
+        it { is_expected.to compile.with_all_deps }
+        if facts[:os]['release']['major'].to_i == 6
+          it { is_expected.to contain_file('/etc/init.d/apache_exporter') }
+        else
+          it { is_expected.to contain_systemd__unit_file('apache_exporter.service') }
+        end
+
+        if facts[:os]['name'] == 'Archlinux'
+          it { is_expected.to contain_package('apache_exporter') }
+          it { is_expected.not_to contain_archive('/tmp/apache_exporter-0.8.0.tar.gz') }
+          it { is_expected.not_to contain_file('/opt/apache_exporter-0.8.0.linux-amd64/apache_exporter') }
+        else
+          it { is_expected.not_to contain_package('apache-exporter') }
+          it { is_expected.to contain_archive('/tmp/apache_exporter-0.8.0.tar.gz') }
+          it { is_expected.to contain_file('/opt/apache_exporter-0.8.0.linux-amd64/apache_exporter') }
+        end
+      end
+      context 'with some params' do
         let(:params) do
           {
             version: '0.5.0',
@@ -21,6 +39,7 @@ describe 'prometheus::apache_exporter' do
         describe 'with specific params' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_archive('/tmp/apache_exporter-0.5.0.tar.gz') }
+          it { is_expected.to contain_file('/opt/apache_exporter-0.5.0.linux-amd64/apache_exporter') }
           it { is_expected.to contain_class('prometheus') }
           it { is_expected.to contain_group('apache-exporter') }
           it { is_expected.to contain_user('apache-exporter') }
@@ -48,6 +67,7 @@ describe 'prometheus::apache_exporter' do
         describe 'with specific params' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_archive('/tmp/apache_exporter-0.4.0.tar.gz') }
+          it { is_expected.to contain_file('/opt/apache_exporter-0.4.0.linux-amd64/apache_exporter') }
           it { is_expected.to contain_class('prometheus') }
           it { is_expected.to contain_group('apache-exporter') }
           it { is_expected.to contain_user('apache-exporter') }

--- a/spec/classes/bird_exporter_spec.rb
+++ b/spec/classes/bird_exporter_spec.rb
@@ -26,9 +26,28 @@ describe 'prometheus::bird_exporter' do
         end
 
         if facts[:os]['family'] == 'RedHat'
+          it { is_expected.not_to contain_file('/etc/sysconfig/bird_exporter') }
+        else
+          it { is_expected.not_to contain_file('/etc/default/bird_exporter') }
+        end
+      end
+
+      context 'with env vars' do
+        let :params do
+          {
+            env_vars: {
+              blub: 'foobar'
+            }
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        if facts[:os]['family'] == 'RedHat'
           it { is_expected.to contain_file('/etc/sysconfig/bird_exporter') }
+          it { is_expected.not_to contain_file('/etc/default/bird_exporter') }
         else
           it { is_expected.to contain_file('/etc/default/bird_exporter') }
+          it { is_expected.not_to contain_file('/etc/sysconfig/bird_exporter') }
         end
       end
     end

--- a/spec/classes/node_exporter_spec.rb
+++ b/spec/classes/node_exporter_spec.rb
@@ -19,7 +19,6 @@ describe 'prometheus::node_exporter' do
           it { is_expected.not_to contain_file('/opt/node_exporter-1.0.1.linux-amd64/node_exporter') }
           it { is_expected.not_to contain_file('/usr/local/bin/node_exporter') }
           it { is_expected.to contain_package('prometheus-node-exporter') }
-          it { is_expected.to contain_file('/etc/default/node_exporter') }
           it { is_expected.to contain_systemd__unit_file('node_exporter.service') }
         else
           it { is_expected.to contain_user('node-exporter') }
@@ -29,12 +28,13 @@ describe 'prometheus::node_exporter' do
         end
 
         if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'].to_i < 7
-          it { is_expected.to contain_file('/etc/sysconfig/node_exporter') }
           it { is_expected.to contain_file('/etc/init.d/node_exporter') }
         end
 
-        if facts[:os]['release']['major'].to_i == 14
-          it { is_expected.to contain_file('/etc/init/node_exporter.conf') }
+        if facts[:os]['family'] == 'RedHat'
+          it { is_expected.not_to contain_file('/etc/sysconfig/bird_exporter') }
+        else
+          it { is_expected.not_to contain_file('/etc/default/bird_exporter') }
         end
       end
 

--- a/templates/daemon.env.erb
+++ b/templates/daemon.env.erb
@@ -1,3 +1,4 @@
+# THIS FILE IS MANAGED BY PUPPET
 <% @env_vars.each do |key, value| -%>
 <%= key %>="<%= value %>"
 <% end -%>

--- a/templates/daemon.systemd.erb
+++ b/templates/daemon.systemd.erb
@@ -7,7 +7,9 @@ After=basic.target network.target
 [Service]
 User=<%= @user %>
 Group=<%= @group %>
+<%- unless @env_vars.empty? -%>
 EnvironmentFile=<%= @env_file_path %>/<%= @name%>
+<% end %>
 <%- require 'shellwords' -%>
 ExecStart=<%= @bin_dir %>/<%= @bin_name %><% for option in Shellwords.split(@options) %> \
 <%= option -%>


### PR DESCRIPTION
In the past we always created the env files, even if they are empty if `$env_vars` isn't set). The `env_file_path` was optional, but we set a default via hiera which makes it impossible to overwrite. So the `Optioanl[]` is useless and can be removed. Also It's always an absolute path so we can replace `String` with `Stdlib::Absolutepath`.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
