### PR TITLE
Move the URL releases to their own directory under /opt to create the…

### DIFF
--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -187,7 +187,7 @@ class prometheus::alertmanager (
     # If version >= 0.10.0 then install amtool - Alertmanager validation tool
     file { "${bin_dir}/amtool":
       ensure => link,
-      target => "/opt/${package_name}-${version}.${os}-${arch}/amtool",
+      target => "${prometheus::basepath}/${package_name}-${version}.${os}-${arch}/amtool",
     }
 
     if $manage_config {

--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -202,7 +202,7 @@ class prometheus::alertmanager (
     # If version >= 0.10.0 then install amtool - Alertmanager validation tool
     file { "${bin_dir}/amtool":
       ensure => link,
-      target => "/opt/${package_name}-${version}.${os}-${arch}/amtool",
+      target => "${prometheus::basepath}/${package_name}-${version}.${os}-${arch}/amtool",
     }
 
     if $manage_config {

--- a/manifests/cgroup_exporter.pp
+++ b/manifests/cgroup_exporter.pp
@@ -92,7 +92,7 @@ class prometheus::cgroup_exporter (
   Boolean                                        $manage_service     = true,
   Boolean                                        $manage_user        = true,
   String[1]                                      $os                 = downcase(fact('kernel')),
-  Stdlib::Absolutepath                           $archive_bin_path   = "/opt/${package_name}-${version}.${os}-${arch}/${package_name}",
+  Stdlib::Absolutepath                           $archive_bin_path   = "${prometheus::basepath}/${package_name}-${version}.${os}-${arch}/${package_name}",
   Optional[String[1]]                            $extra_options      = undef,
   Optional[Prometheus::Uri]                      $download_url       = undef,
   Optional[Stdlib::Host]                         $scrape_host        = undef,

--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -75,8 +75,8 @@ define prometheus::daemon (
   Hash[String[1], Scalar] $env_vars                          = {},
   Stdlib::Absolutepath $env_file_path                        = $prometheus::env_file_path,
   Optional[String[1]] $extract_command                       = $prometheus::extract_command,
-  Stdlib::Absolutepath $extract_path                         = '/opt',
-  Stdlib::Absolutepath $archive_bin_path                     = "/opt/${name}-${version}.${os}-${arch}/${name}",
+  Stdlib::Absolutepath $extract_path                         = $prometheus::basepath,
+  Stdlib::Absolutepath $archive_bin_path                     = "${prometheus::basepath}/${name}-${version}.${os}-${arch}/${name}",
   Boolean $export_scrape_job                                 = false,
   Stdlib::Host $scrape_host                                  = $facts['networking']['fqdn'],
   Optional[Stdlib::Port] $scrape_port                        = undef,
@@ -89,17 +89,17 @@ define prometheus::daemon (
   case $install_method {
     'url': {
       if $download_extension == '' {
-        file { "/opt/${name}-${version}.${os}-${arch}":
+        file { "${prometheus::basepath}/${name}-${version}.${os}-${arch}":
           ensure => directory,
           owner  => 'root',
           group  => 0, # 0 instead of root because OS X uses "wheel".
           mode   => '0755',
         }
-        -> archive { "/opt/${name}-${version}.${os}-${arch}/${name}":
+        -> archive { "${prometheus::basepath}/${name}-${version}.${os}-${arch}/${name}":
           ensure          => present,
           source          => $real_download_url,
           checksum_verify => false,
-          before          => File["/opt/${name}-${version}.${os}-${arch}/${name}"],
+          before          => File["${prometheus::basepath}/${name}-${version}.${os}-${arch}/${name}"],
           proxy_server    => $proxy_server,
           proxy_type      => $proxy_type,
         }

--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -78,8 +78,8 @@ define prometheus::daemon (
   Hash[String[1], Scalar] $env_vars                          = {},
   Stdlib::Absolutepath $env_file_path                        = $prometheus::env_file_path,
   Optional[String[1]] $extract_command                       = $prometheus::extract_command,
-  Stdlib::Absolutepath $extract_path                         = '/opt',
-  Stdlib::Absolutepath $archive_bin_path                     = "/opt/${name}-${version}.${os}-${arch}/${name}",
+  Stdlib::Absolutepath $extract_path                         = $prometheus::basepath,
+  Stdlib::Absolutepath $archive_bin_path                     = "${prometheus::basepath}/${name}-${version}.${os}-${arch}/${name}",
   Boolean $export_scrape_job                                 = false,
   Stdlib::Host $scrape_host                                  = $facts['networking']['fqdn'],
   Optional[Stdlib::Port] $scrape_port                        = undef,
@@ -96,17 +96,17 @@ define prometheus::daemon (
   case $install_method {
     'url': {
       if $download_extension == '' {
-        file { "/opt/${name}-${version}.${os}-${arch}":
+        file { "${prometheus::basepath}/${name}-${version}.${os}-${arch}":
           ensure => stdlib::ensure($ensure, 'directory'),
           owner  => 'root',
           group  => 0, # 0 instead of root because OS X uses "wheel".
           mode   => '0755',
         }
-        -> archive { "/opt/${name}-${version}.${os}-${arch}/${name}":
+        -> archive { "${prometheus::basepath}/${name}-${version}.${os}-${arch}/${name}":
           ensure          => $ensure,
           source          => $real_download_url,
           checksum_verify => false,
-          before          => File["/opt/${name}-${version}.${os}-${arch}/${name}"],
+          before          => File["${prometheus::basepath}/${name}-${version}.${os}-${arch}/${name}"],
           proxy_server    => $proxy_server,
           proxy_type      => $proxy_type,
         }

--- a/manifests/dellhw_exporter.pp
+++ b/manifests/dellhw_exporter.pp
@@ -46,7 +46,7 @@
 # @param version
 #  The binary release version
 # @param omreport_path
-#  The file path to the omReport executable (default "/opt/dell/srvadmin/bin/omreport")
+#  The file path to the omReport executable (default "/opt/prometheus/dell/srvadmin/bin/omreport")
 # @param scrape_ipadress
 #  The ip address that the exporter will to listen to (default '')
 # @param proxy_server
@@ -84,7 +84,7 @@ class prometheus::dellhw_exporter (
   String[1] $scrape_job_name                                 = 'dellhw',
   Optional[Hash] $scrape_job_labels                          = undef,
   Optional[String[1]] $bin_name                              = undef,
-  Stdlib::Unixpath $omreport_path                            = '/opt/dell/srvadmin/bin/omreport',
+  Stdlib::Unixpath $omreport_path                            = "${prometheus::basepath}/dell/srvadmin/bin/omreport",
   Optional[String[1]] $proxy_server                          = undef,
   Optional[Enum['none', 'http', 'https', 'ftp']] $proxy_type = undef,
 ) inherits prometheus {
@@ -127,7 +127,7 @@ class prometheus::dellhw_exporter (
     scrape_job_name    => $scrape_job_name,
     scrape_job_labels  => $scrape_job_labels,
     bin_name           => $bin_name,
-    archive_bin_path   => "/opt/dellhw_exporter-${version}.${os}-${arch}/dellhw_exporter",
+    archive_bin_path   => "${prometheus::basepath}/dellhw_exporter-${version}.${os}-${arch}/dellhw_exporter",
     proxy_server       => $proxy_server,
     proxy_type         => $proxy_type,
   }

--- a/manifests/dellhw_exporter.pp
+++ b/manifests/dellhw_exporter.pp
@@ -128,7 +128,7 @@ class prometheus::dellhw_exporter (
     scrape_job_name    => $scrape_job_name,
     scrape_job_labels  => $scrape_job_labels,
     bin_name           => $bin_name,
-    archive_bin_path   => "/opt/dellhw_exporter-${version}.${os}-${arch}/dellhw_exporter",
+    archive_bin_path   => "${prometheus::basepath}/dellhw_exporter-${version}.${os}-${arch}/dellhw_exporter",
     proxy_server       => $proxy_server,
     proxy_type         => $proxy_type,
   }

--- a/manifests/frr_exporter.pp
+++ b/manifests/frr_exporter.pp
@@ -187,6 +187,6 @@ class prometheus::frr_exporter (
     scrape_job_name    => 'frr',
     scrape_job_labels  => {},
     bin_name           => $package_name,
-    archive_bin_path   => "/opt/${package_name}-${version}.${os}-${arch}/${package_name}",
+    archive_bin_path   => "${prometheus::basepath}/${package_name}-${version}.${os}-${arch}/${package_name}",
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -223,35 +223,38 @@
 # @param systemd_install_options
 #  Options for the install section of prometheus systemd unit file. Can be used to add custom options
 #  or to override default. Only used when init_style is set to systemd.
+# @param clean_url_releases
+#  If this variable is activated, the releases are no longer installed under /opt but under
+#  /opt/prometheus. In addition, all releases that are no longer used are automatically deleted.
 class prometheus (
   Stdlib::Absolutepath $env_file_path,
-  Array $extra_groups = [],
-  Hash $global_config = { 'scrape_interval' => '15s', 'evaluation_interval' => '15s', 'external_labels' => { 'monitor' => 'master' } },
-  String $package_ensure = 'latest',
-  String $package_name = 'prometheus',
-  Array $rule_files = [],
-  Array $scrape_configs = [],
-  Optional[Array] $scrape_config_files = undef,
-  Array $remote_read_configs = [],
-  Array $remote_write_configs = [],
-  Boolean $enable_tracing = false,
-  Hash $tracing_config = {},
-  Stdlib::Absolutepath $shared_dir = '/usr/local/share/prometheus',
-  String $storage_retention = '360h',
-  String $user = 'prometheus',
-  Prometheus::Uri $download_url_base = 'https://github.com/prometheus/prometheus/releases',
-  Array $alertmanagers_config = [],
-  Array $alert_relabel_config = [],
-  String $download_extension = 'tar.gz',
-  String $config_template = 'prometheus/prometheus.yaml.erb',
-  String $config_mode = '0640',
-  String $config_dir = '/etc/prometheus',
-  Boolean $manage_config_dir = true,
-  Boolean $manage_init_file = true,
-  Hash $alerts = {},
-  Boolean $manage_config = true,
-  String $group = 'prometheus',
-  Stdlib::Absolutepath $localstorage = '/var/lib/prometheus',
+  Array $extra_groups                                                           = [],
+  Hash $global_config                                                           = { 'scrape_interval' => '15s', 'evaluation_interval' => '15s', 'external_labels' => { 'monitor' => 'master' } },
+  String $package_ensure                                                        = 'latest',
+  String $package_name                                                          = 'prometheus',
+  Array $rule_files                                                             = [],
+  Array $scrape_configs                                                         = [],
+  Optional[Array] $scrape_config_files                                          = undef,
+  Array $remote_read_configs                                                    = [],
+  Array $remote_write_configs                                                   = [],
+  Boolean $enable_tracing                                                       = false,
+  Hash $tracing_config                                                          = {},
+  Stdlib::Absolutepath $shared_dir                                              = '/usr/local/share/prometheus',
+  String $storage_retention                                                     = '360h',
+  String $user                                                                  = 'prometheus',
+  Prometheus::Uri $download_url_base                                            = 'https://github.com/prometheus/prometheus/releases',
+  Array $alertmanagers_config                                                   = [],
+  Array $alert_relabel_config                                                   = [],
+  String $download_extension                                                    = 'tar.gz',
+  String $config_template                                                       = 'prometheus/prometheus.yaml.erb',
+  String $config_mode                                                           = '0640',
+  String $config_dir                                                            = '/etc/prometheus',
+  Boolean $manage_config_dir                                                    = true,
+  Boolean $manage_init_file                                                     = true,
+  Hash $alerts                                                                  = {},
+  Boolean $manage_config                                                        = true,
+  String $group                                                                 = 'prometheus',
+  Stdlib::Absolutepath $localstorage                                            = '/var/lib/prometheus',
   Boolean $manage_localstorage                                                  = true,
   Stdlib::Absolutepath $bin_dir                                                 = '/usr/local/bin',
   String $version                                                               = '2.52.0',
@@ -315,6 +318,7 @@ class prometheus (
   Boolean $include_default_scrape_configs                                       = true,
   Optional[String[1]] $proxy_server                                             = undef,
   Optional[Enum['none', 'http', 'https', 'ftp']] $proxy_type                    = undef,
+  Boolean $clean_url_releases                                                   = false,
 ) {
   $real_arch = $arch ? {
     'x86_64'  => 'amd64',
@@ -324,6 +328,23 @@ class prometheus (
     'armv6l'  => 'armv6',
     'armv5l'  => 'armv5',
     default   => $arch,
+  }
+
+  if $clean_url_releases {
+    $basepath = '/opt/prometheus'
+
+    file { $basepath:
+      ensure  => directory,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      backup  => false,
+      force   => true,
+      purge   => true,
+      recurse => true,
+    }
+  } else {
+    $basepath = '/opt'
   }
 
   if $manage_prometheus_server {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,25 +19,25 @@ class prometheus::install {
       archive { "/tmp/prometheus-${prometheus::server::version}.${prometheus::server::download_extension}":
         ensure          => present,
         extract         => true,
-        extract_path    => '/opt',
+        extract_path    => $prometheus::basepath,
         source          => $prometheus::server::real_download_url,
         checksum_verify => false,
-        creates         => "/opt/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/prometheus",
+        creates         => "${prometheus::basepath}/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/prometheus",
         cleanup         => true,
         extract_command => $prometheus::extract_command,
       }
       -> file {
-        "/opt/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/prometheus":
+        "${prometheus::basepath}/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/prometheus":
           owner => 'root',
           group => 0, # 0 instead of root because OS X uses "wheel".
           mode  => '0555';
         "${prometheus::server::bin_dir}/prometheus":
           ensure => link,
           notify => $prometheus::server::notify_service,
-          target => "/opt/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/prometheus";
+          target => "${prometheus::basepath}/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/prometheus";
         "${prometheus::server::bin_dir}/promtool":
           ensure => link,
-          target => "/opt/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/promtool";
+          target => "${prometheus::basepath}/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/promtool";
         $prometheus::server::shared_dir:
           ensure => directory,
           owner  => $prometheus::server::user,
@@ -46,11 +46,11 @@ class prometheus::install {
         "${prometheus::server::shared_dir}/consoles":
           ensure => link,
           notify => $prometheus::server::notify_service,
-          target => "/opt/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/consoles";
+          target => "${prometheus::basepath}/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/consoles";
         "${prometheus::server::shared_dir}/console_libraries":
           ensure => link,
           notify => $prometheus::server::notify_service,
-          target => "/opt/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/console_libraries";
+          target => "${prometheus::basepath}/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/console_libraries";
       }
     }
     'package': {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -22,27 +22,27 @@ class prometheus::install {
       archive { "/tmp/prometheus-${prometheus::server::version}.${prometheus::server::download_extension}":
         ensure          => present,
         extract         => true,
-        extract_path    => '/opt',
+        extract_path    => $prometheus::basepath,
         source          => $prometheus::server::real_download_url,
         checksum_verify => false,
-        creates         => "/opt/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/prometheus",
+        creates         => "${prometheus::basepath}/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/prometheus",
         cleanup         => true,
         extract_command => $prometheus::extract_command,
         proxy_server    => $prometheus::server::proxy_server,
         proxy_type      => $prometheus::server::proxy_type,
       }
       -> file {
-        "/opt/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/prometheus":
+        "${prometheus::basepath}/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/prometheus":
           owner => 'root',
           group => 0, # 0 instead of root because OS X uses "wheel".
           mode  => '0555';
         "${prometheus::server::bin_dir}/prometheus":
           ensure => link,
           notify => $prometheus::server::notify_service,
-          target => "/opt/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/prometheus";
+          target => "${prometheus::basepath}/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/prometheus";
         "${prometheus::server::bin_dir}/promtool":
           ensure => link,
-          target => "/opt/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/promtool";
+          target => "${prometheus::basepath}/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/promtool";
         $prometheus::server::shared_dir:
           ensure => directory,
           owner  => $prometheus::server::user,
@@ -51,11 +51,11 @@ class prometheus::install {
         "${prometheus::server::shared_dir}/consoles":
           ensure => link,
           notify => $prometheus::server::notify_service,
-          target => "/opt/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/consoles";
+          target => "${prometheus::basepath}/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/consoles";
         "${prometheus::server::shared_dir}/console_libraries":
           ensure => link,
           notify => $prometheus::server::notify_service,
-          target => "/opt/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/console_libraries";
+          target => "${prometheus::basepath}/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/console_libraries";
       }
     }
     'package': {

--- a/manifests/ipsec_exporter.pp
+++ b/manifests/ipsec_exporter.pp
@@ -88,7 +88,7 @@ class prometheus::ipsec_exporter (
   }
   else {
     $release          = "v${version}"
-    $archive_bin_path = "/opt/ipsec_exporter-v${version}.${os}-${arch}"
+    $archive_bin_path = "${prometheus::basepath}/ipsec_exporter-v${version}.${os}-${arch}"
   }
   $real_download_url = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${release}.${os}-${arch}.${download_extension}")
 

--- a/manifests/ipsec_exporter.pp
+++ b/manifests/ipsec_exporter.pp
@@ -89,7 +89,7 @@ class prometheus::ipsec_exporter (
   }
   else {
     $release          = "v${version}"
-    $archive_bin_path = "/opt/ipsec_exporter-v${version}.${os}-${arch}"
+    $archive_bin_path = "${prometheus::basepath}/ipsec_exporter-v${version}.${os}-${arch}"
   }
   $real_download_url = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${release}.${os}-${arch}.${download_extension}")
 

--- a/manifests/jmx_exporter.pp
+++ b/manifests/jmx_exporter.pp
@@ -131,7 +131,7 @@ class prometheus::jmx_exporter (
     manage_bin_link    => false,
     bin_dir            => dirname($java_bin_path),
     bin_name           => basename($java_bin_path),
-    options            => "${_java_options}-jar /opt/${service_name}-${version}.${os}-${arch}/${service_name} ${port} ${config_file_location}",
+    options            => "${_java_options}-jar ${prometheus::basepath}/${service_name}-${version}.${os}-${arch}/${service_name} ${port} ${config_file_location}",
     os                 => $os,
     arch               => $arch,
   }

--- a/manifests/mongodb_exporter.pp
+++ b/manifests/mongodb_exporter.pp
@@ -95,7 +95,7 @@ class prometheus::mongodb_exporter (
   if versioncmp($version, '0.7.0') < 0 or versioncmp($version, '0.20.4') >= 0 {
     $archive_bin_path = undef  # use default
   } else {
-    $archive_bin_path = '/opt/mongodb_exporter'
+    $archive_bin_path = "${prometheus::basepath}/mongodb_exporter"
   }
 
   $notify_service = $restart_on_change ? {

--- a/manifests/mongodb_exporter.pp
+++ b/manifests/mongodb_exporter.pp
@@ -99,7 +99,7 @@ class prometheus::mongodb_exporter (
   if versioncmp($version, '0.7.0') < 0 or versioncmp($version, '0.20.4') >= 0 {
     $archive_bin_path = undef  # use default
   } else {
-    $archive_bin_path = '/opt/mongodb_exporter'
+    $archive_bin_path = "${prometheus::basepath}/mongodb_exporter"
   }
 
   $notify_service = $restart_on_change ? {

--- a/manifests/nginx_prometheus_exporter.pp
+++ b/manifests/nginx_prometheus_exporter.pp
@@ -104,7 +104,7 @@ class prometheus::nginx_prometheus_exporter (
     # nginx_prometheus_exporter lacks currently as of version 0.9.0
     # TODO: patch prometheus::daemon to support custom extract directories
     $real_install_method = 'none'
-    $install_dir = "/opt/${package_name}-${version}.${os}-${arch}"
+    $install_dir = "${prometheus::basepath}/${package_name}-${version}.${os}-${arch}"
     file { $install_dir:
       ensure => 'directory',
       owner  => 'root',

--- a/manifests/nginx_prometheus_exporter.pp
+++ b/manifests/nginx_prometheus_exporter.pp
@@ -103,7 +103,7 @@ class prometheus::nginx_prometheus_exporter (
     $options = "-nginx.scrape-uri '${scrape_uri}' ${extra_options}"
   }
 
-  $extract_path = "/opt/${package_name}-${version}.${os}-${arch}"
+  $extract_path = "${prometheus::basepath}/${package_name}-${version}.${os}-${arch}"
   $archive_bin_path = "${extract_path}/${bin_name}"
 
   file { $extract_path:

--- a/manifests/openldap_exporter.pp
+++ b/manifests/openldap_exporter.pp
@@ -86,7 +86,7 @@ class prometheus::openldap_exporter (
   if versioncmp($version, '2.2.1') >= 0 {
     $real_download_extension = 'gz'
     $real_download_url = pick($download_url,"${download_url_base}/download/${release}/${package_name}-${os}-${prometheus::real_arch}.gz")
-    $extract_path = "/opt/openldap_exporter-${version}.${os}-${prometheus::real_arch}"
+    $extract_path = "${prometheus::basepath}/openldap_exporter-${version}.${os}-${prometheus::real_arch}"
     $archive_bin_path = "${extract_path}/openldap_exporter-${os}-${prometheus::real_arch}"
     $extract_command = "gzip -cd %s > ${archive_bin_path}"
     file { $extract_path:

--- a/manifests/openldap_exporter.pp
+++ b/manifests/openldap_exporter.pp
@@ -96,7 +96,7 @@ class prometheus::openldap_exporter (
 
   # For compatibility with previous versions, we keep the previous name for the service
   # but since the binary has changed name, we need to specify it manually.
-  $extract_path = "/opt/${service_name}-${version}.${os}-${real_arch}"
+  $extract_path = "${prometheus::basepath}/${service_name}-${version}.${os}-${real_arch}"
   $archive_bin_path = "${extract_path}/${package_name}"
   file { $extract_path:
     ensure => 'directory',

--- a/manifests/php_fpm_exporter.pp
+++ b/manifests/php_fpm_exporter.pp
@@ -105,7 +105,7 @@ class prometheus::php_fpm_exporter (
     # php-fpm_exporter lacks currently as of version 2.0.4
     # TODO: patch prometheus::daemon to support custom extract directories
     $real_install_method = 'none'
-    $install_dir = "/opt/${package_name}-${version}.${os}-${arch}"
+    $install_dir = "${prometheus::basepath}/${package_name}-${version}.${os}-${arch}"
     file { $install_dir:
       ensure => 'directory',
       owner  => 'root',

--- a/manifests/php_fpm_exporter.pp
+++ b/manifests/php_fpm_exporter.pp
@@ -100,7 +100,7 @@ class prometheus::php_fpm_exporter (
 
   $options = "server --phpfpm.scrape-uri '${scrape_uri}' ${extra_options}"
 
-  $extract_path = "/opt/${package_name}-${version}.${os}-${arch}"
+  $extract_path = "${prometheus::basepath}/${package_name}-${version}.${os}-${arch}"
   $archive_bin_path = "${extract_path}/${bin_name}"
 
   file { $extract_path:

--- a/manifests/postgres_exporter.pp
+++ b/manifests/postgres_exporter.pp
@@ -138,7 +138,7 @@ class prometheus::postgres_exporter (
     # postgres_exporter lacks.
     # TODO: patch prometheus::daemon to support custom extract directories
     $exporter_install_method = 'none'
-    $install_dir = "/opt/${service_name}-${version}.${os}-${arch}"
+    $install_dir = "${prometheus::basepath}/${service_name}-${version}.${os}-${arch}"
     file { $install_dir:
       ensure => 'directory',
       owner  => 'root',

--- a/manifests/postgres_exporter.pp
+++ b/manifests/postgres_exporter.pp
@@ -107,10 +107,10 @@ class prometheus::postgres_exporter (
 
   if versioncmp($version, '0.9.0') < 0 {
     $real_download_url = pick($download_url, "${download_url_base}/download/${release}/${package_name}_${release}_${os}-${arch}.${download_extension}")
-    $bin_path = "/opt/${package_name}_v${version}_${os}-${arch}/postgres_exporter"
+    $bin_path = "${prometheus::basepath}/${package_name}_v${version}_${os}-${arch}/postgres_exporter"
   } else {
     $real_download_url = pick($download_url, "${download_url_base}/download/${release}/${package_name}-${version}.${os}-${arch}.${download_extension}")
-    $bin_path = "/opt/${package_name}-${version}.${os}-${arch}/postgres_exporter"
+    $bin_path = "${prometheus::basepath}/${package_name}-${version}.${os}-${arch}/postgres_exporter"
   }
 
   $notify_service = $restart_on_change ? {

--- a/manifests/puppetdb_exporter.pp
+++ b/manifests/puppetdb_exporter.pp
@@ -123,7 +123,7 @@ class prometheus::puppetdb_exporter (
     scrape_job_name    => $scrape_job_name,
     scrape_job_labels  => $scrape_job_labels,
     bin_name           => $bin_name,
-    archive_bin_path   => "/opt/prometheus-puppetdb-exporter-${version}.${os}-${arch}/prometheus-puppetdb-exporter",
+    archive_bin_path   => "${prometheus::basepath}/prometheus-puppetdb-exporter-${version}.${os}-${arch}/prometheus-puppetdb-exporter",
     proxy_server       => $proxy_server,
     proxy_type         => $proxy_type,
   }

--- a/manifests/puppetdb_exporter.pp
+++ b/manifests/puppetdb_exporter.pp
@@ -124,7 +124,7 @@ class prometheus::puppetdb_exporter (
     scrape_job_name    => $scrape_job_name,
     scrape_job_labels  => $scrape_job_labels,
     bin_name           => $bin_name,
-    archive_bin_path   => "/opt/prometheus-puppetdb-exporter-${version}.${os}-${arch}/prometheus-puppetdb-exporter",
+    archive_bin_path   => "${prometheus::basepath}/prometheus-puppetdb-exporter-${version}.${os}-${arch}/prometheus-puppetdb-exporter",
     proxy_server       => $proxy_server,
     proxy_type         => $proxy_type,
   }

--- a/manifests/pushprox_client.pp
+++ b/manifests/pushprox_client.pp
@@ -96,7 +96,7 @@ class prometheus::pushprox_client (
     install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,
-    archive_bin_path   => "/opt/PushProx-${version}.${os}-${arch}/pushprox-client",
+    archive_bin_path   => "${prometheus::basepath}/PushProx-${version}.${os}-${arch}/pushprox-client",
     os                 => $os,
     arch               => $arch,
     real_download_url  => $real_download_url,

--- a/manifests/pushprox_proxy.pp
+++ b/manifests/pushprox_proxy.pp
@@ -90,7 +90,7 @@ class prometheus::pushprox_proxy (
     install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,
-    archive_bin_path   => "/opt/PushProx-${version}.${os}-${arch}/pushprox-proxy",
+    archive_bin_path   => "${prometheus::basepath}/PushProx-${version}.${os}-${arch}/pushprox-proxy",
     os                 => $os,
     arch               => $arch,
     real_download_url  => $real_download_url,

--- a/manifests/redis_exporter.pp
+++ b/manifests/redis_exporter.pp
@@ -110,7 +110,7 @@ class prometheus::redis_exporter (
       # redis_exporter lacks before version 1.0.0
       # TODO: patch prometheus::daemon to support custom extract directories
       $real_install_method = 'none'
-      $install_dir = "/opt/${service_name}-${version}.${os}-${arch}"
+      $install_dir = "${prometheus::basepath}/${service_name}-${version}.${os}-${arch}"
       file { $install_dir:
         ensure => 'directory',
         owner  => 'root',

--- a/manifests/snmp_exporter.pp
+++ b/manifests/snmp_exporter.pp
@@ -105,12 +105,12 @@ class prometheus::snmp_exporter (
   }
 
   $_source = $config_template ? {
-    ''      => "file:/opt/snmp_exporter-${version}.${os}-${arch}/snmp.yml",
+    ''      => "file:${prometheus::basepath}/snmp_exporter-${version}.${os}-${arch}/snmp.yml",
     default => undef,
   }
 
   $_require = $config_template ? {
-    ''      => File["/opt/snmp_exporter-${version}.${os}-${arch}/snmp_exporter"],
+    ''      => File["${prometheus::basepath}/snmp_exporter-${version}.${os}-${arch}/snmp_exporter"],
     default => undef,
   }
 

--- a/manifests/snmp_exporter.pp
+++ b/manifests/snmp_exporter.pp
@@ -106,12 +106,12 @@ class prometheus::snmp_exporter (
   }
 
   $_source = $config_template ? {
-    ''      => "file:/opt/snmp_exporter-${version}.${os}-${arch}/snmp.yml",
+    ''      => "file:${prometheus::basepath}/snmp_exporter-${version}.${os}-${arch}/snmp.yml",
     default => undef,
   }
 
   $_require = $config_template ? {
-    ''      => File["/opt/snmp_exporter-${version}.${os}-${arch}/snmp_exporter"],
+    ''      => File["${prometheus::basepath}/snmp_exporter-${version}.${os}-${arch}/snmp_exporter"],
     default => undef,
   }
 

--- a/manifests/ssl_exporter.pp
+++ b/manifests/ssl_exporter.pp
@@ -113,7 +113,7 @@ class prometheus::ssl_exporter (
   ], ' ')
 
   # SSL exporter is not packaged into a directory
-  $extract_path = "/opt/${service_name}-${version}.${os}-${arch}"
+  $extract_path = "${prometheus::basepath}/${service_name}-${version}.${os}-${arch}"
   file { $extract_path:
     ensure => 'directory',
     owner  => 'root',

--- a/manifests/ssl_exporter.pp
+++ b/manifests/ssl_exporter.pp
@@ -114,7 +114,7 @@ class prometheus::ssl_exporter (
   ], ' ')
 
   # SSL exporter is not packaged into a directory
-  $extract_path = "/opt/${service_name}-${version}.${os}-${arch}"
+  $extract_path = "${prometheus::basepath}/${service_name}-${version}.${os}-${arch}"
   file { $extract_path:
     ensure => 'directory',
     owner  => 'root',

--- a/spec/acceptance/prometheus_spec.rb
+++ b/spec/acceptance/prometheus_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'prometheus' do
+  it 'prometheus do not clean URL releases' do
+    pp_dirty_v0152 = <<-EOS
+      class { 'prometheus':
+        clean_url_releases => false,
+      }
+      class { 'prometheus::node_exporter':
+        version => '0.15.2',
+      }
+    EOS
+
+    pp_dirty_v0160 = <<-EOS
+      class { 'prometheus':
+        clean_url_releases => false,
+      }
+      class { 'prometheus::node_exporter':
+        version => '0.16.0',
+      }
+    EOS
+
+    # Run it twice and test for idempotency
+    apply_manifest(pp_dirty_v0152, catch_failures: true)
+    apply_manifest(pp_dirty_v0152, catch_changes: true)
+
+    # Run it twice and test for idempotency
+    apply_manifest(pp_dirty_v0160, catch_failures: true)
+    apply_manifest(pp_dirty_v0160, catch_changes: true)
+  end
+
+  # rubocop:disable RSpec/RepeatedExampleGroupBody,RSpec/RepeatedExampleGroupDescription
+  describe service('node_exporter') do
+    it { is_expected.to be_running }
+    it { is_expected.to be_enabled }
+  end
+
+  describe port(9100) do
+    it { is_expected.to be_listening.with('tcp6') }
+  end
+
+  describe file('/opt/node_exporter-0.15.2.linux-amd64') do
+    it { is_expected.to exist }
+  end
+
+  describe file('/opt/node_exporter-0.16.0.linux-amd64') do
+    it { is_expected.to exist }
+  end
+  # rubocop:enable RSpec/RepeatedExampleGroupBody,RSpec/RepeatedExampleGroupDescription
+
+  it 'prometheus do clean URL releases' do
+    pp_clean_v0152 = <<-EOS
+      class { 'prometheus':
+        clean_url_releases => false,
+      }
+      class { 'prometheus::node_exporter':
+        version => '0.15.2',
+      }
+    EOS
+
+    pp_clean_v0160 = <<-EOS
+      class { 'prometheus':
+        clean_url_releases => false,
+      }
+      class { 'prometheus::node_exporter':
+        version => '0.16.0',
+      }
+    EOS
+
+    # Run it twice and test for idempotency
+    apply_manifest(pp_clean_v0152, catch_failures: true)
+    apply_manifest(pp_clean_v0152, catch_changes: true)
+
+    # Run it twice and test for idempotency
+    apply_manifest(pp_clean_v0160, catch_failures: true)
+    apply_manifest(pp_clean_v0160, catch_changes: true)
+  end
+
+  # rubocop:disable RSpec/RepeatedExampleGroupBody,RSpec/RepeatedExampleGroupDescription
+  describe service('node_exporter') do
+    it { is_expected.to be_running }
+    it { is_expected.to be_enabled }
+  end
+
+  describe port(9100) do
+    it { is_expected.to be_listening.with('tcp6') }
+  end
+
+  describe file('/opt/prometheus/node_exporter-0.15.2.linux-amd64') do
+    it { is_expected.not_to exist }
+  end
+
+  describe file('/opt/prometheus/node_exporter-0.16.0.linux-amd64') do
+    it { is_expected.to exist }
+  end
+  # rubocop:enable RSpec/RepeatedExampleGroupBody,RSpec/RepeatedExampleGroupDescription
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'prometheus' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge(os_specific_facts(facts))
+      end
+
+      context 'without parameters' do
+        it {
+          is_expected.to compile.with_all_deps
+        }
+
+        it {
+          is_expected.not_to contain_file('/opt/prometheus')
+        }
+      end
+
+      context 'with activated url release cleaning' do
+        let(:params) do
+          {
+            clean_url_releases: true,
+          }
+        end
+
+        it {
+          is_expected.to compile.with_all_deps
+        }
+
+        it {
+          is_expected.to contain_file('/opt/prometheus').with(
+            ensure: 'directory',
+            owner: 'root',
+            group: 'root',
+            mode: '0755',
+            backup: false,
+            force: true,
+            purge: true,
+            recurse: true
+          )
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Move the URL releases to their own directory under /opt to create the possibility for Puppet to remove old releases that are no longer used.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
In order to achieve that Puppet can clean up the directory in which Prometheus and the exporters are located, I have created a subdirectory under `/opt`. This allows Puppet to purge the directory which would lead to unwanted behavior with `/opt`.

However, this would reinstall all exporters once, which would require one-time manual clean-up. Then you can have that automatically.

So that the change is minimally invasive, I have the whole thing activated via a variable that is deactivated by default.

Please let me know if anything is missing or if my approach does not fit.

#### This Pull Request (PR) fixes the following issues
Fixes #625
