### PR TITLE
Change default port from 9090 to 9419

### DIFF
--- a/manifests/rabbitmq_exporter.pp
+++ b/manifests/rabbitmq_exporter.pp
@@ -102,7 +102,7 @@ class prometheus::rabbitmq_exporter (
   Hash[String,String] $extra_env_vars                        = {},
   Boolean $export_scrape_job                                 = false,
   Optional[Stdlib::Host] $scrape_host                        = undef,
-  Stdlib::Port $scrape_port                                  = 9090,
+  Stdlib::Port $scrape_port                                  = 9419,
   String[1] $scrape_job_name                                 = 'rabbitmq',
   Optional[Hash] $scrape_job_labels                          = undef,
   Optional[String[1]] $proxy_server                          = undef,
@@ -122,6 +122,7 @@ class prometheus::rabbitmq_exporter (
     'SKIP_QUEUES'         => $queues_exclude_regex,
     'RABBIT_CAPABILITIES' => join($rabbit_capabilities, ','),
     'RABBIT_EXPORTERS'    => join($rabbit_exporters, ','),
+    'PUBLISH_PORT'        => $scrape_port,
   }
 
   $real_env_vars = merge($env_vars, $extra_env_vars)

--- a/spec/acceptance/rabbitmq_exporter_spec.rb
+++ b/spec/acceptance/rabbitmq_exporter_spec.rb
@@ -36,7 +36,7 @@ describe 'prometheus rabbitmq_exporter' do
       it { is_expected.to be_enabled }
     end
 
-    describe port(9090) do
+    describe port(9419) do
       it { is_expected.to be_listening.with('tcp6') }
     end
   end

--- a/spec/classes/rabbitmq_exporter_spec.rb
+++ b/spec/classes/rabbitmq_exporter_spec.rb
@@ -34,6 +34,20 @@ describe 'prometheus::rabbitmq_exporter' do
           it { is_expected.to contain_group('rabbitmq-exporter') }
           it { is_expected.to contain_service('rabbitmq_exporter') }
         end
+        describe 'create env_var file' do
+          it 'should set publish_port env_var to scrape_port value' do
+            if facts[:os]['family'] == 'RedHat'
+              rabbitmq_env = catalogue.resource('File', '/etc/sysconfig/rabbitmq_exporter').send(:parameters)[:content]
+            elsif facts[:os]['name'] == 'Archlinux'
+              rabbitmq_env = catalogue.resource('File', '/etc/conf.d/rabbitmq_exporter').send(:parameters)[:content]
+            elsif facts[:os]['name'] == 'Darwin'
+              rabbitmq_env = catalogue.resource('File', '/etc/rabbitmq_exporter').send(:parameters)[:content]
+            else
+              rabbitmq_env = catalogue.resource('File', '/etc/default/rabbitmq_exporter').send(:parameters)[:content]
+            end
+            expect(rabbitmq_env).to include('PUBLISH_PORT="9419"')
+          end
+        end
       end
     end
   end

--- a/spec/classes/rabbitmq_exporter_spec.rb
+++ b/spec/classes/rabbitmq_exporter_spec.rb
@@ -34,17 +34,18 @@ describe 'prometheus::rabbitmq_exporter' do
           it { is_expected.to contain_group('rabbitmq-exporter') }
           it { is_expected.to contain_service('rabbitmq_exporter') }
         end
+
         describe 'create env_var file' do
-          it 'should set publish_port env_var to scrape_port value' do
-            if facts[:os]['family'] == 'RedHat'
-              rabbitmq_env = catalogue.resource('File', '/etc/sysconfig/rabbitmq_exporter').send(:parameters)[:content]
-            elsif facts[:os]['name'] == 'Archlinux'
-              rabbitmq_env = catalogue.resource('File', '/etc/conf.d/rabbitmq_exporter').send(:parameters)[:content]
-            elsif facts[:os]['name'] == 'Darwin'
-              rabbitmq_env = catalogue.resource('File', '/etc/rabbitmq_exporter').send(:parameters)[:content]
-            else
-              rabbitmq_env = catalogue.resource('File', '/etc/default/rabbitmq_exporter').send(:parameters)[:content]
-            end
+          it 'sets publish_port env_var to scrape_port value' do
+            rabbitmq_env = if facts[:os]['family'] == 'RedHat'
+                             catalogue.resource('File', '/etc/sysconfig/rabbitmq_exporter').send(:parameters)[:content]
+                           elsif facts[:os]['name'] == 'Archlinux'
+                             catalogue.resource('File', '/etc/conf.d/rabbitmq_exporter').send(:parameters)[:content]
+                           elsif facts[:os]['name'] == 'Darwin'
+                             catalogue.resource('File', '/etc/rabbitmq_exporter').send(:parameters)[:content]
+                           else
+                             catalogue.resource('File', '/etc/default/rabbitmq_exporter').send(:parameters)[:content]
+                           end
             expect(rabbitmq_env).to include('PUBLISH_PORT="9419"')
           end
         end


### PR DESCRIPTION
#### Pull Request (PR) description

Changes the default scrape port for the rabbitmq_exporter to avoid the issue mentioned in the maintainers readme https://github.com/kbudde/rabbitmq_exporter/tree/v0.29.0#breaking-change---100

#### This Pull Request (PR) fixes the following issues

