### PR TITLE
prometheus config: set file_sd_config.d mode

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -191,6 +191,7 @@ class prometheus::config {
   file { "${prometheus::config_dir}/file_sd_config.d":
     ensure  => directory,
     group   => $prometheus::server::group,
+    mode    => $prometheus::config_mode,
     purge   => $prometheus::purge_config_dir,
     recurse => true,
     notify  => Class['prometheus::service_reload'], # After purging, a reload is needed


### PR DESCRIPTION
Hello, this PR aims to set the mode to the folder containing the scrape files that are themselves already set to this parameter.
The goal is to ensure that the folder has the correct permissions.


Signed-off-by: Arnaud SINAYS <sinaysarnaud@gmail.com>


