### PR TITLE
add time_intervals support for alertmanager >= 0.24.0

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -914,6 +914,7 @@ The following parameters are available in the `prometheus::alertmanager` class:
 * [`service_name`](#service_name)
 * [`storage_path`](#storage_path)
 * [`templates`](#templates)
+* [`time_intervals`](#time_intervals)
 * [`user`](#user)
 * [`version`](#version)
 * [`proxy_server`](#proxy_server)
@@ -1181,6 +1182,17 @@ The storage path to pass to the alertmanager. Defaults to '/var/lib/alertmanager
 Data type: `Array`
 
 The array of template files. Defaults to [ "${config_dir}/*.tmpl" ]
+
+##### <a name="time_intervals"></a>`time_intervals`
+
+Data type: `Array[Hash]`
+
+Array of time intervals
+Example:
+prometheus::alertmanager::time_intervals:
+- name: weekend
+  time_intervals:
+  - weekdays: ['saturday','sunday']
 
 ##### <a name="user"></a>`user`
 

--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -54,6 +54,7 @@ prometheus::alertmanager::route:
 prometheus::alertmanager::mute_time_intervals: []
 prometheus::alertmanager::storage_path: '/var/lib/alertmanager'
 prometheus::alertmanager::templates: [ "%{lookup('prometheus::alertmanager::config_dir')}/*.tmpl" ]
+prometheus::alertmanager::time_intervals: []
 prometheus::alertmanager::user: 'alertmanager'
 prometheus::alertmanager::version: '0.21.0'
 prometheus::alerts: {}

--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -96,6 +96,13 @@
 #  The storage path to pass to the alertmanager. Defaults to '/var/lib/alertmanager'
 # @param templates
 #  The array of template files. Defaults to [ "${config_dir}/*.tmpl" ]
+# @param time_intervals
+#  Array of time intervals
+#  Example:
+#  prometheus::alertmanager::time_intervals:
+#  - name: weekend
+#    time_intervals:
+#      - weekdays: ['saturday','sunday']
 # @param user
 #  User which runs the service
 # @param version
@@ -120,6 +127,7 @@ class prometheus::alertmanager (
   Array[Hash] $mute_time_intervals,
   Stdlib::Absolutepath $storage_path,
   Array $templates,
+  Array[Hash] $time_intervals,
   String[1] $user,
   String[1] $version,
   Boolean $service_enable                                    = true,

--- a/spec/classes/alertmanager_spec.rb
+++ b/spec/classes/alertmanager_spec.rb
@@ -42,6 +42,7 @@ describe 'prometheus::alertmanager' do
 
           it {
             expect(subject).not_to contain_file('/etc/alertmanager/alertmanager.yaml').with_content(%r{mute_time_intervals})
+            expect(subject).not_to contain_file('/etc/alertmanager/alertmanager.yaml').with_content(%r{time_intervals})
           }
         end
 
@@ -75,6 +76,30 @@ describe 'prometheus::alertmanager' do
                             '  weekdays:',
                             '  - saturday',
                             '  - sunday',
+                          ])
+        }
+      end
+
+      context 'with latest version specified and time_intervals' do
+        let(:params) do
+          {
+            version: '0.24.0',
+            arch: 'amd64',
+            os: 'linux',
+            bin_dir: '/usr/local/bin',
+            install_method: 'url',
+            time_intervals: [{ 'name' => 'weekend', 'time_intervals' => [{ 'weekdays' => %w[saturday sunday] }] }],
+          }
+        end
+
+        it {
+          verify_contents(catalogue, '/etc/alertmanager/alertmanager.yaml', [
+                            'time_intervals:',
+                            '- name: weekend',
+                            '  time_intervals:',
+                            '  - weekdays:',
+                            '    - saturday',
+                            '    - sunday',
                           ])
         }
       end

--- a/templates/alertmanager.yaml.erb
+++ b/templates/alertmanager.yaml.erb
@@ -9,5 +9,8 @@
 if scope.function_versioncmp([scope.lookupvar('::prometheus::alertmanager::version'), '0.22.0']) >= 0
   full_config['mute_time_intervals'] = scope.lookupvar('::prometheus::alertmanager::mute_time_intervals')
 end
+if scope.function_versioncmp([scope.lookupvar('::prometheus::alertmanager::version'), '0.24.0']) >= 0
+  full_config['time_intervals'] = scope.lookupvar('::prometheus::alertmanager::time_intervals')
+end
 -%>
 <%= full_config.to_yaml -%>


### PR DESCRIPTION
#### Pull Request (PR) description
The alertmanager `mute_time_intervals` directive introduced in 0.22.0 has (already) been deprecated in favor of the more flexible `time_interval` directive, for which this PR adds support. For details, see [the alertmanager configuration documentation.](https://prometheus.io/docs/alerting/0.24/configuration/)

#### This Pull Request (PR) fixes the following issues
Adds support for the missing `time_intervals` configuration directive for alertmanager 0.24.0 and up.