### PR TITLE
allow to set env_vars for blackbox exporter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2581,6 +2581,7 @@ The following parameters are available in the `prometheus::blackbox_exporter` cl
 * [`download_url_base`](#-prometheus--blackbox_exporter--download_url_base)
 * [`extra_groups`](#-prometheus--blackbox_exporter--extra_groups)
 * [`extra_options`](#-prometheus--blackbox_exporter--extra_options)
+* [`env_vars`](#-prometheus--blackbox_exporter--env_vars)
 * [`group`](#-prometheus--blackbox_exporter--group)
 * [`init_style`](#-prometheus--blackbox_exporter--init_style)
 * [`install_method`](#-prometheus--blackbox_exporter--install_method)
@@ -2671,6 +2672,14 @@ Data type: `Optional[String[1]]`
 Extra options added to the startup command
 
 Default value: `undef`
+
+##### <a name="-prometheus--blackbox_exporter--env_vars"></a>`env_vars`
+
+Data type: `Hash[String[1], Scalar]`
+
+env_vars added to the unit file (key:value)
+
+Default value: `{}`
 
 ##### <a name="-prometheus--blackbox_exporter--group"></a>`group`
 

--- a/manifests/blackbox_exporter.pp
+++ b/manifests/blackbox_exporter.pp
@@ -15,6 +15,8 @@
 #  Extra groups to add the binary user to
 # @param extra_options
 #  Extra options added to the startup command
+# @param env_vars
+#  env_vars added to the unit file (key:value)
 # @param group
 #  Group under which the binary is running
 # @param init_style
@@ -101,6 +103,7 @@ class prometheus::blackbox_exporter (
   Boolean $manage_user                                       = true,
   String[1] $os                                              = downcase($facts['kernel']),
   Optional[String[1]] $extra_options                         = undef,
+  Hash[String[1], Scalar] $env_vars                          = {},
   Optional[Prometheus::Uri] $download_url                    = undef,
   String[1] $config_mode                                     = $prometheus::config_mode,
   String[1] $arch                                            = $prometheus::real_arch,
@@ -184,6 +187,7 @@ class prometheus::blackbox_exporter (
     service_ensure     => $service_ensure,
     service_enable     => $service_enable,
     manage_service     => $manage_service,
+    env_vars           => $env_vars,
     export_scrape_job  => $export_scrape_job,
     scrape_host        => $scrape_host,
     scrape_port        => $scrape_port,

--- a/spec/classes/blackbox_exporter_spec.rb
+++ b/spec/classes/blackbox_exporter_spec.rb
@@ -58,6 +58,19 @@ describe 'prometheus::blackbox_exporter' do
           it { is_expected.to contain_file('/etc/blackbox_exporter_web-config.yml').with(ensure: 'file') }
           it { is_expected.to contain_prometheus__daemon('blackbox_exporter').with(options: '--config.file=/etc/blackbox-exporter.yaml --web.config.file=/etc/blackbox_exporter_web-config.yml') }
         end
+
+        context 'with env_vars set' do
+          let(:params) do
+            {
+              env_vars: {
+                'FOO' => 'BAR'
+              }
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_prometheus__daemon('blackbox_exporter').with(env_vars: { 'FOO' => 'BAR' }) }
+        end
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description
This PR is intended to allow environment variables to be set for the blackbox exporter.
This can be useful, for example, if you want to use `SSL_CERT_FILE`.

#### This Pull Request (PR) fixes the following issues
Fixes #535 
