### PR TITLE
issue #604 : compatibility for ssl connections to the database

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6441,6 +6441,9 @@ The following parameters are available in the `prometheus::mysqld_exporter` clas
 * [`cnf_port`](#-prometheus--mysqld_exporter--cnf_port)
 * [`cnf_socket`](#-prometheus--mysqld_exporter--cnf_socket)
 * [`cnf_user`](#-prometheus--mysqld_exporter--cnf_user)
+* [`cnf_ssl_ca`](#-prometheus--mysqld_exporter--cnf_ssl_ca)
+* [`cnf_ssl_cert`](#-prometheus--mysqld_exporter--cnf_ssl_cert)
+* [`cnf_ssl_key`](#-prometheus--mysqld_exporter--cnf_ssl_key)
 * [`arch`](#-prometheus--mysqld_exporter--arch)
 * [`bin_dir`](#-prometheus--mysqld_exporter--bin_dir)
 * [`config_mode`](#-prometheus--mysqld_exporter--config_mode)
@@ -6520,6 +6523,30 @@ Data type: `String[1]`
 The mysql user to use when connecting.
 
 Default value: `login`
+
+##### <a name="-prometheus--mysqld_exporter--cnf_ssl_ca"></a>`cnf_ssl_ca`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+The path name of the Certificate Authority (CA) certificate file in PEM format. The file may contain a list of trusted SSL Certificate Authorities.
+
+Default value: `undef`
+
+##### <a name="-prometheus--mysqld_exporter--cnf_ssl_cert"></a>`cnf_ssl_cert`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+The path name of the client SSL public key certificate file in PEM format.
+
+Default value: `undef`
+
+##### <a name="-prometheus--mysqld_exporter--cnf_ssl_key"></a>`cnf_ssl_key`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+The path name of the client SSL private key file in PEM format.
+
+Default value: `undef`
 
 ##### <a name="-prometheus--mysqld_exporter--arch"></a>`arch`
 

--- a/manifests/mysqld_exporter.pp
+++ b/manifests/mysqld_exporter.pp
@@ -12,6 +12,12 @@
 #  The socket which the mysql host is running. If defined, host and port are not used.
 # @param cnf_user
 #  The mysql user to use when connecting.
+# @param cnf_ssl_ca
+#  The path name of the Certificate Authority (CA) certificate file in PEM format. The file may contain a list of trusted SSL Certificate Authorities.
+# @param cnf_ssl_cert
+#  The path name of the client SSL public key certificate file in PEM format.
+# @param cnf_ssl_key
+#  The path name of the client SSL private key file in PEM format.
 # @param arch
 #  Architecture (amd64 or i386)
 # @param bin_dir
@@ -80,6 +86,9 @@ class prometheus::mysqld_exporter (
   String[1] $cnf_user                                        = login,
   Variant[Sensitive[String],String] $cnf_password            = 'password',
   Optional[Stdlib::Absolutepath] $cnf_socket                 = undef,
+  Optional[Stdlib::Absolutepath] $cnf_ssl_ca                 = undef,
+  Optional[Stdlib::Absolutepath] $cnf_ssl_cert               = undef,
+  Optional[Stdlib::Absolutepath] $cnf_ssl_key                = undef,
   Boolean $purge_config_dir                                  = true,
   Boolean $restart_on_change                                 = true,
   Boolean $service_enable                                    = true,
@@ -124,6 +133,9 @@ class prometheus::mysqld_exporter (
           'cnf_port'     => $cnf_port,
           'cnf_host'     => $cnf_host,
           'cnf_socket'   => $cnf_socket,
+          'cnf_ssl_ca'   => $cnf_ssl_ca,
+          'cnf_ssl_cert' => $cnf_ssl_cert,
+          'cnf_ssl_key'  => $cnf_ssl_key,
         },
       )
     ),

--- a/templates/my.cnf.epp
+++ b/templates/my.cnf.epp
@@ -4,6 +4,9 @@
   Stdlib::Port $cnf_port,
   Stdlib::Host $cnf_host,
   Optional[Stdlib::Absolutepath] $cnf_socket = undef,
+  Optional[Stdlib::Absolutepath] $cnf_ssl_ca = undef,
+  Optional[Stdlib::Absolutepath] $cnf_ssl_cert = undef,
+  Optional[Stdlib::Absolutepath] $cnf_ssl_key = undef,
 | -%>
 # THIS FILE IS MANAGED BY PUPPET
 [client]
@@ -20,4 +23,12 @@ socket = <%= $cnf_socket %>
 <%- } else { -%>
 host = <%= $cnf_host %>
 port = <%= $cnf_port %>
+<% } -%>
+<% if $cnf_ssl_ca { -%>
+ssl-ca = <%= $cnf_ssl_ca %>
+<% } -%>
+<%# client ssl cert and key, only used if both provided %>
+<% if $cnf_ssl_cert and $cnf_ssl_key { -%>
+ssl-cert = <%= $cnf_ssl_cert %>
+ssl-key = <%= $cnf_ssl_key %>
 <% } -%>


### PR DESCRIPTION
e.g. azure database for mysql

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Added the possibility to provide ssl ca, cert and key paths for ssl connection to the database.
Due to the fact that mysqld_exporter determines this on the ssl-ca variable in exporter my cnf file, this variable is needed at least.


#### This Pull Request (PR) fixes the following issues

Fixes #604
