### PR TITLE
fix file ownerships

### DIFF
--- a/manifests/ipsec_exporter.pp
+++ b/manifests/ipsec_exporter.pp
@@ -79,10 +79,12 @@ class prometheus::ipsec_exporter (
   if versioncmp ($version, '0.3.2') >= 0 {
     $release          = $version
     $archive_bin_path = undef  # use default
+    $install_path     = undef  # use default
   }
   else {
     $release          = "v${version}"
     $archive_bin_path = "/opt/ipsec_exporter-v${version}.${os}-${arch}"
+    $install_path     = "/opt/ipsec_exporter-v${version}.${os}-${arch}"
   }
   $real_download_url = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${release}.${os}-${arch}.${download_extension}")
 
@@ -100,6 +102,7 @@ class prometheus::ipsec_exporter (
     real_download_url  => $real_download_url,
     bin_dir            => $bin_dir,
     archive_bin_path   => $archive_bin_path,
+    install_path       => $install_path,
     notify_service     => $notify_service,
     package_name       => $package_name,
     package_ensure     => $package_ensure,

--- a/manifests/nginx_prometheus_exporter.pp
+++ b/manifests/nginx_prometheus_exporter.pp
@@ -114,6 +114,13 @@ class prometheus::nginx_prometheus_exporter (
       creates         => "${install_dir}/${package_name}",
       cleanup         => true,
     }
+    -> exec { "/bin/chown root:0 -R ${install_dir}":
+      command => "/bin/chown root:0 -R ${install_dir}",
+      onlyif  => "/usr/bin/test `/usr/bin/stat -c '%U' ${install_dir}/${service_name}` != 'root'",
+    }
+    -> file { "${install_dir}/${service_name}":
+      mode  => '0555',
+    }
     -> file { "${bin_dir}/${package_name}":
       ensure => link,
       notify => $notify_service,

--- a/manifests/postgres_exporter.pp
+++ b/manifests/postgres_exporter.pp
@@ -149,6 +149,13 @@ class prometheus::postgres_exporter (
       creates         => "${install_dir}/${service_name}",
       cleanup         => true,
     }
+    -> exec { "/bin/chown root:0 -R ${install_dir}":
+      command => "/bin/chown root:0 -R ${install_dir}",
+      onlyif  => "/usr/bin/test `/usr/bin/stat -c '%U' ${install_dir}/${service_name}` != 'root'",
+    }
+    -> file { "${install_dir}/${service_name}":
+      mode  => '0555',
+    }
     -> file { "${bin_dir}/${service_name}":
       ensure => link,
       notify => $notify_service,

--- a/manifests/pushprox_client.pp
+++ b/manifests/pushprox_client.pp
@@ -91,6 +91,7 @@ class prometheus::pushprox_client (
     version            => $version,
     download_extension => $download_extension,
     archive_bin_path   => "/opt/PushProx-${version}.${os}-${arch}/pushprox-client",
+    install_path       => "/opt/PushProx-${version}.${os}-${arch}",
     os                 => $os,
     arch               => $arch,
     real_download_url  => $real_download_url,

--- a/manifests/pushprox_proxy.pp
+++ b/manifests/pushprox_proxy.pp
@@ -85,6 +85,7 @@ class prometheus::pushprox_proxy (
     version            => $version,
     download_extension => $download_extension,
     archive_bin_path   => "/opt/PushProx-${version}.${os}-${arch}/pushprox-proxy",
+    install_path       => "/opt/PushProx-${version}.${os}-${arch}",
     os                 => $os,
     arch               => $arch,
     real_download_url  => $real_download_url,

--- a/manifests/redis_exporter.pp
+++ b/manifests/redis_exporter.pp
@@ -120,6 +120,13 @@ class prometheus::redis_exporter (
         creates         => "${install_dir}/${service_name}",
         cleanup         => true,
       }
+      -> exec { "/bin/chown root:0 -R ${install_dir}":
+        command => "/bin/chown root:0 -R ${install_dir}",
+        onlyif  => "/usr/bin/test `/usr/bin/stat -c '%U' ${install_dir}/${service_name}` != 'root'",
+      }
+      -> file { "${install_dir}/${service_name}":
+        mode  => '0555',
+      }
       -> file { "${bin_dir}/${service_name}":
         ensure => link,
         notify => $notify_service,

--- a/spec/defines/daemon_spec.rb
+++ b/spec/defines/daemon_spec.rb
@@ -58,8 +58,6 @@ describe 'prometheus::daemon' do
 
           it {
             expect(subject).to contain_file("/opt/smurf_exporter-#{parameters[:version]}.#{prom_os}-#{prom_arch}/smurf_exporter").with(
-              'owner' => 'root',
-              'group' => 0,
               'mode' => '0555'
             )
           }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Currently most exporters have weird permissions after being installed (e.g. 3434:3434 ownership). For the exporters installed via daemon, there is already a patch applied, which sets the owner and group to root:0 for the executables, which still leaves files like "LICENSE" etc. with the wrong ownerships. I am adding a patch for all files, replacing the old patch.

#### This Pull Request (PR) fixes the following issues
Fixes #111
