### PR TITLE
remove duplicate exported scrape job name in file name

### DIFF
--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -250,7 +250,7 @@ define prometheus::daemon (
       fail('must set $scrape_port on exported daemon')
     }
 
-    @@prometheus::scrape_job { "${scrape_job_name}_${scrape_host}_${scrape_port}":
+    @@prometheus::scrape_job { "${scrape_host}_${scrape_port}":
       job_name => $scrape_job_name,
       targets  => ["${scrape_host}:${scrape_port}"],
       labels   => $scrape_job_labels,

--- a/spec/defines/daemon_spec.rb
+++ b/spec/defines/daemon_spec.rb
@@ -153,7 +153,7 @@ describe 'prometheus::daemon' do
             subject { exported_resources }
 
             it {
-              is_expected.to contain_prometheus__scrape_job('smurf_exporter_localhost_1234').with(
+              is_expected.to contain_prometheus__scrape_job('localhost_1234').with(
                 'labels' => {
                   'alias' => 'localhost'
                 }
@@ -185,7 +185,7 @@ describe 'prometheus::daemon' do
           subject { exported_resources }
 
           it {
-            is_expected.to contain_prometheus__scrape_job('smurf_exporter_localhost_1234').with(
+            is_expected.to contain_prometheus__scrape_job('localhost_1234').with(
               'labels' => {
                 'instance' => 'smurf1'
               }


### PR DESCRIPTION
Between #435 and #450, the file path for the exported job names was
changed to use underscores instead of colons. That's fine, except
that, in the end, the actual filename had a superfluous
`$scrape_job_name` parameter added. Taking the Apache exporter as an
example, I used to have:

    /etc/prometheus/file_sd_config.d/apache_perdulce.torproject.org:9117.yaml

I now have:

    /etc/prometheus/file_sd_config.d/apache_apache_eugeni.torproject.org_9117.yaml

That still works of course: the old file is removed and the new one is
picked up, but it does look silly and needlessly redundant.

I should note that this might mean some clashes between jobs, if the
same host/port combination is scraped by multiple jobs on the
Prometheus server. I have no idea if that's a valid use case, but I
should point out that, if it is, then the `job_name` parameter should
just be removed and instead the resource name should forcibly include
the job name, instead of enforcing this weird duplication.

In other words, maybe this is also an API breaking change that should
warrant a changelog entry, but I'll let my co-maintainers be the
judges of this.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
