### PR TITLE
Support mute_time_intervals for Alertmanager

### DIFF
--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -107,6 +107,7 @@ class prometheus::alertmanager (
   Array $templates,
   String[1] $user,
   String[1] $version,
+  Hash $mute_time_intervals,
   Boolean $service_enable                 = true,
   Stdlib::Ensure::Service $service_ensure = 'running',
   String[1] $service_name                 = 'alertmanager',

--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -107,7 +107,7 @@ class prometheus::alertmanager (
   Array $templates,
   String[1] $user,
   String[1] $version,
-  Hash $mute_time_intervals,
+  Array $mute_time_intervals,
   Boolean $service_enable                 = true,
   Stdlib::Ensure::Service $service_ensure = 'running',
   String[1] $service_name                 = 'alertmanager',

--- a/templates/alertmanager.yaml.erb
+++ b/templates/alertmanager.yaml.erb
@@ -1,8 +1,9 @@
 <% require 'yaml' -%>
 <% global = scope.lookupvar('::prometheus::alertmanager::global') -%>
+<% mute_time_intervals = scope.lookupvar('::prometheus::alertmanager::mute_time_intervals') -%>
 <% templates = scope.lookupvar('::prometheus::alertmanager::templates') -%>
 <% route = scope.lookupvar('::prometheus::alertmanager::route') -%>
 <% receivers = scope.lookupvar('::prometheus::alertmanager::receivers') -%>
 <% inhibit_rules = scope.lookupvar('::prometheus::alertmanager::inhibit_rules') -%>
-<% full_config = { 'global'=>global, 'templates'=>templates, 'route'=>route, 'receivers'=>receivers, 'inhibit_rules'=>inhibit_rules } -%>
+<% full_config = { 'global'=>global, 'templates'=>templates, 'route'=>route, 'receivers'=>receivers, 'mute_time_intervals'=>mute_time_intervals, 'inhibit_rules'=>inhibit_rules } -%>
 <%= full_config.to_yaml -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Support mute_time_intervals for Alertmanager config

#### This Pull Request (PR) fixes the following issues
If user defines something like:
```
prometheus::alertmanager::mute_time_intervals:
  - name: business_hours
    time_intervals:
      - weekdays: [ 'monday','tuesday','friday' ]
        times:
          - start_time: '16:00'
            end_time:   '23:59'
          - start_time: '00:00'
            end_time:   '07:00'
```
it won't be picked up, and therefore create a configuration error on other places "missing definition for business_hours".