### PR TITLE
Update default external_labels

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -93,8 +93,7 @@ prometheus::extra_groups: []
 prometheus::global_config:
   'scrape_interval': '15s'
   'evaluation_interval': '15s'
-  'external_labels':
-    'monitor': 'master'
+  'external_labels': {}
 prometheus::group: 'prometheus'
 prometheus::include_default_scrape_configs: true
 prometheus::localstorage: '/var/lib/prometheus'

--- a/spec/fixtures/files/prometheus1.yaml
+++ b/spec/fixtures/files/prometheus1.yaml
@@ -2,8 +2,7 @@
 global:
   scrape_interval: 15s
   evaluation_interval: 15s
-  external_labels:
-    monitor: master
+  external_labels: {}
 rule_files:
 - "/etc/prometheus/rules.d/*.rules"
 scrape_configs:

--- a/spec/fixtures/files/prometheus2.yaml
+++ b/spec/fixtures/files/prometheus2.yaml
@@ -2,8 +2,7 @@
 global:
   scrape_interval: 15s
   evaluation_interval: 15s
-  external_labels:
-    monitor: master
+  external_labels: {}
 rule_files:
 - "/etc/prometheus/rules.d/*.rules"
 scrape_configs:


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
The following commit sets `external_labels` to an empty hash by default. The previous value prevent the use of deep-merge strategy for the key `prometheus::global_config` when using hiera.

⚠️ This might be a breaking change for some users

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
None