### PR TITLE
add `timeout_stop` to control systemd `TimeoutStopSec`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -397,6 +397,16 @@ Currently only implemented for systemd based service.
 
 Default value: ``undef``
 
+##### `timeout_stop`
+
+Data type: `Optional[String]`
+
+The timeout for stopping prometheus via systemd.
+Defaults to `undef`, but set to a time string to override your default OS limit of 1min 30s.
+Currently only implemented for systemd based service.
+
+Default value: ``undef``
+
 ##### `usershell`
 
 Data type: `Stdlib::Absolutepath`
@@ -7436,6 +7446,14 @@ Data type: `Optional[Integer]`
 
 
 Default value: `$prometheus::max_open_files`
+
+##### `timeout_stop`
+
+Data type: `Optional[String]`
+
+
+
+Default value: `$prometheus::timeout_stop`
 
 ##### `usershell`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,6 +3,7 @@ class prometheus::config {
   assert_private()
 
   $max_open_files = $prometheus::server::max_open_files
+  $timeout_stop = $prometheus::server::timeout_stop
 
   $prometheus_v2 = versioncmp($prometheus::server::version, '2.0.0') >= 0
 
@@ -184,6 +185,7 @@ class prometheus::config {
             'group'          => $prometheus::server::group,
             'daemon_flags'   => $daemon_flags,
             'max_open_files' => $max_open_files,
+            'timeout_stop'   => $timeout_stop,
             'bin_dir'        => $prometheus::server::bin_dir,
         }),
         notify  => $notify,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,6 +102,10 @@
 #  The maximum number of file descriptors for the prometheus server.
 #  Defaults to `undef`, but set to a large integer to override your default OS limit.
 #  Currently only implemented for systemd based service.
+# @param timeout_stop
+#  Timeout when stopping the prometheus service.
+#  Defaults to `undef`, but set to a time definition like `5min` to override your default OS limit.
+#  Currently only implemented for systemd based service.
 # @param usershell
 #  if requested, we create a user for prometheus or the exporters. The default
 #  shell is nologin. It can be overwritten to any valid path.
@@ -287,6 +291,7 @@ class prometheus (
   Optional[Array[Hash[String[1], Any]]] $collect_scrape_jobs                    = [],
   Optional[String[1]] $collect_tag                                              = undef,
   Optional[Integer] $max_open_files                                             = undef,
+  Optional[String] $timeout_stop                                                = undef,
   String[1] $configname                                                         = 'prometheus.yaml',
   Boolean $service_enable                                                       = true,
   Boolean $manage_service                                                       = true,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -47,6 +47,7 @@ class prometheus::server (
   Optional[Array[Hash[String[1], Any]]] $collect_scrape_jobs                    = $prometheus::collect_scrape_jobs,
   Optional[String[1]] $collect_tag                                              = $prometheus::collect_tag,
   Optional[Integer] $max_open_files                                             = $prometheus::max_open_files,
+  Optional[String] $timeout_stop                                                = $prometheus::timeout_stop,
   Stdlib::Absolutepath $usershell                                               = $prometheus::usershell,
 ) inherits prometheus {
   if( versioncmp($version, '1.0.0') == -1 ) {

--- a/spec/classes/prometheus_spec.rb
+++ b/spec/classes/prometheus_spec.rb
@@ -148,6 +148,24 @@ describe 'prometheus' do
                 }
               end
             end
+            describe 'timeout_stop' do
+              context 'by default' do
+                it {
+                  content = catalogue.resource('systemd::unit_file', 'prometheus.service').send(:parameters)[:content]
+                  expect(content).not_to include('TimeoutStopSec')
+                }
+              end
+              context 'when set to 5min' do
+                let(:params) do
+                  parameters.merge('timeout_stop' => '5min')
+                end
+
+                it {
+                  content = catalogue.resource('systemd::unit_file', 'prometheus.service').send(:parameters)[:content]
+                  expect(content).to include('TimeoutStopSec=5min')
+                }
+              end
+            end
           elsif os == 'archlinux-5-x86_64'
 
             it { is_expected.not_to contain_systemd__unit_file('prometheus.service') }

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -43,6 +43,24 @@ describe 'prometheus::server' do
                 }
               end
             end
+            describe 'timeout_stop' do
+              context 'by default' do
+                it {
+                  content = catalogue.resource('systemd::unit_file', 'prometheus.service').send(:parameters)[:content]
+                  expect(content).not_to include('TimeoutStopSec')
+                }
+              end
+              context 'when set to 5min' do
+                let(:params) do
+                  parameters.merge('timeout_stop' => '5min')
+                end
+
+                it {
+                  content = catalogue.resource('systemd::unit_file', 'prometheus.service').send(:parameters)[:content]
+                  expect(content).to include('TimeoutStopSec=5min')
+                }
+              end
+            end
           end
         end
       end

--- a/templates/prometheus.systemd.epp
+++ b/templates/prometheus.systemd.epp
@@ -2,6 +2,7 @@
       String[1] $group,
       Array[String] $daemon_flags,
       Optional[Integer] $max_open_files,
+      Optional[String] $timeout_stop,
       Stdlib::Absolutepath $bin_dir,
 | -%>
 # THIS FILE IS MANAGED BY PUPPET
@@ -20,6 +21,9 @@ KillMode=process
 Restart=always
 <% if $max_open_files { -%>
 LimitNOFILE=<%= $max_open_files %>
+<% } -%>
+<% if $timeout_stop { -%>
+TimeoutStopSec=<%= $timeout_stop %>
 <% } -%>
 NoNewPrivileges=true
 ProtectHome=true


### PR DESCRIPTION
#### Pull Request (PR) description
With larger WAL segments, prometheus fails to write
a new checkpoint in `TimeoutStopSec` time:

```
Oct 03 15:13:37 prometheus prometheus[2452]: level=info ts=2020-10-03T15:13:37.751Z caller=checkpoint.go:96 component=tsdb msg="Creating checkpoint" from_segment=85417 to_segment=85677 mint
Oct 03 15:15:06 prometheus systemd[1]: prometheus.service: State 'stop-sigterm' timed out. Killing.
Oct 03 15:15:06 prometheus systemd[1]: prometheus.service: Killing process 2452 (prometheus) with signal SIGKILL.
Oct 03 15:15:06 prometheus systemd[1]: prometheus.service: Main process exited, code=killed, status=9/KILL
Oct 03 15:15:06 prometheus systemd[1]: prometheus.service: Failed with result 'timeout'.
Oct 03 15:15:06 prometheus systemd[1]: Stopped Prometheus Monitoring framework.
```

This change adds a new parameter to define `TimeoutStopSec`
for `prometheus.service`.

#### This Pull Request (PR) fixes the following issues

No issue previously created.

The required systemd unitfile overwrite could have been made locally as well - but as I suppose that others could also face similar issues, I decided to implement the parameter directly.