### PR TITLE
Purge collected configs based on $purge_config_dir

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -222,7 +222,7 @@ class prometheus::config {
   file { "${prometheus::config_dir}/file_sd_config.d":
     ensure  => directory,
     group   => $prometheus::server::group,
-    purge   => true,
+    purge   => $prometheus::purge_config_dir,
     recurse => true,
     notify  => Class['prometheus::service_reload'], # After purging, a reload is needed
   }


### PR DESCRIPTION
#### Pull Request (PR) description

This uses the `$purge_config_dir` variable for the collected `file_sd_config.d` entries as well, leading to consistent behaviour.

I do not expect there to be any breaking impact; the height would be people relying on keeping their non-standard files in `$config_dir` but not in `$config_dir/file_sd_config.d`.

#### This Pull Request (PR) fixes the following issues

Fixes #460 