### PR TITLE
Overhaul and fix ipmi_exporter class

### DIFF
--- a/spec/acceptance/ipmi_exporter_spec.rb
+++ b/spec/acceptance/ipmi_exporter_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper_acceptance'
+
+describe 'prometheus ipmi exporter' do
+  it 'ipmi_exporter works idempotently with no errors' do
+    # Debian does not automatically have /etc/sudoers.d during tests
+    if fact('os.family') == 'Debian'
+      on hosts, 'mkdir -p /etc/sudoers.d'
+    end
+    pp = 'include prometheus::ipmi_exporter'
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
+  end
+
+  describe service('ipmi_exporter') do
+    it { is_expected.to be_running }
+    it { is_expected.to be_enabled }
+  end
+  describe port(9290) do
+    it { is_expected.to be_listening.with('tcp6') }
+  end
+end

--- a/templates/ipmi_exporter.yaml.epp
+++ b/templates/ipmi_exporter.yaml.epp
@@ -1,0 +1,3 @@
+<%- | Hash $modules | -%>
+<%- $config = { 'modules' => $modules } -%>
+<%= to_yaml($config) -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
I'm pretty sure the original ipmi_exporter class was copied from node exporter but it's nothing like node exporter.

The ipmi_exporter does not support `--collector` or `--no-collector` flags and never has, it's entirely configured via a YAML file that defines modules

```
[tdockendorf@owens-rw01 ipmi_exporter-1.4.0.linux-amd64]$ ./ipmi_exporter --help
usage: ipmi_exporter [<flags>]

Flags:
  -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
      --config.file=CONFIG.FILE  Path to configuration file.
      --freeipmi.path=FREEIPMI.PATH  
                                 Path to FreeIPMI executables (default: rely on $PATH).
      --web.listen-address=":9290"  
                                 Address to listen on for web interface and telemetry.
      --log.level="info"         Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal]
      --log.format="logger:stderr"  
                                 Set the log target and format. Example: "logger:syslog?appname=bob&local=7" or "logger:stdout?json=true"
      --version                  Show application version.
```

Also hardcoding the wrapper scripts to `/usr/local/bin` is not great and on one of my clusters that won't work because we made the unfortunate mistake years ago to make `/usr/local` a NFS mount, so don't want Puppet writing things there.

This pull request should make the IPMI exporter class behave more like blackbox exporter which is more like how that exporter behaves.

I also added acceptance tests.