### PR TITLE
Adapt web.config.file option for node_exporter versions higher than 1.5.0

### DIFF
--- a/manifests/node_exporter.pp
+++ b/manifests/node_exporter.pp
@@ -202,7 +202,11 @@ class prometheus::node_exporter (
       content => $web_config_content.to_yaml,
     }
 
-    $web_config = "--web.config=${$web_config_file}"
+    if versioncmp($version, '1.5.0') >= 0 {
+      $web_config = "--web.config.file=${$web_config_file}"
+    } else {
+      $web_config = "--web.config=${$web_config_file}"
+    }
   }
 
   $options = [

--- a/spec/classes/node_exporter_spec.rb
+++ b/spec/classes/node_exporter_spec.rb
@@ -128,9 +128,10 @@ describe 'prometheus::node_exporter' do
         end
       end
 
-      context 'with tls set in web-config.yml' do
+      context 'with tls set in web-config.yml version lower than 1.5.0' do
         let(:params) do
           {
+            version: '1.4.0',
             use_tls_server_config: true,
             tls_cert_file: '/etc/node_exporter/foo.cert',
             tls_key_file: '/etc/node_exporter/foo.key'
@@ -144,6 +145,46 @@ describe 'prometheus::node_exporter' do
           it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '   --web.config=/etc/node_exporter_web-config.yml') }
         else
           it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '   --web.config=/etc/node_exporter_web-config.yml') }
+        end
+      end
+
+      context 'with tls set in web-config.yml version equal to 1.5.0' do
+        let(:params) do
+          {
+            version: '1.5.0',
+            use_tls_server_config: true,
+            tls_cert_file: '/etc/node_exporter/foo.cert',
+            tls_key_file: '/etc/node_exporter/foo.key'
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/etc/node_exporter_web-config.yml').with(ensure: 'file') }
+
+        if facts[:os]['name'] == 'Archlinux'
+          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '   --web.config.file=/etc/node_exporter_web-config.yml') }
+        else
+          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '   --web.config.file=/etc/node_exporter_web-config.yml') }
+        end
+      end
+
+      context 'with tls set in web-config.yml version higher to 1.5.0' do
+        let(:params) do
+          {
+            version: '1.5.1',
+            use_tls_server_config: true,
+            tls_cert_file: '/etc/node_exporter/foo.cert',
+            tls_key_file: '/etc/node_exporter/foo.key'
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/etc/node_exporter_web-config.yml').with(ensure: 'file') }
+
+        if facts[:os]['name'] == 'Archlinux'
+          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '   --web.config.file=/etc/node_exporter_web-config.yml') }
+        else
+          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '   --web.config.file=/etc/node_exporter_web-config.yml') }
         end
       end
     end


### PR DESCRIPTION
From: https://github.com/prometheus/node_exporter/blob/master/CHANGELOG.md version 1.5.0:

```
NOTE: A command line arg has been changed from --web.config to --web.config.file.
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
