### PR TITLE
Allow download_extension to be empty string

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -72,7 +72,7 @@ This can be used to make prometheus find instances of your running service or ap
 
 ### `prometheus`
 
-This module manages prometheus.
+This module manages prometheus
 
 #### Parameters
 
@@ -1045,7 +1045,7 @@ Default value: `$prometheus::config_mode`
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -1291,7 +1291,7 @@ Address to bind beanstalkd_exporter to. Default is different than upstream (*:93
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -1674,6 +1674,14 @@ The binary release version
 
 Default value: `'1.2.4'`
 
+##### `env_vars`
+
+Data type: `Hash[String[1], Scalar]`
+
+hash with custom environment variables thats passed to the exporter via init script / unit file
+
+Default value: `{}`
+
 ##### `export_scrape_job`
 
 Data type: `Boolean`
@@ -1765,7 +1773,7 @@ Absolute path to configuration file (blackbox module definitions)
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -1989,7 +1997,7 @@ Default value: `$prometheus::bin_dir`
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -2211,7 +2219,7 @@ Generate a health summary for each service instance. Needs n+1 queries to collec
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -2443,7 +2451,7 @@ Default value: `$prometheus::bin_dir`
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -2711,7 +2719,7 @@ Timeout for trying to get stats from elasticsearch URI
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -2933,7 +2941,7 @@ Default value: `$prometheus::bin_dir`
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -3160,7 +3168,7 @@ Default value: `$prometheus::config_mode`
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -3382,7 +3390,7 @@ The URI to obtain HAProxy stats from
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -3603,7 +3611,7 @@ Default value: `$prometheus::bin_dir`
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -3855,7 +3863,7 @@ The URI to obtain mesos stats from
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -4075,7 +4083,7 @@ The URI to obtain MongoDB stats from
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -4356,7 +4364,7 @@ Default value: `$prometheus::config_mode`
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -4817,7 +4825,7 @@ Default value: `[]`
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -5262,7 +5270,7 @@ Default value: `{}`
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -5533,7 +5541,7 @@ Default value: `$prometheus::bin_dir`
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -5778,7 +5786,7 @@ Default value: `$prometheus::bin_dir`
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -6576,7 +6584,7 @@ Default value: `$prometheus::bin_dir`
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -6849,7 +6857,7 @@ Array of address of one or more redis nodes. Defaults to redis://localhost:6379
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -7491,7 +7499,7 @@ Configuration template to use. If empty, uses upstream config (default "")
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -7713,7 +7721,7 @@ Default value: `$prometheus::config_mode`
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -7944,7 +7952,7 @@ Default value: `$prometheus::bin_dir`
 
 ##### `download_extension`
 
-Data type: `String[1]`
+Data type: `String`
 
 Extension for the release binary archive
 
@@ -8390,7 +8398,7 @@ Default value: `''`
 
 ##### `env_vars`
 
-Data type: `Hash[String, Scalar]`
+Data type: `Hash[String[1], Scalar]`
 
 
 
@@ -8504,7 +8512,7 @@ Alias of `Pattern[/^gs:\/\//]`
 
 The Prometheus::Initstyle data type.
 
-Alias of `Enum['sysv', 'redhat', 'systemd', 'sles', 'debian', 'launchd', 'upstart', 'none']`
+Alias of `Enum['sysv', 'systemd', 'sles', 'launchd', 'upstart', 'none']`
 
 ### `Prometheus::Install`
 

--- a/manifests/apache_exporter.pp
+++ b/manifests/apache_exporter.pp
@@ -51,7 +51,7 @@
 #  The binary release version
 class prometheus::apache_exporter (
   String[1] $scrape_uri,
-  String[1] $download_extension,
+  String $download_extension,
   Prometheus::Uri $download_url_base,
   Array[String[1]] $extra_groups,
   String[1] $group,

--- a/manifests/beanstalkd_exporter.pp
+++ b/manifests/beanstalkd_exporter.pp
@@ -54,7 +54,7 @@
 # @param version
 #  The binary release version
 class prometheus::beanstalkd_exporter (
-  String[1] $download_extension,
+  String $download_extension,
   String[1] $download_url_base,
   Array $extra_groups,
   String[1] $group,

--- a/manifests/blackbox_exporter.pp
+++ b/manifests/blackbox_exporter.pp
@@ -64,7 +64,7 @@
 #       preferred_ip_protocol: ip4
 class prometheus::blackbox_exporter (
   String[1] $config_file,
-  String[1] $download_extension,
+  String $download_extension,
   String[1] $download_url_base,
   Array[String] $extra_groups,
   String[1] $group,

--- a/manifests/collectd_exporter.pp
+++ b/manifests/collectd_exporter.pp
@@ -44,7 +44,7 @@
 # @param version
 #  The binary release version
 class prometheus::collectd_exporter (
-  String[1] $download_extension,
+  String $download_extension,
   String[1] $download_url_base,
   String[1] $group,
   String[1] $package_ensure,

--- a/manifests/consul_exporter.pp
+++ b/manifests/consul_exporter.pp
@@ -58,7 +58,7 @@
 class prometheus::consul_exporter (
   Boolean $consul_health_summary,
   String[1] $consul_server,
-  String[1] $download_extension,
+  String $download_extension,
   String[1] $download_url_base,
   Array $extra_groups,
   String[1] $group,

--- a/manifests/dellhw_exporter.pp
+++ b/manifests/dellhw_exporter.pp
@@ -50,7 +50,7 @@
 # @param scrape_ipadress
 #  The ip address that the exporter will to listen to (default '')
 class prometheus::dellhw_exporter (
-  String[1] $download_extension           = 'tar.gz',
+  String $download_extension              = 'tar.gz',
   String[1] $download_url_base            = 'https://github.com/galexrt/dellhw_exporter/releases',
   Array[String] $extra_groups             = [],
   String[1] $group                        = 'dellhw-exporter',

--- a/manifests/elasticsearch_exporter.pp
+++ b/manifests/elasticsearch_exporter.pp
@@ -54,7 +54,7 @@
 class prometheus::elasticsearch_exporter (
   String[1] $cnf_uri,
   String[1] $cnf_timeout,
-  String[1] $download_extension,
+  String $download_extension,
   String[1] $download_url_base,
   Array $extra_groups,
   String[1] $group,

--- a/manifests/graphite_exporter.pp
+++ b/manifests/graphite_exporter.pp
@@ -44,7 +44,7 @@
 # @param version
 #  The binary release version
 class prometheus::graphite_exporter (
-  String[1] $download_extension,
+  String $download_extension,
   String[1] $download_url_base,
   String[1] $group,
   String[1] $package_ensure,

--- a/manifests/grok_exporter.pp
+++ b/manifests/grok_exporter.pp
@@ -55,7 +55,7 @@
 class prometheus::grok_exporter (
   Hash $config,
   String[1] $config_file,
-  String[1] $download_extension,
+  String $download_extension,
   Prometheus::Uri $download_url_base,
   Array[String[1]] $extra_groups,
   String[1] $group,

--- a/manifests/haproxy_exporter.pp
+++ b/manifests/haproxy_exporter.pp
@@ -49,7 +49,7 @@
 #  The binary release version
 class prometheus::haproxy_exporter (
   Variant[Stdlib::HTTPUrl, Pattern[/unix:(?:\/.+)+/]] $cnf_scrape_uri,
-  String[1] $download_extension,
+  String $download_extension,
   Array $extra_groups,
   String[1] $group,
   String[1] $package_ensure,

--- a/manifests/memcached_exporter.pp
+++ b/manifests/memcached_exporter.pp
@@ -46,7 +46,7 @@
 # @param version
 #  The binary release version
 class prometheus::memcached_exporter (
-  String[1] $download_extension           = 'tar.gz',
+  String $download_extension              = 'tar.gz',
   String[1] $download_url_base            = 'https://github.com/prometheus/memcached_exporter/releases',
   Array[String] $extra_groups             = [],
   String[1] $group                        = 'memcached-exporter',

--- a/manifests/mesos_exporter.pp
+++ b/manifests/mesos_exporter.pp
@@ -52,7 +52,7 @@
 class prometheus::mesos_exporter (
   String[1] $server_type,
   String[1] $cnf_scrape_uri,
-  String[1] $download_extension,
+  String $download_extension,
   String[1] $download_url_base,
   Array $extra_groups,
   String[1] $group,

--- a/manifests/mongodb_exporter.pp
+++ b/manifests/mongodb_exporter.pp
@@ -53,7 +53,7 @@
 #  https://github.com/percona/mongodb_exporter/blob/v0.7.0/CHANGELOG.md
 class prometheus::mongodb_exporter (
   String[1] $cnf_uri,
-  String[1] $download_extension,
+  String $download_extension,
   String[1] $download_url_base,
   Array  $extra_groups,
   String[1] $group,

--- a/manifests/mysqld_exporter.pp
+++ b/manifests/mysqld_exporter.pp
@@ -61,7 +61,7 @@
 # @param version
 #  The binary release version
 class prometheus::mysqld_exporter (
-  String[1] $download_extension,
+  String $download_extension,
   Prometheus::Uri $download_url_base,
   Array $extra_groups,
   String[1] $group,

--- a/manifests/node_exporter.pp
+++ b/manifests/node_exporter.pp
@@ -55,7 +55,7 @@
 # @param version
 #  The binary release version
 class prometheus::node_exporter (
-  String[1] $download_extension,
+  String $download_extension,
   String[1] $download_url_base,
   Array[String] $extra_groups,
   String[1] $group,

--- a/manifests/postgres_exporter.pp
+++ b/manifests/postgres_exporter.pp
@@ -56,7 +56,7 @@
 # @param data_source_uri
 #  Uri on howto connect to the database
 class prometheus::postgres_exporter (
-  String[1] $download_extension,
+  String $download_extension,
   String[1] $download_url_base,
   Array[String[1]] $extra_groups,
   String[1] $group,

--- a/manifests/process_exporter.pp
+++ b/manifests/process_exporter.pp
@@ -71,7 +71,7 @@
 #     ]
 #   }
 class prometheus::process_exporter (
-  String[1] $download_extension,
+  String $download_extension,
   Prometheus::Uri $download_url_base,
   Array $extra_groups,
   String[1] $group,

--- a/manifests/puppetdb_exporter.pp
+++ b/manifests/puppetdb_exporter.pp
@@ -48,7 +48,7 @@
 # @param puppetdb_url
 #  The URI to PuppetDB with http/https protocol at the beginning and `/pdb/query` at the end
 class prometheus::puppetdb_exporter (
-  String[1] $download_extension           = 'tar.gz',
+  String $download_extension              = 'tar.gz',
   String[1] $download_url_base            = 'https://github.com/camptocamp/prometheus-puppetdb-exporter/releases',
   Array[String] $extra_groups             = [],
   String[1] $group                        = 'puppetdb-exporter',

--- a/manifests/rabbitmq_exporter.pp
+++ b/manifests/rabbitmq_exporter.pp
@@ -71,7 +71,7 @@ class prometheus::rabbitmq_exporter (
   String[1] $package_ensure,
   String[1] $package_name,
   String[1] $service_name,
-  String[1] $download_extension,
+  String $download_extension,
   String[1] $user,
   String[1] $version,
   String[1] $rabbit_url,

--- a/manifests/redis_exporter.pp
+++ b/manifests/redis_exporter.pp
@@ -53,7 +53,7 @@
 #  The binary release version
 class prometheus::redis_exporter (
   Array[String] $addr,
-  String[1] $download_extension,
+  String $download_extension,
   String[1] $download_url_base,
   Array[String] $extra_groups,
   String[1] $group,

--- a/manifests/snmp_exporter.pp
+++ b/manifests/snmp_exporter.pp
@@ -54,7 +54,7 @@
 class prometheus::snmp_exporter (
   String[1] $config_file,
   String $config_template,
-  String[1] $download_extension,
+  String $download_extension,
   String[1] $download_url_base,
   Array $extra_groups,
   String[1] $group,

--- a/manifests/statsd_exporter.pp
+++ b/manifests/statsd_exporter.pp
@@ -55,7 +55,7 @@
 # @param version
 #  The binary release version
 class prometheus::statsd_exporter (
-  String[1] $download_extension,
+  String $download_extension,
   Prometheus::Uri $download_url_base,
   Array $extra_groups,
   String[1] $group,

--- a/manifests/varnish_exporter.pp
+++ b/manifests/varnish_exporter.pp
@@ -46,7 +46,7 @@
 # @param version
 #  The binary release version
 class prometheus::varnish_exporter (
-  String[1] $download_extension,
+  String $download_extension,
   Array $extra_groups,
   String[1] $group,
   String[1] $package_ensure,

--- a/spec/classes/node_exporter_spec.rb
+++ b/spec/classes/node_exporter_spec.rb
@@ -86,6 +86,16 @@ describe 'prometheus::node_exporter' do
           it { is_expected.to contain_file('/usr/local/bin/node_exporter').with('target' => '/opt/node_exporter-0.13.0.linux-amd64/node_exporter') }
         end
       end
+
+      context 'with no download_extension' do
+        let(:params) do
+          {
+            download_extension: '',
+          }
+        end
+
+        it { is_expected.to contain_prometheus__daemon('node_exporter').with_download_extension('') }
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
I deploy some exporters like node_exporter from a forked build and I upload the built Go binaries to a web server I host. So I have many exporters with `download_extension: ''` in Hiera.  This worked a few versions ago, and is allowed by `prometheus::daemon` so seems like should be allowed by predefined exporter classes.  I added a test for empty extension so hopefully no one changes this back in the future.