### PR TITLE
alertmanager: Fix config dir mode for ubuntu

### DIFF
--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -189,6 +189,7 @@ class prometheus::alertmanager (
     ensure  => 'directory',
     owner   => 'root',
     group   => $group,
+    mode    => '0750',
     purge   => $purge_config_dir,
     recurse => $purge_config_dir,
   }


### PR DESCRIPTION
Make sure alertmanager group can reach the config on ubuntu.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
