### PR TITLE
Support new download format for openldap_exporter

### DIFF
--- a/spec/acceptance/openldap_exporter_spec.rb
+++ b/spec/acceptance/openldap_exporter_spec.rb
@@ -83,6 +83,21 @@ describe 'prometheus openldap exporter' do
     describe port(9330) do
       it { is_expected.to be_listening.with('tcp6') }
     end
+
+    it 'upgrades to new download format' do
+      pp = "class{'prometheus::openldap_exporter': version => '2.2.1'}"
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe service('openldap_exporter') do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
+
+    describe port(9330) do
+      it { is_expected.to be_listening.with('tcp6') }
+    end
   end
   # rubocop:enable RSpec/RepeatedExampleGroupBody,RSpec/RepeatedExampleGroupDescription
 end

--- a/spec/classes/openldap_exporter_spec.rb
+++ b/spec/classes/openldap_exporter_spec.rb
@@ -27,6 +27,21 @@ describe 'prometheus::openldap_exporter' do
           it { is_expected.to contain_service('openldap_exporter') }
         end
       end
+
+      context 'with version specified using new download format' do
+        let(:params) do
+          {
+            version: '2.2.1',
+          }
+        end
+
+        it {
+          expect(subject).to contain_prometheus__daemon('openldap_exporter').with(
+            download_extension: 'gz',
+            real_download_url: 'https://github.com/tomcz/openldap_exporter/releases/download/v2.2.1/openldap_exporter-linux-amd64.gz'
+          )
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

Beginning with openldap_exporter version 2.2.1, the download format is a gzip'ed file.  This attempts to support both old and new download formats.

