### PR TITLE
Allow default scrape_configs to be optional

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -104,6 +104,7 @@ prometheus::global_config:
   'external_labels':
     'monitor': 'master'
 prometheus::group: 'prometheus'
+prometheus::include_default_scrape_configs: true
 prometheus::localstorage: '/var/lib/prometheus'
 prometheus::manage_config: true
 prometheus::mesos_exporter::server_type: 'master'
@@ -219,15 +220,7 @@ prometheus::beanstalkd_exporter::config: '/etc/beanstalkd-exporter.conf'
 prometheus::package_ensure: 'latest'
 prometheus::package_name: 'prometheus'
 prometheus::rule_files: []
-prometheus::scrape_configs:
-  - 'job_name': 'prometheus'
-    'scrape_interval': '10s'
-    'scrape_timeout': '10s'
-    'static_configs':
-      - 'targets':
-        - 'localhost:9090'
-        'labels':
-          'alias': 'Prometheus'
+prometheus::scrape_configs: []
 prometheus::remote_read_configs: []
 prometheus::remote_write_configs: []
 prometheus::shared_dir: '/usr/local/share/prometheus'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,6 +6,27 @@ class prometheus::config {
 
   $prometheus_v2 = versioncmp($prometheus::server::version, '2.0.0') >= 0
 
+  if $prometheus::server::include_default_scrape_configs {
+    $default_scrape_configs = [
+      {
+        'job_name'        => 'prometheus',
+        'scrape_interval' => '10s',
+        'scrape_timeout'  => '10s',
+        'static_configs'  => [
+          {
+            'targets' => ['localhost:9090'],
+            'labels'  => {
+              'alias' => 'Prometheus',
+            },
+          },
+        ],
+      }
+    ]
+    $scrape_configs = $default_scrape_configs + $prometheus::server::scrape_configs
+  } else {
+    $scrape_configs = $prometheus::server::scrape_configs
+  }
+
   # Validation
   $invalid_args = if $prometheus_v2 {
     {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,8 @@
 #  Prometheus rule files
 # @param scrape_configs
 #  Prometheus scrape configs
+# @param include_default_scrape_configs
+#  Include the module default scrape configs
 # @param remote_read_configs
 #  Prometheus remote_read config to scrape prometheus 1.8+ instances
 # @param remote_write_configs
@@ -298,6 +300,7 @@ class prometheus (
   Boolean $purge_config_dir                                                     = true,
   Boolean $manage_user                                                          = true,
   Boolean $config_show_diff                                                     = true,
+  Boolean $include_default_scrape_configs                                       = true,
 ) {
   case $arch {
     'x86_64', 'amd64': { $real_arch = 'amd64' }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -19,6 +19,7 @@ class prometheus::server (
   Hash $global_config                                                           = $prometheus::global_config,
   Array $rule_files                                                             = $prometheus::rule_files,
   Array $scrape_configs                                                         = $prometheus::scrape_configs,
+  Boolean $include_default_scrape_configs                                       = $prometheus::include_default_scrape_configs,
   Array $remote_read_configs                                                    = $prometheus::remote_read_configs,
   Array $remote_write_configs                                                   = $prometheus::remote_write_configs,
   Variant[Array,Hash] $alerts                                                   = $prometheus::alerts,

--- a/spec/acceptance/prometheus_server_spec.rb
+++ b/spec/acceptance/prometheus_server_spec.rb
@@ -99,19 +99,6 @@ describe 'prometheus server basics' do
           }
         ]
       },
-      scrape_configs => [
-        {
-          'job_name' => 'prometheus',
-          'scrape_interval' => '10s',
-          'scrape_timeout'  => '10s',
-          'static_configs'  => [
-            {
-              'targets' => [ 'localhost:9090' ],
-              'labels'  => { 'alias' => 'Prometheus' }
-            }
-          ]
-        }
-      ]
     }
     EOS
       # Run it twice and test for idempotency
@@ -155,19 +142,6 @@ describe 'prometheus server basics' do
           }
         ]
       },
-      scrape_configs => [
-        {
-          'job_name' => 'prometheus',
-          'scrape_interval' => '10s',
-          'scrape_timeout'  => '10s',
-          'static_configs'  => [
-            {
-              'targets' => [ 'localhost:9090' ],
-              'labels'  => { 'alias' => 'Prometheus' }
-            }
-          ]
-        }
-      ]
     }
     EOS
       # Run it twice and test for idempotency

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -24,6 +24,22 @@ describe 'prometheus::server' do
           )
         }
 
+        it {
+          content = catalogue.resource('file', 'prometheus.yaml').send(:parameters)[:content]
+          expect(content).to include('job_name: prometheus')
+        }
+
+        context 'without default scrape configs' do
+          let(:params) do
+            super().merge('include_default_scrape_configs' => false)
+          end
+
+          it {
+            content = catalogue.resource('file', 'prometheus.yaml').send(:parameters)[:content]
+            expect(content).not_to include('job_name: prometheus')
+          }
+        end
+
         describe 'max_open_files' do
           context 'by default' do
             it {

--- a/templates/prometheus.yaml.erb
+++ b/templates/prometheus.yaml.erb
@@ -1,7 +1,7 @@
 <% require 'yaml' -%>
 <% global_config = scope.lookupvar('::prometheus::server::global_config') -%>
 <% rule_files = scope.lookupvar('::prometheus::server::_rule_files') -%>
-<% scrape_configs = scope.lookupvar('::prometheus::server::scrape_configs') -%>
+<% scrape_configs = scope.lookupvar('::prometheus::config::scrape_configs') -%>
 <% remote_read_configs = scope.lookupvar('::prometheus::server::remote_read_configs') -%>
 <% remote_write_configs = scope.lookupvar('::prometheus::server::remote_write_configs') -%>
 <% full_config = {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Allow the default scrape configs for Prometheus to be disabled.

In my environment I will make use of this in Hiera

```
lookup_options:
  prometheus::scrape_configs:
    merge: unique
```
With the above and current module behavior, I would be forced to use this module's default scrape config for Prometheus which I don't want because we define the Prometheus scrape config differently.  This pull request allows for not including that default scrape config so that something like Hiera merging isn't forced to use this module's scrape config.