### PR TITLE
deploy env_file_path on server

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -158,6 +158,16 @@ class prometheus::config {
     default => undef,
   }
 
+  if $prometheus::env_file_path {
+    file { "${prometheus::env_file_path}/prometheus":
+      mode    => '0644',
+      owner   => 'root',
+      group   => '0', # Darwin uses wheel
+      content => "ARGS='${join(sort($daemon_flags), ' ')}'\n",
+      notify  => $notify,
+    }
+  }
+
   case $prometheus::server::init_style { # lint:ignore:case_without_default
     'upstart': {
       file { '/etc/init/prometheus.conf':


### PR DESCRIPTION
Without this change, when the install_method is set to `package` and
init_style is set to `none`, the various `prometheus::server` settings
will never do anything because we stop touching the systemd config
file.

By default, the Debian systemd.service file has this entry:

    EnvironmentFile=/etc/default/prometheus
    ExecStart=/usr/bin/prometheus $ARGS

... which makes it use the ARGS define in the "default" config
file. This is a hack, but it works on our side in production.

Closes: #323

This is a subset of #303, which should hopefully pass tests and be more manageable.

See also #32