### PR TITLE
Fix download of beanstalkd_exporter for versions newer than 1.0.0

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -205,7 +205,7 @@ prometheus::node_exporter::user: 'node-exporter'
 prometheus::node_exporter::version: '1.0.1'
 prometheus::beanstalkd_exporter::exporter_listen: ':9371'
 prometheus::beanstalkd_exporter::beanstalkd_address: '127.0.0.1:11300'
-prometheus::beanstalkd_exporter::download_extension: 'tar.gz'
+prometheus::beanstalkd_exporter::download_extension: ''
 prometheus::beanstalkd_exporter::download_url_base: 'https://github.com/messagebird/beanstalkd_exporter/releases'
 prometheus::beanstalkd_exporter::extra_groups: []
 prometheus::beanstalkd_exporter::group: 'beanstalkd-exporter'

--- a/spec/classes/beanstalkd_exporter_spec.rb
+++ b/spec/classes/beanstalkd_exporter_spec.rb
@@ -7,14 +7,15 @@ describe 'prometheus::beanstalkd_exporter' do
         facts.merge(os_specific_facts(facts))
       end
 
-      context 'with version specified' do
+      context 'with version 1.0.0' do
         let(:params) do
           {
             version: '1.0.0',
             arch: 'amd64',
             os: 'linux',
             bin_dir: '/usr/local/bin',
-            install_method: 'url'
+            install_method: 'url',
+            download_extension: 'tar.gz'
           }
         end
 
@@ -25,6 +26,8 @@ describe 'prometheus::beanstalkd_exporter' do
           it { is_expected.to contain_user('beanstalkd-exporter') }
           it { is_expected.to contain_prometheus__daemon('beanstalkd_exporter') }
           it { is_expected.to contain_service('beanstalkd_exporter') }
+          it { is_expected.to contain_file('/etc/beanstalkd-exporter.conf').with('ensure' => 'file') }
+          it { is_expected.to contain_file('/etc/beanstalkd-exporter-mapping.conf').with('ensure' => 'file') }
         end
         describe 'compile manifest' do
           it { is_expected.to compile.with_all_deps }
@@ -32,6 +35,38 @@ describe 'prometheus::beanstalkd_exporter' do
 
         describe 'install correct binary' do
           it { is_expected.to contain_file('/usr/local/bin/beanstalkd_exporter').with('target' => '/opt/beanstalkd_exporter-1.0.0.linux-amd64/beanstalkd_exporter') }
+        end
+      end
+
+      context 'with version 1.0.1 and higher' do
+        let(:params) do
+          {
+            version: '1.0.1',
+            arch: 'amd64',
+            os: 'linux',
+            bin_dir: '/usr/local/bin',
+            install_method: 'url'
+          }
+        end
+
+        describe 'with specific params' do
+          it { is_expected.to contain_file('/opt/beanstalkd_exporter-1.0.1.linux-amd64')}
+          it { is_expected.to contain_archive('/opt/beanstalkd_exporter-1.0.1.linux-amd64/beanstalkd_exporter') }
+          it { is_expected.to contain_class('prometheus') }
+          it { is_expected.to contain_group('beanstalkd-exporter') }
+          it { is_expected.to contain_user('beanstalkd-exporter') }
+          it { is_expected.to contain_prometheus__daemon('beanstalkd_exporter') }
+          it { is_expected.to contain_service('beanstalkd_exporter') }
+          it { is_expected.to contain_file('/etc/beanstalkd-exporter.conf').with('ensure' => 'absent') }
+          it { is_expected.to contain_file('/etc/beanstalkd-exporter-mapping.conf').with('ensure' => 'absent') }
+        end
+
+        describe 'compile manifest' do
+          it { is_expected.to compile.with_all_deps }
+        end
+
+        describe 'install correct binary' do
+          it { is_expected.to contain_file('/usr/local/bin/beanstalkd_exporter').with('target' => '/opt/beanstalkd_exporter-1.0.1.linux-amd64/beanstalkd_exporter') }
         end
       end
     end


### PR DESCRIPTION
#### Pull Request (PR) description
beanstalkd_exporter releases newer than 1.0.0 (currently default in this module is 1.0.5) fail to download because the release assets have different naming.
See:
https://github.com/messagebird/beanstalkd_exporter/releases

#### This Pull Request (PR) fixes the following issues

