### PR TITLE
Debian OS family: Install apt-transport-https during CI

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -9,3 +9,9 @@ file_line { '/etc/hosts-squid':
   path => '/etc/hosts',
   line => "${facts['squid_ip']} squid",
 }
+
+if $facts['os']['family'] == 'Debian' {
+  package { 'apt-transport-https':
+    ensure => 'installed'
+  }
+}


### PR DESCRIPTION
This is sometimes required and to speed up our CI, we don't rely on the
puppetlabs/apt module to install it.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
