### PR TITLE
fix download url for new asset url schema

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -249,7 +249,7 @@ prometheus::blackbox_exporter::config_file: '/etc/blackbox-exporter.yaml'
 prometheus::blackbox_exporter::version: '0.17.0'
 prometheus::postgres_exporter::data_source_uri: 'host=/var/run/postgresql/ sslmode=disable'
 prometheus::postgres_exporter::download_extension: 'tar.gz'
-prometheus::postgres_exporter::download_url_base: 'https://github.com/wrouesnel/postgres_exporter/releases'
+prometheus::postgres_exporter::download_url_base: 'https://github.com/prometheus-community/postgres_exporter/releases'
 prometheus::postgres_exporter::extra_groups: []
 prometheus::postgres_exporter::group: 'postgres-exporter'
 prometheus::postgres_exporter::package_ensure: 'latest'

--- a/manifests/postgres_exporter.pp
+++ b/manifests/postgres_exporter.pp
@@ -92,7 +92,11 @@ class prometheus::postgres_exporter (
 ) inherits prometheus {
   $release = "v${version}"
 
-  $real_download_url = pick($download_url, "${download_url_base}/download/${release}/${package_name}_${release}_${os}-${arch}.${download_extension}")
+  if versioncmp($version, '0.9.0') < 0 {
+    $real_download_url = pick($download_url, "${download_url_base}/download/${release}/${package_name}_${release}_${os}-${arch}.${download_extension}")
+  } else {
+    $real_download_url = pick($download_url, "${download_url_base}/download/${release}/${package_name}-${version}.${os}-${arch}.${download_extension}")
+  }
 
   $notify_service = $restart_on_change ? {
     true    => Service[$service_name],


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Since version 0.9.0 of prometheus postgres_exporter the url for the assets has changed and it cannot be downloaded anymore, so we have to change the download_url_base hiera value and the value of the created $real_download_url variable.

#### This Pull Request (PR) fixes the following issues
Fixes #584
