### PR TITLE
Prometheus v2 to_yaml add line_width option

### DIFF
--- a/templates/prometheus.yaml.erb
+++ b/templates/prometheus.yaml.erb
@@ -21,9 +21,4 @@ if @prometheus_v2
     full_config['remote_write'] = remote_write_configs
 end
  -%>
-<%= if @prometheus_v2
-full_config.to_yaml().gsub(/source_labels: ".+?"/) { |x| x.gsub('"', '') }
-else
-full_config.to_yaml(options = {:line_width => -1}).gsub(/source_labels: ".+?"/) { |x| x.gsub('"', '') }
-end
- -%>
+<%= full_config.to_yaml(options = {:line_width => -1}).gsub(/source_labels: ".+?"/) { |x| x.gsub('"', '') } -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Prometheus v2 to_yaml missing line_width option breaks puppetdb queries by adding new lines.

E.g. using:

```
  ...

  $_puppetdb_queries = {
    'some_app'  => "inventory { resources { type = 'Package' and title = 'some_app' } and ( ${_environment_query} ) }",
    'node' => "inventory { resources { type = 'Package' and title = 'node_exporter' } and ( ${_environment_query} ) }",
  }

  class { 'prometheus::server':
  ...
    scrape_configs  => [
      {
        'job_name'            => 'some_app',
        'puppetdb_sd_configs' => [
          {
            'include_parameters' => false,
            'port'               => 8161,
            'query'              => $_puppetdb_queries['some_app'],
```

Without line_width -1, line breaks are added breaking the puppetdb queries.

#### This Pull Request (PR) fixes the following issues
n/a
