### PR TITLE
check node exporter config file instead of bird in node exporter test

### DIFF
--- a/spec/classes/node_exporter_spec.rb
+++ b/spec/classes/node_exporter_spec.rb
@@ -28,9 +28,9 @@ describe 'prometheus::node_exporter' do
         end
 
         if facts[:os]['family'] == 'RedHat'
-          it { is_expected.not_to contain_file('/etc/sysconfig/bird_exporter') }
+          it { is_expected.not_to contain_file('/etc/sysconfig/node_exporter') }
         else
-          it { is_expected.not_to contain_file('/etc/default/bird_exporter') }
+          it { is_expected.not_to contain_file('/etc/default/node_exporter') }
         end
       end
 


### PR DESCRIPTION
For some reason, the node exporter unit test checks for the
inexistence of the bird_exporter config file. Naturally, it doesn't
find it (why would it?).

I suspect this is an artifact of a copy-paste from the bird exporter,
and what was really meant here was to check for the inexistence of the
node exporter config file.

I found this after getting a test failure #530. I couldn't understand why I wasn't getting the same error in the node exporter. Now I know.

Hopefully this is a noop.