### PR TITLE
Drop EOL CentOS 6 support

### DIFF
--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -139,10 +139,10 @@ class prometheus::alertmanager (
   }
 
   $alertmanager_reload = $prometheus::init_style ? {
-    'systemd'              => "systemctl reload-or-restart ${service_name}",
-    /^(upstart|none)$/     => "service ${service_name} reload",
-    /^(sysv|redhat|sles)$/ => "/etc/init.d/${service_name} reload",
-    'launchd'              => "launchctl stop ${service_name} && launchctl start ${service_name}",
+    'systemd'          => "systemctl reload-or-restart ${service_name}",
+    /^(upstart|none)$/ => "service ${service_name} reload",
+    /^(sysv|sles)$/    => "/etc/init.d/${service_name} reload",
+    'launchd'          => "launchctl stop ${service_name} && launchctl start ${service_name}",
   }
 
   exec { 'alertmanager-reload':

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -194,17 +194,13 @@ class prometheus::config {
         Class['systemd::systemctl::daemon_reload'] -> Class['prometheus::run_service']
       }
     }
-    'sysv', 'redhat', 'sles': {
-      $content = $prometheus::server::init_style ? {
-        'redhat' => template('prometheus/prometheus.sysv.erb'), # redhat and sysv share the same template file
-        default  => template("prometheus/prometheus.${prometheus::server::init_style}.erb"),
-      }
+    'sysv', 'sles': {
       file { "/etc/init.d/${prometheus::server::service_name}":
         ensure  => file,
         mode    => '0555',
         owner   => 'root',
         group   => 'root',
-        content => $content,
+        content => template("prometheus/prometheus.${prometheus::server::init_style}.erb"),
         notify  => $notify,
       }
     }

--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -184,8 +184,7 @@ define prometheus::daemon (
         Class['systemd::systemctl::daemon_reload'] -> Service[$name]
       }
     }
-    # service_provider returns redhat on CentOS using sysv, https://tickets.puppetlabs.com/browse/PUP-5296
-    'sysv','redhat': {
+    'sysv': {
       file { "/etc/init.d/${name}":
         mode    => '0555',
         owner   => 'root',

--- a/manifests/service_reload.pp
+++ b/manifests/service_reload.pp
@@ -7,10 +7,10 @@ class prometheus::service_reload () {
     $init_selector = $prometheus::run_service::init_selector
 
     $prometheus_reload = $prometheus::server::init_style ? {
-      'systemd'              => "systemctl reload-or-restart ${init_selector}",
-      /^(upstart|none)$/     => "service ${init_selector} reload",
-      /^(sysv|redhat|sles)$/ => "/etc/init.d/${init_selector} reload",
-      'launchd'              => "launchctl stop ${init_selector} && launchctl start ${init_selector}",
+      'systemd'          => "systemctl reload-or-restart ${init_selector}",
+      /^(upstart|none)$/ => "service ${init_selector} reload",
+      /^(sysv|sles)$/    => "/etc/init.d/${init_selector} reload",
+      'launchd'          => "launchctl stop ${init_selector} && launchctl start ${init_selector}",
     }
 
     exec { 'prometheus-reload':

--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -33,7 +32,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -41,7 +39,6 @@
     {
       "operatingsystem": "VirtuozzoLinux",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },

--- a/spec/classes/bird_exporter_spec.rb
+++ b/spec/classes/bird_exporter_spec.rb
@@ -19,11 +19,7 @@ describe 'prometheus::bird_exporter' do
         it { is_expected.to contain_file('/opt/bird_exporter-1.2.4.linux-amd64/bird_exporter') }
         it { is_expected.to contain_file('/opt/bird_exporter-1.2.4.linux-amd64').with_ensure('directory') }
 
-        if facts[:os]['release']['major'].to_i == 6
-          it { is_expected.to contain_file('/etc/init.d/bird_exporter') }
-        else
-          it { is_expected.to contain_systemd__unit_file('bird_exporter.service') }
-        end
+        it { is_expected.to contain_systemd__unit_file('bird_exporter.service') }
 
         if facts[:os]['family'] == 'RedHat'
           it { is_expected.not_to contain_file('/etc/sysconfig/bird_exporter') }

--- a/spec/classes/node_exporter_spec.rb
+++ b/spec/classes/node_exporter_spec.rb
@@ -27,10 +27,6 @@ describe 'prometheus::node_exporter' do
           it { is_expected.to contain_file('/usr/local/bin/node_exporter') }
         end
 
-        if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'].to_i < 7
-          it { is_expected.to contain_file('/etc/init.d/node_exporter') }
-        end
-
         if facts[:os]['family'] == 'RedHat'
           it { is_expected.not_to contain_file('/etc/sysconfig/bird_exporter') }
         else

--- a/spec/classes/prometheus_spec.rb
+++ b/spec/classes/prometheus_spec.rb
@@ -106,18 +106,7 @@ describe 'prometheus' do
             )
           }
 
-          if ['centos-6-x86_64', 'redhat-6-x86_64'].include?(os)
-            # init_style = 'sysv'
-
-            it {
-              is_expected.to contain_file('/etc/init.d/prometheus').with(
-                'mode'   => '0555',
-                'owner'  => 'root',
-                'group'  => 'root',
-                'content' => File.read(fixtures('files', "prometheus#{prom_major}.sysv"))
-              )
-            }
-          elsif ['centos-7-x86_64', 'centos-8-x86_64', 'debian-9-x86_64', 'debian-10-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'ubuntu-16.04-x86_64', 'ubuntu-18.04-x86_64', 'virtuozzolinux-7-x86_64'].include?(os)
+          if ['centos-7-x86_64', 'centos-8-x86_64', 'debian-9-x86_64', 'debian-10-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'ubuntu-16.04-x86_64', 'ubuntu-18.04-x86_64', 'virtuozzolinux-7-x86_64'].include?(os)
             # 'archlinux-5-x86_64' got removed from that list. It has systemd, but we use the repo packages and their shipped unit files.
             # init_style = 'systemd'
 

--- a/spec/defines/daemon_spec.rb
+++ b/spec/defines/daemon_spec.rb
@@ -91,32 +91,7 @@ describe 'prometheus::daemon' do
             it { is_expected.to contain_archive("/tmp/smurf_exporter-#{parameters[:version]}.tar.gz").with_extract_path('/opt/foo') }
           end
 
-          # prometheus::config
-          if ['centos-6-x86_64', 'redhat-6-x86_64'].include?(os)
-            # init_style = 'sysv'
-
-            it {
-              is_expected.to contain_file('/etc/init.d/smurf_exporter').with(
-                'mode'    => '0555',
-                'owner'   => 'root',
-                'group'   => 'root'
-              ).with_content(
-                %r{daemon --user=smurf_user \\\n            --pidfile="\$PID_FILE" \\\n            "'\$DAEMON' '' >> '\$LOG_FILE' 2>&1 &"}
-              )
-            }
-
-            context 'with overidden bin_name' do
-              let(:params) do
-                parameters.merge(bin_name: 'notsmurf_exporter')
-              end
-
-              it {
-                is_expected.to contain_file('/etc/init.d/smurf_exporter').with_content(
-                  %r{DAEMON=/usr/local/bin/notsmurf_exporter}
-                )
-              }
-            end
-          elsif ['centos-7-x86_64', 'centos-8-x86_64', 'debian-9-x86_64', 'debian-10-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'ubuntu-16.04-x86_64', 'ubuntu-18.04-x86_64', 'archlinux-5-x86_64', 'virtuozzolinux-7-x86_64'].include?(os)
+          if ['centos-7-x86_64', 'centos-8-x86_64', 'debian-9-x86_64', 'debian-10-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'ubuntu-16.04-x86_64', 'ubuntu-18.04-x86_64', 'archlinux-5-x86_64', 'virtuozzolinux-7-x86_64'].include?(os)
             # init_style = 'systemd'
 
             it { is_expected.to contain_class('systemd') }

--- a/spec/spec_helper_methods.rb
+++ b/spec/spec_helper_methods.rb
@@ -14,13 +14,6 @@ def os_specific_facts(facts)
       { service_provider: 'systemd' }
     end
   when 'RedHat'
-    case facts[:os]['release']['major']
-    when '6'
-      { service_provider: 'sysv' }
-    when '7'
-      { service_provider: 'systemd' }
-    when '8'
-      { service_provider: 'systemd' }
-    end
+    { service_provider: 'systemd' }
   end
 end

--- a/types/initstyle.pp
+++ b/types/initstyle.pp
@@ -1,6 +1,5 @@
 type Prometheus::Initstyle = Enum[
   'sysv',
-  'redhat',
   'systemd',
   'sles',
   'launchd',


### PR DESCRIPTION
CentOS 6 is EOL. They already purged some files from their mirrors so
the acceptance tests do not pass anymore.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
