### PR TITLE
pass options through env_vars if no control over init files

### DIFF
--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -214,7 +214,7 @@ define prometheus::daemon (
     'none': {}
   }
 
-  if $init_style == 'none' and $install_method == 'package' {
+  if $init_style == 'none' and $install_method == 'package' and !$options.empty {
     $env_vars_merged = $env_vars + {
       'ARGS' => $options,
     }
@@ -222,7 +222,11 @@ define prometheus::daemon (
     $env_vars_merged = $env_vars
   }
 
-  unless $env_vars_merged.empty {
+  if $env_vars_merged.empty {
+    file { "${env_file_path}/${name}":
+      ensure => absent,
+    }
+  } else {
     file { "${env_file_path}/${name}":
       mode    => '0644',
       owner   => 'root',

--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -214,7 +214,7 @@ define prometheus::daemon (
     'none': {}
   }
 
-  if $init_style == 'none' and $install_method == 'package' and !$options.empty {
+  if $init_style == 'none' and $install_method == 'package' and !empty($options) {
     $env_vars_merged = $env_vars + {
       'ARGS' => $options,
     }
@@ -222,7 +222,7 @@ define prometheus::daemon (
     $env_vars_merged = $env_vars
   }
 
-  if $env_vars_merged.empty {
+  if empty($env_vars_merged) {
     file { "${env_file_path}/${name}":
       ensure => absent,
     }

--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -214,7 +214,15 @@ define prometheus::daemon (
     'none': {}
   }
 
-  unless $env_vars.empty {
+  if $init_style == 'none' and $install_method == 'package' {
+    $env_vars_merged = $env_vars + {
+      'ARGS' => $options,
+    }
+  } else {
+    $env_vars_merged = $env_vars
+  }
+
+  unless $env_vars_merged.empty {
     file { "${env_file_path}/${name}":
       mode    => '0644',
       owner   => 'root',
@@ -222,7 +230,7 @@ define prometheus::daemon (
       content => epp(
         'prometheus/daemon.env.epp',
         {
-          'env_vars' => $env_vars,
+          'env_vars' => $env_vars_merged,
         }
       ),
       notify  => $notify_service,

--- a/spec/classes/bird_exporter_spec.rb
+++ b/spec/classes/bird_exporter_spec.rb
@@ -23,10 +23,6 @@ describe 'prometheus::bird_exporter' do
 
         if facts[:os]['family'] == 'RedHat'
           it { is_expected.not_to contain_file('/etc/sysconfig/bird_exporter') }
-        elsif facts[:os]['family'] == 'Archlinux'
-          # by default the ARGS array gets passed through here
-          it { is_expected.to contain_file('/etc/default/bird_exporter') }
-          it { is_expected.not_to contain_file('/etc/sysconfig/bird_exporter') }
         else
           it { is_expected.not_to contain_file('/etc/default/bird_exporter') }
         end

--- a/spec/classes/bird_exporter_spec.rb
+++ b/spec/classes/bird_exporter_spec.rb
@@ -23,6 +23,10 @@ describe 'prometheus::bird_exporter' do
 
         if facts[:os]['family'] == 'RedHat'
           it { is_expected.not_to contain_file('/etc/sysconfig/bird_exporter') }
+        elsif facts[:os]['family'] == 'Archlinux'
+          # by default the ARGS array gets passed through here
+          it { is_expected.to contain_file('/etc/default/bird_exporter') }
+          it { is_expected.not_to contain_file('/etc/sysconfig/bird_exporter') }
         else
           it { is_expected.not_to contain_file('/etc/default/bird_exporter') }
         end

--- a/spec/classes/node_exporter_spec.rb
+++ b/spec/classes/node_exporter_spec.rb
@@ -28,9 +28,9 @@ describe 'prometheus::node_exporter' do
         end
 
         if facts[:os]['family'] == 'RedHat'
-          it { is_expected.not_to contain_file('/etc/sysconfig/bird_exporter') }
+          it { is_expected.not_to contain_file('/etc/sysconfig/node_exporter') }
         else
-          it { is_expected.not_to contain_file('/etc/default/bird_exporter') }
+          it { is_expected.not_to contain_file('/etc/default/node_exporter') }
         end
       end
 

--- a/spec/classes/node_exporter_spec.rb
+++ b/spec/classes/node_exporter_spec.rb
@@ -29,8 +29,12 @@ describe 'prometheus::node_exporter' do
 
         if facts[:os]['family'] == 'RedHat'
           it { is_expected.not_to contain_file('/etc/sysconfig/node_exporter') }
+        elsif facts[:os]['name'] == 'Archlinux'
+          it { is_expected.to contain_file('/etc/default/node_exporter') }
+          it { is_expected.not_to contain_file('/etc/sysconfig/node_exporter') }
         else
           it { is_expected.not_to contain_file('/etc/default/node_exporter') }
+          it { is_expected.not_to contain_file('/etc/sysconfig/node_exporter') }
         end
       end
 


### PR DESCRIPTION
The logic here is that if init_style is non, then we have no control
over the init files themselves *except* through the environment
file.

Typically, the way this works is there is a ARGS environment variable
that gets sucked into the systemd unit file (or the sysv init file).

followup to #32, replacement for #528, based on top of #529