### PR TITLE
Support time_intervals with alertmanager >= 0.24.0

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -52,6 +52,7 @@ prometheus::alertmanager::route:
   'repeat_interval': '3h'
   'receiver': 'Admin'
 prometheus::alertmanager::mute_time_intervals: []
+prometheus::alertmanager::time_intervals: []
 prometheus::alertmanager::storage_path: '/var/lib/alertmanager'
 prometheus::alertmanager::templates: [ "%{lookup('prometheus::alertmanager::config_dir')}/*.tmpl" ]
 prometheus::alertmanager::user: 'alertmanager'

--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -49,10 +49,19 @@
 #  Whether to create user or rely on external code for that
 # @param mute_time_intervals
 #  Array of mute time intervals
+#  Not applied if time_intervals is defined
 #  Example:
 #  prometheus::alertmanager::mute_time_intervals:
 #  - name: weekend
-#    weekdays: ['saturday','sunday']
+#    time_intervals:
+#      - weekdays: ['saturday','sunday']
+# @param time_intervals
+#   Array of time intervals, only supported with 0.24.0 and newer
+#  Example:
+#  prometheus::alertmanager::time_intervals:
+#  - name: weekend
+#    time_intervals:
+#      - weekdays: ['saturday','sunday']
 # @param os
 #  Operating system (linux is the only one supported)
 # @param package_ensure
@@ -118,6 +127,7 @@ class prometheus::alertmanager (
   Array $receivers,
   Hash $route,
   Array[Hash] $mute_time_intervals,
+  Array[Hash] $time_intervals,
   Stdlib::Absolutepath $storage_path,
   Array $templates,
   String[1] $user,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -80,7 +80,7 @@ class prometheus::install {
     }
   }
   if $prometheus::server::manage_group {
-    ensure_resource('group', [$prometheus::server::group],{
+    ensure_resource('group', [$prometheus::server::group], {
         ensure => 'present',
         system => true,
     })

--- a/manifests/statsd_exporter.pp
+++ b/manifests/statsd_exporter.pp
@@ -110,7 +110,7 @@ class prometheus::statsd_exporter (
     mode    => $config_mode,
     owner   => 'root',
     group   => $group,
-    content => to_yaml( { mappings => $mappings }),
+    content => to_yaml({ mappings => $mappings }),
     notify  => $notify_service,
   }
 

--- a/spec/classes/alertmanager_spec.rb
+++ b/spec/classes/alertmanager_spec.rb
@@ -64,7 +64,9 @@ describe 'prometheus::alertmanager' do
             os: 'linux',
             bin_dir: '/usr/local/bin',
             install_method: 'url',
-            mute_time_intervals: [{ 'name' => 'weekend', 'weekdays' => %w[saturday sunday] }],
+            mute_time_intervals: [
+              { 'name' => 'weekend', 'time_intervals' => [{ 'weekdays' => %w[saturday sunday] }] }
+            ],
           }
         end
 
@@ -72,9 +74,41 @@ describe 'prometheus::alertmanager' do
           verify_contents(catalogue, '/etc/alertmanager/alertmanager.yaml', [
                             'mute_time_intervals:',
                             '- name: weekend',
-                            '  weekdays:',
-                            '  - saturday',
-                            '  - sunday',
+                            '  time_intervals:',
+                            '  - weekdays:',
+                            '    - saturday',
+                            '    - sunday',
+                          ])
+        }
+      end
+
+      context 'with latest version specified and time_intervals' do
+        let(:params) do
+          {
+            version: '0.24.0',
+            arch: 'amd64',
+            os: 'linux',
+            bin_dir: '/usr/local/bin',
+            install_method: 'url',
+            mute_time_intervals: [
+              { 'name' => 'weekend', 'time_intervals' => [{ 'weekdays' => %w[saturday sunday] }] }
+            ],
+            time_intervals: [
+              { 'name' => 'weekend', 'time_intervals' => [{ 'weekdays' => %w[saturday sunday] }] }
+            ],
+          }
+        end
+
+        it { is_expected.to contain_file('/etc/alertmanager/alertmanager.yaml').without(content: %r{mute_time_intervals}) }
+
+        it {
+          verify_contents(catalogue, '/etc/alertmanager/alertmanager.yaml', [
+                            'time_intervals:',
+                            '- name: weekend',
+                            '  time_intervals:',
+                            '  - weekdays:',
+                            '    - saturday',
+                            '    - sunday',
                           ])
         }
       end

--- a/templates/alertmanager.yaml.erb
+++ b/templates/alertmanager.yaml.erb
@@ -6,8 +6,13 @@
 <% inhibit_rules = scope.lookupvar('::prometheus::alertmanager::inhibit_rules') -%>
 <% full_config = { 'global'=>global, 'templates'=>templates, 'route'=>route, 'receivers'=>receivers, 'inhibit_rules'=>inhibit_rules } -%>
 <%
-if scope.function_versioncmp([scope.lookupvar('::prometheus::alertmanager::version'), '0.22.0']) >= 0
+if scope.function_versioncmp([scope.lookupvar('::prometheus::alertmanager::version'), '0.22.0']) >= 0 &&
+    scope.lookupvar('::prometheus::alertmanager::time_intervals').empty?
   full_config['mute_time_intervals'] = scope.lookupvar('::prometheus::alertmanager::mute_time_intervals')
+end
+if scope.function_versioncmp([scope.lookupvar('::prometheus::alertmanager::version'), '0.24.0']) >= 0 &&
+    ! scope.lookupvar('::prometheus::alertmanager::time_intervals').empty?
+  full_config['time_intervals'] = scope.lookupvar('::prometheus::alertmanager::time_intervals')
 end
 -%>
 <%= full_config.to_yaml -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

Adds `time_intervals` parameter to alertmanager that is supported with 0.24.0 and newer.  This will replace `mute_time_intervals` which is now deprecated.

https://github.com/prometheus/alertmanager/releases/tag/v0.24.0

Also fixed the usage examples for `mute_time_intervals` to be the correct data structures.