### PR TITLE
make process exporter service name propagate correctly

### DIFF
--- a/manifests/process_exporter.pp
+++ b/manifests/process_exporter.pp
@@ -134,7 +134,7 @@ class prometheus::process_exporter (
 
   $options = "-config.path=${config_path} ${extra_options}"
 
-  prometheus::daemon { 'process-exporter':
+  prometheus::daemon { $service_name:
     install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,


### PR DESCRIPTION
Most (but not all!) of the other exporters set the service name properly by passing it like that to the prometheus::daemon. It's important to have this so that it works when installing from Debian packages, where the service name is `prometheus-process-exporter` and not `process-exporter`.

This is similar to commit 14849dd578ddf870dcda2bcc0bb197050cf1b136 ("have a $service_name parameter for all prometheus-exporters", #430 ) and 82cc646a31fa1062f3617262f14143539ef9d400 ("make apache exporter service name customizable", #400).
