### PR TITLE
Update ipmi_exporter URL, project moved

### DIFF
--- a/manifests/ipmi_exporter.pp
+++ b/manifests/ipmi_exporter.pp
@@ -63,7 +63,7 @@ class prometheus::ipmi_exporter (
   String[1] $package_ensure                                  = 'latest',
   String[1] $user                                            = 'ipmi-exporter',
   String[1] $group                                           = 'ipmi-exporter',
-  Prometheus::Uri $download_url_base                         = 'https://github.com/soundcloud/ipmi_exporter/releases',
+  Prometheus::Uri $download_url_base                         = 'https://github.com/prometheus-community/ipmi_exporter/releases',
   Array[String] $extra_groups                                = [],
   Prometheus::Initstyle $init_style                          = $facts['service_provider'],
   Boolean $purge_config_dir                                  = true,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

The IPMI exporter moved to prometheus-community organization: https://github.com/prometheus-community/ipmi_exporter/releases.  That new org has all the same downloads as previous org so all that's needed is updated URL.

