### PR TITLE
revert the env_vars removal for two exporters

### DIFF
--- a/manifests/blackbox_exporter.pp
+++ b/manifests/blackbox_exporter.pp
@@ -15,6 +15,8 @@
 #  Extra groups to add the binary user to
 # @param extra_options
 #  Extra options added to the startup command
+# @param env_vars
+#  The environment variable to pass to the daemon
 # @param group
 #  Group under which the binary is running
 # @param init_style
@@ -83,6 +85,7 @@ class prometheus::blackbox_exporter (
   Boolean $manage_user                    = true,
   String[1] $os                           = downcase($facts['kernel']),
   String $extra_options                   = '',
+  Hash[String, Scalar] $env_vars          = {},
   Optional[String] $download_url          = undef,
   String[1] $config_mode                  = $prometheus::config_mode,
   String[1] $arch                         = $prometheus::real_arch,
@@ -136,6 +139,7 @@ class prometheus::blackbox_exporter (
     manage_group       => $manage_group,
     options            => $options,
     init_style         => $init_style,
+    env_vars           => $env_vars,
     service_ensure     => $service_ensure,
     service_enable     => $service_enable,
     manage_service     => $manage_service,

--- a/manifests/postfix_exporter.pp
+++ b/manifests/postfix_exporter.pp
@@ -40,6 +40,8 @@
 #   Whether to enable the service from puppet.
 # @param extra_options
 #   Extra options added to the startup command. Override these if you want to monitor a logfile instead of systemd.
+# @param env_vars
+#  The environment variable to pass to the daemon
 # @param restart_on_change
 #   Should puppet restart the service on configuration change?
 # @param export_scrape_job
@@ -79,6 +81,7 @@ class prometheus::postfix_exporter (
   # exporter configuration
   String  $extra_options     = '--systemd.enable --systemd.unit=\'postfix.service\' --postfix.logfile_path=\'\'',
   Boolean $restart_on_change = true,
+  Hash[String, Scalar] $env_vars = {},
 
   # scrape job configuration
   Boolean        $export_scrape_job = false,
@@ -113,6 +116,7 @@ class prometheus::postfix_exporter (
     manage_group       => $manage_group,
     options            => $extra_options,
     init_style         => $init_style,
+    env_vars           => $env_vars,
     service_ensure     => $service_ensure,
     service_enable     => $service_enable,
     manage_service     => $manage_service,


### PR DESCRIPTION
We need the env_vars for the Debian package to work properly. In
Debian-land, the systemd `.service` file gets its parameters from the
EnvironmentFile, which we deploy through the `env_vars` here.

Yes, it's backwards, and no, it's not great because it doesn't
actually use the `options` stuff, but at least it works.

This is necessary to have those exporters be able to accept options
when using init_style=none and install_method=package.

This is a split off of #303 which should at least pass
tests (/probably/ because the `install_method=package` code path is
basically untested).

See also #32