### PR TITLE
Add systemd_configs to prometheus::daemon

### DIFF
--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -45,6 +45,8 @@
 #  Service startup scripts style (e.g. rc, upstart or systemd).
 #  Can also be set to `none` when you don't want the class to create a startup script/unit_file for you.
 #  Typically this can be used when a package is already providing the file.
+# @param systemd_configs
+#   Additional systemd Service configurations
 define prometheus::daemon (
   String[1] $version,
   Prometheus::Uri $real_download_url,
@@ -79,6 +81,7 @@ define prometheus::daemon (
   String[1] $scrape_job_name              = $name,
   Hash $scrape_job_labels                 = { 'alias' => $scrape_host },
   Stdlib::Absolutepath $usershell         = $prometheus::usershell,
+  Hash[String[1],Scalar] $systemd_configs = {},
 ) {
   case $install_method {
     'url': {

--- a/spec/defines/daemon_spec.rb
+++ b/spec/defines/daemon_spec.rb
@@ -147,6 +147,21 @@ describe 'prometheus::daemon' do
               }
             end
 
+            context 'with systemd_configs defined' do
+              let(:params) do
+                parameters.merge(systemd_configs: {
+                                   'StandardOutput' => 'tty',
+                                   'StandardError' => 'journal',
+                                 })
+              end
+
+              it {
+                is_expected.to contain_systemd__unit_file('smurf_exporter.service').with_content(
+                  %r{StandardOutput=tty\nStandardError=journal}
+                )
+              }
+            end
+
           elsif ['ubuntu-14.04-x86_64'].include?(os)
             # init_style = 'upstart'
 

--- a/templates/daemon.systemd.erb
+++ b/templates/daemon.systemd.erb
@@ -14,6 +14,9 @@ EnvironmentFile=<%= @env_file_path %>/<%= @name%>
 ExecStart=<%= @bin_dir %>/<%= @bin_name %><% for option in Shellwords.split(@options) %> \
 <%= option -%>
 <% end %>
+<%- @systemd_configs.each_pair do |key,value| -%>
+<%= key %>=<%= value %>
+<%- end -%>
 
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Adds `systemd_configs` parameter to `prometheus::daemon`

I have written the TSM (Tivoli Storage Manager / IBM Spectrum Protect) exporter and it relies on goexpect to handle prompts when connecting up to TSM to avoid passing passwords at the shell.  I've found I have to set these two things in systemd to get that to work:

```
StandardOutput=tty
StandardError=journal
```

Rather than add options for those two specific settings, figured just allow any key/value pair configs for systemd to be provided.
