### PR TITLE
Increased the upper limit for 2/3 dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 10.0.0"
+      "version_requirement": ">= 4.25.0 < 9.0.0"
     },
     {
       "name": "puppet/systemd",

--- a/metadata.json
+++ b/metadata.json
@@ -10,15 +10,15 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 9.0.0"
+      "version_requirement": ">= 4.25.0 < 10.0.0"
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 1.1.1 < 5.0.0"
+      "version_requirement": ">= 1.1.1 < 6.0.0"
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 2.2.0 < 7.0.0"
+      "version_requirement": ">= 2.2.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Increase the upper limit on dependencies:
systemd < 6.0.0
archive < 8.0.0


#### This Pull Request (PR) fixes the following issues
Please note the following:
- The module is not currently managed with PDK, I have not upgraded the testing harness to PDK
