### PR TITLE
Support Stdlib::Filesource as type for download urls

### DIFF
--- a/spec/type_aliases/uri_spec.rb
+++ b/spec/type_aliases/uri_spec.rb
@@ -1,12 +1,14 @@
 require 'spec_helper'
 
 describe 'Prometheus::Uri' do
-  describe 'accepts http, https, and case-sensitive aws s3 uris' do
+  describe 'accepts http, https, file paths, and case-sensitive aws s3 uris' do
     [
       'http://www.download.com',
       'HTTP://www.download.com',
       'Https://service.io',
       'https://service.io',
+      'puppet:///files/path',
+      'file:///files/path',
       's3://bucket-name/path',
       's3://bucket/path/to/file.txt'
     ].each do |value|

--- a/types/uri.pp
+++ b/types/uri.pp
@@ -1,4 +1,5 @@
 type Prometheus::Uri = Variant[
+  Stdlib::Filesource,
   Stdlib::HTTPUrl,
   Stdlib::HTTPSUrl,
   Prometheus::S3Uri,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
It's desirable to be able to specify Puppet fileserver urls (`puppet://...`) as the download_url for exporters in cases where exporter releases are mirrored internally to avoid reliance on reaching the internet.

#### This Pull Request (PR) fixes the following issues
n/a