### PR TITLE
fix default scrape_uri in apache_exporter

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -319,7 +319,7 @@ prometheus::collectd_exporter::service_name: 'collectd_exporter'
 prometheus::collectd_exporter::user: 'collectd-exporter'
 prometheus::collectd_exporter::version: '0.5.0'
 prometheus::collectd_exporter::options: ''
-prometheus::apache_exporter::scrape_uri: 'http://localhost/server-status?auto'
+prometheus::apache_exporter::scrape_uri: 'http://localhost/server-status/?auto'
 prometheus::apache_exporter::download_extension: 'tar.gz'
 prometheus::apache_exporter::download_url_base: 'https://github.com/Lusitaniae/apache_exporter/releases'
 prometheus::apache_exporter::extra_groups: []

--- a/spec/acceptance/apache_exporter_spec.rb
+++ b/spec/acceptance/apache_exporter_spec.rb
@@ -16,7 +16,7 @@ describe 'prometheus apache exporter' do
       it { is_expected.to be_listening.with('tcp6') }
     end
     describe process('apache_exporter') do
-      its(:args) { is_expected.to match %r{\ --scrape_uri http://localhost/server-status\?auto} }
+      its(:args) { is_expected.to match %r{\ --scrape_uri http://localhost/server-status/\?auto} }
     end
   end
 
@@ -33,7 +33,7 @@ describe 'prometheus apache exporter' do
     end
 
     describe process('apache_exporter') do
-      its(:args) { is_expected.to match %r{\ -scrape_uri http://localhost/server-status\?auto} }
+      its(:args) { is_expected.to match %r{\ -scrape_uri http://localhost/server-status/\?auto} }
     end
 
     describe port(9117) do
@@ -51,7 +51,7 @@ describe 'prometheus apache exporter' do
     end
 
     describe process('apache_exporter') do
-      its(:args) { is_expected.to match %r{\ -scrape_uri http://localhost/server-status\?auto} }
+      its(:args) { is_expected.to match %r{\ -scrape_uri http://localhost/server-status/\?auto} }
     end
 
     describe port(9117) do

--- a/spec/classes/apache_exporter_spec.rb
+++ b/spec/classes/apache_exporter_spec.rb
@@ -43,7 +43,7 @@ describe 'prometheus::apache_exporter' do
           it { is_expected.to contain_class('prometheus') }
           it { is_expected.to contain_group('apache-exporter') }
           it { is_expected.to contain_user('apache-exporter') }
-          it { is_expected.to contain_prometheus__daemon('apache_exporter').with('options' => '-scrape_uri "http://localhost/server-status?auto" ') }
+          it { is_expected.to contain_prometheus__daemon('apache_exporter').with('options' => '-scrape_uri "http://localhost/server-status/?auto" ') }
           it { is_expected.to contain_service('apache_exporter') }
         end
         describe 'install correct binary' do
@@ -54,7 +54,7 @@ describe 'prometheus::apache_exporter' do
       context 'with version, scrape_uri and extra options specified' do
         let(:params) do
           {
-            scrape_uri: 'http://127.0.0.1/server-status?auto',
+            scrape_uri: 'http://127.0.0.1/server-status/?auto',
             extra_options: '-test',
             version: '0.4.0',
             arch: 'amd64',
@@ -71,7 +71,7 @@ describe 'prometheus::apache_exporter' do
           it { is_expected.to contain_class('prometheus') }
           it { is_expected.to contain_group('apache-exporter') }
           it { is_expected.to contain_user('apache-exporter') }
-          it { is_expected.to contain_prometheus__daemon('apache_exporter').with('options' => '-scrape_uri "http://127.0.0.1/server-status?auto" -test') }
+          it { is_expected.to contain_prometheus__daemon('apache_exporter').with('options' => '-scrape_uri "http://127.0.0.1/server-status/?auto" -test') }
           it { is_expected.to contain_service('apache_exporter') }
         end
         describe 'install correct binary' do
@@ -82,7 +82,7 @@ describe 'prometheus::apache_exporter' do
       context 'with version 0.8.0+' do
         let(:params) do
           {
-            scrape_uri: 'http://127.0.0.1/server-status?auto',
+            scrape_uri: 'http://127.0.0.1/server-status/?auto',
             extra_options: '--test',
             version: '0.8.0',
             arch: 'amd64',
@@ -93,7 +93,7 @@ describe 'prometheus::apache_exporter' do
         end
 
         describe 'uses argument prefix correctly' do
-          it { is_expected.to contain_prometheus__daemon('apache_exporter').with('options' => '--scrape_uri "http://127.0.0.1/server-status?auto" --test') }
+          it { is_expected.to contain_prometheus__daemon('apache_exporter').with('options' => '--scrape_uri "http://127.0.0.1/server-status/?auto" --test') }
         end
       end
     end


### PR DESCRIPTION
The default scrape_uri in the prometheus apache exporter actually has
a trailing slash. This matters because somehow, here, the address
without a trailing slash fails to scrape.

The default is documented here:

https://github.com/Lusitaniae/apache_exporter/blob/83d8e4d2003eaa85c754d12c110e0a7757e78143/apache_exporter.go#L30

Unit tests adjusted to match change.
