### PR TITLE
add proxy_server & proxy_type to server install

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -11613,6 +11613,8 @@ The following parameters are available in the `prometheus::server` class:
 * [`collect_tag`](#-prometheus--server--collect_tag)
 * [`max_open_files`](#-prometheus--server--max_open_files)
 * [`usershell`](#-prometheus--server--usershell)
+* [`proxy_server`](#-prometheus--server--proxy_server)
+* [`proxy_type`](#-prometheus--server--proxy_type)
 
 ##### <a name="-prometheus--server--configname"></a>`configname`
 
@@ -12005,6 +12007,22 @@ Data type: `Stdlib::Absolutepath`
 
 
 Default value: `$prometheus::usershell`
+
+##### <a name="-prometheus--server--proxy_server"></a>`proxy_server`
+
+Data type: `Optional[String[1]]`
+
+
+
+Default value: `$prometheus::proxy_server`
+
+##### <a name="-prometheus--server--proxy_type"></a>`proxy_type`
+
+Data type: `Optional[Enum['none', 'http', 'https', 'ftp']]`
+
+
+
+Default value: `$prometheus::proxy_type`
 
 ### <a name="prometheus--snmp_exporter"></a>`prometheus::snmp_exporter`
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,6 +25,8 @@ class prometheus::install {
         creates         => "/opt/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/prometheus",
         cleanup         => true,
         extract_command => $prometheus::extract_command,
+        proxy_server    => $prometheus::server::proxy_server,
+        proxy_type      => $prometheus::server::proxy_type,
       }
       -> file {
         "/opt/prometheus-${prometheus::server::version}.${prometheus::server::os}-${prometheus::server::real_arch}/prometheus":

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -49,6 +49,8 @@ class prometheus::server (
   Optional[String[1]] $collect_tag                                              = $prometheus::collect_tag,
   Optional[Integer] $max_open_files                                             = $prometheus::max_open_files,
   Stdlib::Absolutepath $usershell                                               = $prometheus::usershell,
+  Optional[String[1]] $proxy_server                                             = $prometheus::proxy_server,
+  Optional[Enum['none', 'http', 'https', 'ftp']] $proxy_type                    = $prometheus::proxy_type,
 ) inherits prometheus {
   if( versioncmp($version, '1.0.0') == -1 ) {
     $real_download_url = pick($download_url,

--- a/spec/classes/prometheus_spec.rb
+++ b/spec/classes/prometheus_spec.rb
@@ -15,7 +15,7 @@ describe 'prometheus' do
                      '/etc/prometheus/prometheus.yaml'
                    end
 
-      [{ manage_prometheus_server: true, version: '2.0.0-rc.1', bin_dir: '/usr/local/bin', install_method: 'url', rule_files: ['/etc/prometheus/rules.d/*.rules'] }].each do |parameters|
+      [{ manage_prometheus_server: true, version: '2.0.0-rc.1', bin_dir: '/usr/local/bin', install_method: 'url', rule_files: ['/etc/prometheus/rules.d/*.rules'], proxy_server: 'proxy.test', proxy_type: 'https' }].each do |parameters|
         context "with parameters #{parameters}" do
           let(:params) do
             parameters
@@ -51,7 +51,9 @@ describe 'prometheus' do
               'source' => "https://github.com/prometheus/prometheus/releases/download/v#{prom_version}/prometheus-#{prom_version}.#{prom_os}-#{prom_arch}.tar.gz",
               'checksum_verify' => false,
               'creates' => "/opt/prometheus-#{prom_version}.#{prom_os}-#{prom_arch}/prometheus",
-              'cleanup' => true
+              'cleanup' => true,
+              'proxy_server' => 'proxy.test',
+              'proxy_type' => 'https'
             ).that_comes_before("File[/opt/prometheus-#{prom_version}.#{prom_os}-#{prom_arch}/prometheus]")
           }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Adds proxy parameters to the archive resource in install.pp, allowing prometheus to be installed from behind a proxy server.

#### This Pull Request (PR) fixes the following issues
PR #596 said it closed issue #186. However, while that PR adds `proxy_server` and `proxy_type` to Alertmanager and every exporter, it did not add the proxy parameters to the installation of prometheus itself. 
