### PR TITLE
Implement web-config.yml handling

### DIFF
--- a/spec/classes/node_exporter_spec.rb
+++ b/spec/classes/node_exporter_spec.rb
@@ -21,14 +21,14 @@ describe 'prometheus::node_exporter' do
           it { is_expected.to contain_package('prometheus-node-exporter') }
           it { is_expected.not_to contain_systemd__unit_file('node_exporter.service') }
           it { is_expected.to contain_service('prometheus-node-exporter') }
-          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '  ') }
+          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '   ') }
         else
           it { is_expected.to contain_user('node-exporter') }
           it { is_expected.to contain_group('node-exporter') }
           it { is_expected.to contain_file('/opt/node_exporter-1.0.1.linux-amd64/node_exporter') }
           it { is_expected.to contain_file('/usr/local/bin/node_exporter') }
           it { is_expected.to contain_service('node_exporter') }
-          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '  ') }
+          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '   ') }
           it { is_expected.to contain_systemd__unit_file('node_exporter.service') }
         end
         # rubocop:disable RSpec/RepeatedExample
@@ -58,7 +58,7 @@ describe 'prometheus::node_exporter' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_archive('/tmp/node_exporter-1.0.1.tar.gz') }
-        it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: ' --collector.foo --collector.bar --no-collector.baz --no-collector.qux') }
+        it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: ' --collector.foo --collector.bar --no-collector.baz --no-collector.qux ') }
 
         if facts[:os]['name'] == 'Archlinux'
           it { is_expected.to contain_file('/usr/bin/node_exporter') }
@@ -81,7 +81,7 @@ describe 'prometheus::node_exporter' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '--path.procfs /host/proc --path.sysfs /host/sys --collector.foo --collector.bar --no-collector.baz --no-collector.qux') }
+        it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '--path.procfs /host/proc --path.sysfs /host/sys --collector.foo --collector.bar --no-collector.baz --no-collector.qux ') }
       end
 
       context 'with version specified' do
@@ -115,6 +115,36 @@ describe 'prometheus::node_exporter' do
         end
 
         it { is_expected.to contain_prometheus__daemon('node_exporter').with_download_extension('') }
+      end
+
+      context 'without web-config.yml' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/etc/node_exporter_web-config.yml').with(ensure: 'absent') }
+
+        if facts[:os]['name'] == 'Archlinux'
+          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '   ') }
+        else
+          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '   ') }
+        end
+      end
+
+      context 'with tls set in web-config.yml' do
+        let(:params) do
+          {
+            use_tls_server_config: true,
+            tls_cert_file: '/etc/node_exporter/foo.cert',
+            tls_key_file: '/etc/node_exporter/foo.key'
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/etc/node_exporter_web-config.yml').with(ensure: 'file') }
+
+        if facts[:os]['name'] == 'Archlinux'
+          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '   --web.config=/etc/node_exporter_web-config.yml') }
+        else
+          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '   --web.config=/etc/node_exporter_web-config.yml') }
+        end
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description
Implement web-config.yml handling
- needed for native tls without proxy
- needed for http2 settings
- needed for basic auth
- FYI: feature is marked as experimental in prometheus node exporter
- tested on local systems, spec/unit test still might fail, will fix them than

#### This Pull Request (PR) fixes the following issues
Fixes #520 