### PR TITLE
fix syntax of altermanager::receivers

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -49,7 +49,7 @@ prometheus::alertmanager::package_ensure: 'latest'
 prometheus::alertmanager::package_name: 'alertmanager'
 prometheus::alertmanager::receivers:
   - 'name': 'Admin'
-  - 'email_configs':
+    'email_configs':
     - 'to': 'root@localhost'
 prometheus::alertmanager::route:
   'group_by':


### PR DESCRIPTION
The "name" block is an object. This actually matches the example in
prometheus::alertmanager's documentation:

```
# @param receivers
#  An array of receivers.
#  Example (also default):
#  prometheus::alertmanager::receivers:
#  - name: 'Admin'
#    email_configs:
#      - to: 'root@localhost'
```

I wonder why unit tests didn't catch those...?

Closes: #539
