### PR TITLE
haproxy_exporter: escape cnf_scrape_uri to avoid malformed strings

### DIFF
--- a/manifests/haproxy_exporter.pp
+++ b/manifests/haproxy_exporter.pp
@@ -124,8 +124,9 @@ class prometheus::haproxy_exporter (
     "--web.config.file=${$web_config_file}"
   }
 
+  $scrape_uri_quoted = String($cnf_scrape_uri, '%p')
   $options = [
-    "--haproxy.scrape-uri=\"${cnf_scrape_uri}\"",
+    "--haproxy.scrape-uri=${scrape_uri_quoted}",
     $extra_options,
     $_web_config,
   ].filter |$x| { !$x.empty }.join(' ')

--- a/spec/classes/haproxy_exporter_spec.rb
+++ b/spec/classes/haproxy_exporter_spec.rb
@@ -52,6 +52,7 @@ describe 'prometheus::haproxy_exporter' do
             end
 
             it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_prometheus__daemon('haproxy_exporter').with('options' => "--haproxy.scrape-uri='#{value}'") }
           end
         end
 
@@ -78,7 +79,7 @@ describe 'prometheus::haproxy_exporter' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_file('/etc/haproxy_exporter_web-config.yml').with(ensure: 'file') }
-        it { is_expected.to contain_prometheus__daemon('haproxy_exporter').with(options: '--haproxy.scrape-uri="http://localhost:1234/haproxy?stats;csv" --web.config.file=/etc/haproxy_exporter_web-config.yml') }
+        it { is_expected.to contain_prometheus__daemon('haproxy_exporter').with(options: '--haproxy.scrape-uri=\'http://localhost:1234/haproxy?stats;csv\' --web.config.file=/etc/haproxy_exporter_web-config.yml') }
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description
Hello, this PR changes the way cnf_scrape_uri is being escaped in manifests/haproxy_exporter.pp to avoid malformed string like the one being described in Issue #600.

#### This Pull Request (PR) fixes the following issues
Fixes #600
