### PR TITLE
(FACT-2880) fact: call Puppet within setcode block

### DIFF
--- a/lib/facter/alert_manager_running.rb
+++ b/lib/facter/alert_manager_running.rb
@@ -1,10 +1,9 @@
 require 'puppet'
 
-service = Puppet::Type.type(:service).new(:name => 'alert_manager') # rubocop:disable Style/HashSyntax
-
 Facter.add('prometheus_alert_manager_running') do
   setcode do
     begin
+      service = Puppet::Type.type(:service).new(:name => 'alert_manager') # rubocop:disable Style/HashSyntax
       service.provider.status == :running
     rescue Puppet::Error
       false


### PR DESCRIPTION
This change is a result of https://tickets.puppetlabs.com/browse/FACT-2880

previous to this change, we called Puppet outside the setcode block.
This works fine on Facter 3. On Facter 4 this sets the service_provider
fact to `base`. Moving the code into the setcode block fixes it.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
