### PR TITLE
Drop legacy systemd reload code for Puppet 5

### DIFF
--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -192,11 +192,6 @@ define prometheus::daemon (
         content => template('prometheus/daemon.systemd.erb'),
         notify  => $notify_service,
       }
-      # Puppet 5 doesn't have https://tickets.puppetlabs.com/browse/PUP-3483
-      # and camptocamp/systemd only creates this relationship when managing the service
-      if $manage_service and versioncmp($facts['puppetversion'], '6.1.0') < 0 {
-        Class['systemd::systemctl::daemon_reload'] -> Service[$name]
-      }
     }
     'sysv': {
       file { "/etc/init.d/${name}":


### PR DESCRIPTION
This was required for Puppet 6.0 and older. We only support Puppet 7 and newer an can drop the old code.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
