### PR TITLE
Fix IPMI exporter sudo config, add dependency on saz/sudo

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,3 +3,4 @@ fixtures:
     archive: "https://github.com/voxpupuli/puppet-archive"
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib"
     systemd: "https://github.com/camptocamp/puppet-systemd"
+    sudo: "https://github.com/saz/puppet-sudo"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ This module supports below Prometheus architectures:
 - i386
 - armv71 (Tested on raspberry pi 3)
 
+The `prometheus::ipmi_exporter` class has a dependency on [saz/sudo](https://forge.puppet.com/modules/saz/sudo) Puppet module.
+
 ## Background
 
 This module automates the install and configuration of Prometheus monitoring tool: [Prometheus web site](https://prometheus.io/docs/introduction/overview/)

--- a/manifests/ipmi_exporter.pp
+++ b/manifests/ipmi_exporter.pp
@@ -116,12 +116,9 @@ class prometheus::ipmi_exporter (
 
   if $unprivileged {
     # crazy workaround from https://github.com/soundcloud/ipmi_exporter#running-as-unprivileged-user
-
-    file { "/etc/sudoers.d/${service_name}":
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0440',
-      content => join([
+    sudo::conf { $service_name:
+      ensure         => 'present',
+      content        => join([
           "${user} ALL = NOPASSWD: /usr/sbin/ipmimonitoring",
           "${user} ALL = NOPASSWD: /usr/sbin/ipmi-sensors",
           "${user} ALL = NOPASSWD: /usr/sbin/ipmi-dcmi",
@@ -130,6 +127,7 @@ class prometheus::ipmi_exporter (
           "${user} ALL = NOPASSWD: /usr/sbin/ipmi-chassis",
           "${user} ALL = NOPASSWD: /usr/sbin/ipmi-sel",
       ], "\n"),
+      sudo_file_name => $service_name,
     }
 
     file { "${script_dir}/ipmi-sudo.sh":

--- a/spec/acceptance/ipmi_exporter_spec.rb
+++ b/spec/acceptance/ipmi_exporter_spec.rb
@@ -2,10 +2,8 @@ require 'spec_helper_acceptance'
 
 describe 'prometheus ipmi exporter' do
   it 'ipmi_exporter works idempotently with no errors' do
-    # Debian does not automatically have /etc/sudoers.d during tests
-    if fact('os.family') == 'Debian'
-      on hosts, 'mkdir -p /etc/sudoers.d'
-    end
+    # TODO: Remove --ignore-dependencies once > 6.0.0 is released with https://github.com/saz/puppet-sudo/pull/268
+    on hosts, puppet('module', 'install', 'saz-sudo', '--version', '6.0.0', '--ignore-dependencies')
     pp = 'include prometheus::ipmi_exporter'
     apply_manifest(pp, catch_failures: true)
     apply_manifest(pp, catch_changes: true)

--- a/spec/acceptance/ipmi_exporter_spec.rb
+++ b/spec/acceptance/ipmi_exporter_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper_acceptance'
 
 describe 'prometheus ipmi exporter' do
   it 'ipmi_exporter works idempotently with no errors' do
-    # TODO: Remove --ignore-dependencies once > 6.0.0 is released with https://github.com/saz/puppet-sudo/pull/268
-    on hosts, puppet('module', 'install', 'saz-sudo', '--version', '6.0.0', '--ignore-dependencies')
+    # TODO: Update to newer release once > 6.0.0 is released with https://github.com/saz/puppet-sudo/pull/268
+    on hosts, puppet('module', 'install', 'saz-sudo', '--version', '4.1.0')
     pp = 'include prometheus::ipmi_exporter'
     apply_manifest(pp, catch_failures: true)
     apply_manifest(pp, catch_changes: true)

--- a/spec/default_module_facts.yml
+++ b/spec/default_module_facts.yml
@@ -2,3 +2,4 @@
 #   if a same named fact exists in facterdb it will be overridden.
 ---
 prometheus_alert_manager_running: 'stopped'
+sudoversion: '1.8.23'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
The sudo config that was in previous code isn't actually valid and this module was just deploying a file with no validation.  I added a dependency on `saz/sudo` so that proper sudo validation can be performed to avoid deploying broken configuration files. I opted to make it a soft dependency so not added to metadata.json.
