### PR TITLE
Facter: confine to linux only

### DIFF
--- a/lib/facter/alert_manager_running.rb
+++ b/lib/facter/alert_manager_running.rb
@@ -3,10 +3,13 @@
 require 'puppet'
 
 Facter.add('prometheus_alert_manager_running') do
+  confine kernel: :linux
   setcode do
-    service = Puppet::Type.type(:service).new(:name => 'alert_manager') # rubocop:disable Style/HashSyntax
-    service.provider.status == :running
-  rescue Puppet::Error
-    false
+    begin
+      service = Puppet::Type.type(:service).new(:name => 'alert_manager') # rubocop:disable Style/HashSyntax
+      service.provider.status == :running
+    rescue Puppet::Error
+      false
+    end
   end
 end


### PR DESCRIPTION
Having this module enabled on Windows nodes, will raise an error like:
`error while resolving custom facts in C:/ProgramData\PuppetLabs\puppet\cache\lib\facter\alert_manager_running.rb: C:/ProgramData/PuppetLabs/puppet/cache/lib/facter/alert_manager_running.rb:10: syntax error, unexpected keyword_rescue, expecting keyword_end
rescue Puppet::Error
^
C:/ProgramData/PuppetLabs/puppet/cache/lib/facter/alert_manager_running.rb:13: syntax error, unexpected keyword_end, expecting end-of-input`

Confine facter to only run on linux nodes fix this issue.