### PR TITLE
fix quoting in apache exporter

### DIFF
--- a/manifests/apache_exporter.pp
+++ b/manifests/apache_exporter.pp
@@ -89,9 +89,9 @@ class prometheus::apache_exporter (
   }
 
   if versioncmp($version, '0.8.0') < 0 {
-    $options = "-scrape_uri \"${scrape_uri}\" ${extra_options}"
+    $options = "-scrape_uri '${scrape_uri}' ${extra_options}"
   } else {
-    $options = "--scrape_uri \"${scrape_uri}\" ${extra_options}"
+    $options = "--scrape_uri '${scrape_uri}' ${extra_options}"
   }
 
   prometheus::daemon { $service_name:

--- a/spec/classes/apache_exporter_spec.rb
+++ b/spec/classes/apache_exporter_spec.rb
@@ -43,7 +43,7 @@ describe 'prometheus::apache_exporter' do
           it { is_expected.to contain_class('prometheus') }
           it { is_expected.to contain_group('apache-exporter') }
           it { is_expected.to contain_user('apache-exporter') }
-          it { is_expected.to contain_prometheus__daemon('apache_exporter').with('options' => '-scrape_uri "http://localhost/server-status/?auto" ') }
+          it { is_expected.to contain_prometheus__daemon('apache_exporter').with('options' => "-scrape_uri 'http://localhost/server-status/?auto' ") }
           it { is_expected.to contain_service('apache_exporter') }
         end
         describe 'install correct binary' do
@@ -71,7 +71,7 @@ describe 'prometheus::apache_exporter' do
           it { is_expected.to contain_class('prometheus') }
           it { is_expected.to contain_group('apache-exporter') }
           it { is_expected.to contain_user('apache-exporter') }
-          it { is_expected.to contain_prometheus__daemon('apache_exporter').with('options' => '-scrape_uri "http://127.0.0.1/server-status/?auto" -test') }
+          it { is_expected.to contain_prometheus__daemon('apache_exporter').with('options' => "-scrape_uri 'http://127.0.0.1/server-status/?auto' -test") }
           it { is_expected.to contain_service('apache_exporter') }
         end
         describe 'install correct binary' do
@@ -93,7 +93,7 @@ describe 'prometheus::apache_exporter' do
         end
 
         describe 'uses argument prefix correctly' do
-          it { is_expected.to contain_prometheus__daemon('apache_exporter').with('options' => '--scrape_uri "http://127.0.0.1/server-status/?auto" --test') }
+          it { is_expected.to contain_prometheus__daemon('apache_exporter').with('options' => "--scrape_uri 'http://127.0.0.1/server-status/?auto' --test") }
         end
       end
     end


### PR DESCRIPTION
When using the Debian package to deploy the exporter, like this:

    class { 'prometheus::apache_exporter':
      package_ensure    => $package_ensure,
      service_ensure    => $service_ensure,
      export_scrape_job => true,
      install_method    => 'package',
      init_style        => 'none',
      user              => 'prometheus',
      group             => 'prometheus',
      package_name      => 'prometheus-apache-exporter',
      service_name      => 'prometheus-apache-exporter',
    }

... we end up with the options in
`/etc/default/prometheus-apache-exporter`. It *looks* like it will be
fine: the systemd unit file sucks those in as an environment variable,
and then passes that along to the process. But look closely at what
actually gets generated:

    ARGS="--scrape_uri "http://localhost/server-status/?auto" "

This kind of looks okay if you squint a little, but it actually turns
out it's really, really wrong. What it ends up doing is basically
this:

        apache-exporter --scrape_uri "http://localhost/server-status/?auto "

Notice the trailing slash here. When the exporter makes the request to
Apache next, it ends up doing this query:

    GET /server-status/?auto  HTTP/1.1
    [...]

At first glance, this looks fine: just a regular HTTP request, right?
But if you look more closely, there are *two* spaces before the
HTTP/1.1 Apache doesn't like that, *at all*. It doesn't even wait for
the rest of the headings to come in, it immediately answers with:

    HTTP/1.1 400 Bad Request

... and closes the socket. That, naturally, makes the exporter quite
unhappy and totally unable to collect metrics.

By using single quotes, we work around the quoting issue and correctly
pass the right URL down to the exporter, at least in Debian.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
