### PR TITLE
Rework web-config support for multiple exporters

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -75,6 +75,9 @@ restarting the whole service when a config changes
 * [`Prometheus::Install`](#Prometheus--Install): type to enforce the different installation methods for our exporters.
 * [`Prometheus::S3Uri`](#Prometheus--S3Uri): Type for S3 URIs
 * [`Prometheus::Uri`](#Prometheus--Uri): A URI that can be used to fetch a Prometheus configuration file
+* [`Prometheus::Web_config`](#Prometheus--Web_config): webconfig for the exporter
+* [`Prometheus::Web_config::Http_server_config`](#Prometheus--Web_config--Http_server_config): http_server_config of a exporter webconfig
+* [`Prometheus::Web_config::Tls_server_config`](#Prometheus--Web_config--Tls_server_config): tls_server_config of a exporter webconfig
 
 ## Classes
 
@@ -1340,6 +1343,8 @@ The following parameters are available in the `prometheus::apache_exporter` clas
 * [`version`](#-prometheus--apache_exporter--version)
 * [`proxy_server`](#-prometheus--apache_exporter--proxy_server)
 * [`proxy_type`](#-prometheus--apache_exporter--proxy_type)
+* [`web_config_file`](#-prometheus--apache_exporter--web_config_file)
+* [`web_config_content`](#-prometheus--apache_exporter--web_config_content)
 * [`export_scrape_job`](#-prometheus--apache_exporter--export_scrape_job)
 * [`scrape_host`](#-prometheus--apache_exporter--scrape_host)
 * [`scrape_port`](#-prometheus--apache_exporter--scrape_port)
@@ -1561,6 +1566,22 @@ Data type: `Optional[Enum['none', 'http', 'https', 'ftp']]`
 Optional proxy server type (none|http|https|ftp)
 
 Default value: `undef`
+
+##### <a name="-prometheus--apache_exporter--web_config_file"></a>`web_config_file`
+
+Data type: `Stdlib::Absolutepath`
+
+Path of file where the web-config will be saved to
+
+Default value: `'/etc/apache_exporter_web-config.yml'`
+
+##### <a name="-prometheus--apache_exporter--web_config_content"></a>`web_config_content`
+
+Data type: `Prometheus::Web_config`
+
+Unless empty the content of the web-config yaml which will handed over as option to the exporter
+
+Default value: `{}`
 
 ##### <a name="-prometheus--apache_exporter--export_scrape_job"></a>`export_scrape_job`
 
@@ -2566,6 +2587,8 @@ The following parameters are available in the `prometheus::blackbox_exporter` cl
 * [`config_mode`](#-prometheus--blackbox_exporter--config_mode)
 * [`proxy_server`](#-prometheus--blackbox_exporter--proxy_server)
 * [`proxy_type`](#-prometheus--blackbox_exporter--proxy_type)
+* [`web_config_file`](#-prometheus--blackbox_exporter--web_config_file)
+* [`web_config_content`](#-prometheus--blackbox_exporter--web_config_content)
 
 ##### <a name="-prometheus--blackbox_exporter--arch"></a>`arch`
 
@@ -2822,6 +2845,22 @@ Data type: `Optional[Enum['none', 'http', 'https', 'ftp']]`
 Optional proxy server type (none|http|https|ftp)
 
 Default value: `undef`
+
+##### <a name="-prometheus--blackbox_exporter--web_config_file"></a>`web_config_file`
+
+Data type: `Stdlib::Absolutepath`
+
+Path of file where the web-config will be saved to
+
+Default value: `'/etc/blackbox_exporter_web-config.yml'`
+
+##### <a name="-prometheus--blackbox_exporter--web_config_content"></a>`web_config_content`
+
+Data type: `Prometheus::Web_config`
+
+Unless empty the content of the web-config yaml which will handed over as option to the exporter
+
+Default value: `{}`
 
 ### <a name="prometheus--collectd_exporter"></a>`prometheus::collectd_exporter`
 
@@ -3722,6 +3761,11 @@ The following parameters are available in the `prometheus::elasticsearch_exporte
 * [`manage_group`](#-prometheus--elasticsearch_exporter--manage_group)
 * [`manage_service`](#-prometheus--elasticsearch_exporter--manage_service)
 * [`manage_user`](#-prometheus--elasticsearch_exporter--manage_user)
+* [`export_scrape_job`](#-prometheus--elasticsearch_exporter--export_scrape_job)
+* [`scrape_host`](#-prometheus--elasticsearch_exporter--scrape_host)
+* [`scrape_port`](#-prometheus--elasticsearch_exporter--scrape_port)
+* [`scrape_job_name`](#-prometheus--elasticsearch_exporter--scrape_job_name)
+* [`scrape_job_labels`](#-prometheus--elasticsearch_exporter--scrape_job_labels)
 * [`os`](#-prometheus--elasticsearch_exporter--os)
 * [`package_ensure`](#-prometheus--elasticsearch_exporter--package_ensure)
 * [`package_name`](#-prometheus--elasticsearch_exporter--package_name)
@@ -3729,17 +3773,14 @@ The following parameters are available in the `prometheus::elasticsearch_exporte
 * [`restart_on_change`](#-prometheus--elasticsearch_exporter--restart_on_change)
 * [`service_enable`](#-prometheus--elasticsearch_exporter--service_enable)
 * [`service_ensure`](#-prometheus--elasticsearch_exporter--service_ensure)
+* [`service_name`](#-prometheus--elasticsearch_exporter--service_name)
 * [`user`](#-prometheus--elasticsearch_exporter--user)
 * [`version`](#-prometheus--elasticsearch_exporter--version)
 * [`use_kingpin`](#-prometheus--elasticsearch_exporter--use_kingpin)
 * [`proxy_server`](#-prometheus--elasticsearch_exporter--proxy_server)
 * [`proxy_type`](#-prometheus--elasticsearch_exporter--proxy_type)
-* [`service_name`](#-prometheus--elasticsearch_exporter--service_name)
-* [`export_scrape_job`](#-prometheus--elasticsearch_exporter--export_scrape_job)
-* [`scrape_host`](#-prometheus--elasticsearch_exporter--scrape_host)
-* [`scrape_port`](#-prometheus--elasticsearch_exporter--scrape_port)
-* [`scrape_job_name`](#-prometheus--elasticsearch_exporter--scrape_job_name)
-* [`scrape_job_labels`](#-prometheus--elasticsearch_exporter--scrape_job_labels)
+* [`web_config_file`](#-prometheus--elasticsearch_exporter--web_config_file)
+* [`web_config_content`](#-prometheus--elasticsearch_exporter--web_config_content)
 
 ##### <a name="-prometheus--elasticsearch_exporter--arch"></a>`arch`
 
@@ -3849,6 +3890,46 @@ Whether to create user or rely on external code for that
 
 Default value: `true`
 
+##### <a name="-prometheus--elasticsearch_exporter--export_scrape_job"></a>`export_scrape_job`
+
+Data type: `Boolean`
+
+Whether to export a scrape job for this service
+
+Default value: `false`
+
+##### <a name="-prometheus--elasticsearch_exporter--scrape_host"></a>`scrape_host`
+
+Data type: `Optional[Stdlib::Host]`
+
+Hostname or IP address to scrape
+
+Default value: `undef`
+
+##### <a name="-prometheus--elasticsearch_exporter--scrape_port"></a>`scrape_port`
+
+Data type: `Stdlib::Port`
+
+Host port to scrape
+
+Default value: `9114`
+
+##### <a name="-prometheus--elasticsearch_exporter--scrape_job_name"></a>`scrape_job_name`
+
+Data type: `String[1]`
+
+Name of the scrape job to export, if export_scrape_job is true
+
+Default value: `'elasticsearch'`
+
+##### <a name="-prometheus--elasticsearch_exporter--scrape_job_labels"></a>`scrape_job_labels`
+
+Data type: `Optional[Hash]`
+
+Labels to add to the scrape job, if export_scrape_job is true
+
+Default value: `undef`
+
 ##### <a name="-prometheus--elasticsearch_exporter--os"></a>`os`
 
 Data type: `String[1]`
@@ -3901,6 +3982,12 @@ State ensured for the service (default 'running')
 
 Default value: `'running'`
 
+##### <a name="-prometheus--elasticsearch_exporter--service_name"></a>`service_name`
+
+Data type: `String[1]`
+
+Name of the node exporter service
+
 ##### <a name="-prometheus--elasticsearch_exporter--user"></a>`user`
 
 Data type: `String[1]`
@@ -3937,51 +4024,21 @@ Optional proxy server type (none|http|https|ftp)
 
 Default value: `undef`
 
-##### <a name="-prometheus--elasticsearch_exporter--service_name"></a>`service_name`
+##### <a name="-prometheus--elasticsearch_exporter--web_config_file"></a>`web_config_file`
 
-Data type: `String[1]`
+Data type: `Stdlib::Absolutepath`
 
+Path of file where the web-config will be saved to
 
+Default value: `'/etc/elasticsearch_exporter_web-config.yml'`
 
-##### <a name="-prometheus--elasticsearch_exporter--export_scrape_job"></a>`export_scrape_job`
+##### <a name="-prometheus--elasticsearch_exporter--web_config_content"></a>`web_config_content`
 
-Data type: `Boolean`
+Data type: `Prometheus::Web_config`
 
+Unless empty the content of the web-config yaml which will handed over as option to the exporter
 
-
-Default value: `false`
-
-##### <a name="-prometheus--elasticsearch_exporter--scrape_host"></a>`scrape_host`
-
-Data type: `Optional[Stdlib::Host]`
-
-
-
-Default value: `undef`
-
-##### <a name="-prometheus--elasticsearch_exporter--scrape_port"></a>`scrape_port`
-
-Data type: `Stdlib::Port`
-
-
-
-Default value: `9114`
-
-##### <a name="-prometheus--elasticsearch_exporter--scrape_job_name"></a>`scrape_job_name`
-
-Data type: `String[1]`
-
-
-
-Default value: `'elasticsearch'`
-
-##### <a name="-prometheus--elasticsearch_exporter--scrape_job_labels"></a>`scrape_job_labels`
-
-Data type: `Optional[Hash]`
-
-
-
-Default value: `undef`
+Default value: `{}`
 
 ### <a name="prometheus--graphite_exporter"></a>`prometheus::graphite_exporter`
 
@@ -4592,6 +4649,8 @@ The following parameters are available in the `prometheus::haproxy_exporter` cla
 * [`version`](#-prometheus--haproxy_exporter--version)
 * [`proxy_server`](#-prometheus--haproxy_exporter--proxy_server)
 * [`proxy_type`](#-prometheus--haproxy_exporter--proxy_type)
+* [`web_config_file`](#-prometheus--haproxy_exporter--web_config_file)
+* [`web_config_content`](#-prometheus--haproxy_exporter--web_config_content)
 * [`export_scrape_job`](#-prometheus--haproxy_exporter--export_scrape_job)
 * [`scrape_host`](#-prometheus--haproxy_exporter--scrape_host)
 * [`scrape_port`](#-prometheus--haproxy_exporter--scrape_port)
@@ -4785,6 +4844,22 @@ Data type: `Optional[Enum['none', 'http', 'https', 'ftp']]`
 Optional proxy server type (none|http|https|ftp)
 
 Default value: `undef`
+
+##### <a name="-prometheus--haproxy_exporter--web_config_file"></a>`web_config_file`
+
+Data type: `Stdlib::Absolutepath`
+
+Path of file where the web-config will be saved to
+
+Default value: `'/etc/haproxy_exporter_web-config.yml'`
+
+##### <a name="-prometheus--haproxy_exporter--web_config_content"></a>`web_config_content`
+
+Data type: `Prometheus::Web_config`
+
+Unless empty the content of the web-config yaml which will handed over as option to the exporter
+
+Default value: `{}`
 
 ##### <a name="-prometheus--haproxy_exporter--export_scrape_job"></a>`export_scrape_job`
 
@@ -6561,6 +6636,8 @@ The following parameters are available in the `prometheus::mysqld_exporter` clas
 * [`version`](#-prometheus--mysqld_exporter--version)
 * [`proxy_server`](#-prometheus--mysqld_exporter--proxy_server)
 * [`proxy_type`](#-prometheus--mysqld_exporter--proxy_type)
+* [`web_config_file`](#-prometheus--mysqld_exporter--web_config_file)
+* [`web_config_content`](#-prometheus--mysqld_exporter--web_config_content)
 * [`export_scrape_job`](#-prometheus--mysqld_exporter--export_scrape_job)
 * [`scrape_host`](#-prometheus--mysqld_exporter--scrape_host)
 * [`scrape_port`](#-prometheus--mysqld_exporter--scrape_port)
@@ -6804,6 +6881,22 @@ Data type: `Optional[Enum['none', 'http', 'https', 'ftp']]`
 Optional proxy server type (none|http|https|ftp)
 
 Default value: `undef`
+
+##### <a name="-prometheus--mysqld_exporter--web_config_file"></a>`web_config_file`
+
+Data type: `Stdlib::Absolutepath`
+
+Path of file where the web-config will be saved to
+
+Default value: `'/etc/mysqld_exporter_web-config.yml'`
+
+##### <a name="-prometheus--mysqld_exporter--web_config_content"></a>`web_config_content`
+
+Data type: `Prometheus::Web_config`
+
+Unless empty the content of the web-config yaml which will handed over as option to the exporter
+
+Default value: `{}`
 
 ##### <a name="-prometheus--mysqld_exporter--export_scrape_job"></a>`export_scrape_job`
 
@@ -7475,27 +7568,14 @@ The following parameters are available in the `prometheus::node_exporter` class:
 * [`env_file_path`](#-prometheus--node_exporter--env_file_path)
 * [`proxy_server`](#-prometheus--node_exporter--proxy_server)
 * [`proxy_type`](#-prometheus--node_exporter--proxy_type)
+* [`web_config_file`](#-prometheus--node_exporter--web_config_file)
+* [`web_config_content`](#-prometheus--node_exporter--web_config_content)
 * [`scrape_host`](#-prometheus--node_exporter--scrape_host)
 * [`export_scrape_job`](#-prometheus--node_exporter--export_scrape_job)
 * [`scrape_port`](#-prometheus--node_exporter--scrape_port)
 * [`scrape_job_name`](#-prometheus--node_exporter--scrape_job_name)
 * [`scrape_job_labels`](#-prometheus--node_exporter--scrape_job_labels)
 * [`bin_name`](#-prometheus--node_exporter--bin_name)
-* [`use_tls_server_config`](#-prometheus--node_exporter--use_tls_server_config)
-* [`tls_cert_file`](#-prometheus--node_exporter--tls_cert_file)
-* [`tls_key_file`](#-prometheus--node_exporter--tls_key_file)
-* [`tls_client_ca_file`](#-prometheus--node_exporter--tls_client_ca_file)
-* [`tls_client_auth_type`](#-prometheus--node_exporter--tls_client_auth_type)
-* [`web_config_file`](#-prometheus--node_exporter--web_config_file)
-* [`tls_min_version`](#-prometheus--node_exporter--tls_min_version)
-* [`tls_max_version`](#-prometheus--node_exporter--tls_max_version)
-* [`tls_cipher_suites`](#-prometheus--node_exporter--tls_cipher_suites)
-* [`tls_curve_preferences`](#-prometheus--node_exporter--tls_curve_preferences)
-* [`tls_prefer_server_cipher_suites`](#-prometheus--node_exporter--tls_prefer_server_cipher_suites)
-* [`use_http_server_config`](#-prometheus--node_exporter--use_http_server_config)
-* [`http2`](#-prometheus--node_exporter--http2)
-* [`http2_headers`](#-prometheus--node_exporter--http2_headers)
-* [`basic_auth_users`](#-prometheus--node_exporter--basic_auth_users)
 
 ##### <a name="-prometheus--node_exporter--arch"></a>`arch`
 
@@ -7724,6 +7804,22 @@ Optional proxy server type (none|http|https|ftp)
 
 Default value: `undef`
 
+##### <a name="-prometheus--node_exporter--web_config_file"></a>`web_config_file`
+
+Data type: `Stdlib::Absolutepath`
+
+Path of file where the web-config will be saved to
+
+Default value: `'/etc/node_exporter_web-config.yml'`
+
+##### <a name="-prometheus--node_exporter--web_config_content"></a>`web_config_content`
+
+Data type: `Prometheus::Web_config`
+
+Unless empty the content of the web-config yaml which will handed over as option to the exporter
+
+Default value: `{}`
+
 ##### <a name="-prometheus--node_exporter--scrape_host"></a>`scrape_host`
 
 Data type: `Optional[Stdlib::Host]`
@@ -7767,126 +7863,6 @@ Default value: `undef`
 ##### <a name="-prometheus--node_exporter--bin_name"></a>`bin_name`
 
 Data type: `Optional[String[1]]`
-
-
-
-Default value: `undef`
-
-##### <a name="-prometheus--node_exporter--use_tls_server_config"></a>`use_tls_server_config`
-
-Data type: `Boolean`
-
-
-
-Default value: `false`
-
-##### <a name="-prometheus--node_exporter--tls_cert_file"></a>`tls_cert_file`
-
-Data type: `Optional[Stdlib::Absolutepath]`
-
-
-
-Default value: `undef`
-
-##### <a name="-prometheus--node_exporter--tls_key_file"></a>`tls_key_file`
-
-Data type: `Optional[Stdlib::Absolutepath]`
-
-
-
-Default value: `undef`
-
-##### <a name="-prometheus--node_exporter--tls_client_ca_file"></a>`tls_client_ca_file`
-
-Data type: `Optional[Stdlib::Absolutepath]`
-
-
-
-Default value: `undef`
-
-##### <a name="-prometheus--node_exporter--tls_client_auth_type"></a>`tls_client_auth_type`
-
-Data type: `String[1]`
-
-
-
-Default value: `'RequireAndVerifyClientCert'`
-
-##### <a name="-prometheus--node_exporter--web_config_file"></a>`web_config_file`
-
-Data type: `Stdlib::Absolutepath`
-
-
-
-Default value: `'/etc/node_exporter_web-config.yml'`
-
-##### <a name="-prometheus--node_exporter--tls_min_version"></a>`tls_min_version`
-
-Data type: `String[1]`
-
-
-
-Default value: `'TLS12'`
-
-##### <a name="-prometheus--node_exporter--tls_max_version"></a>`tls_max_version`
-
-Data type: `String[1]`
-
-
-
-Default value: `'TLS13'`
-
-##### <a name="-prometheus--node_exporter--tls_cipher_suites"></a>`tls_cipher_suites`
-
-Data type: `Optional[Array[String[1]]]`
-
-
-
-Default value: `undef`
-
-##### <a name="-prometheus--node_exporter--tls_curve_preferences"></a>`tls_curve_preferences`
-
-Data type: `Optional[Array[String[1]]]`
-
-
-
-Default value: `undef`
-
-##### <a name="-prometheus--node_exporter--tls_prefer_server_cipher_suites"></a>`tls_prefer_server_cipher_suites`
-
-Data type: `Boolean`
-
-
-
-Default value: `true`
-
-##### <a name="-prometheus--node_exporter--use_http_server_config"></a>`use_http_server_config`
-
-Data type: `Boolean`
-
-
-
-Default value: `false`
-
-##### <a name="-prometheus--node_exporter--http2"></a>`http2`
-
-Data type: `Boolean`
-
-
-
-Default value: `true`
-
-##### <a name="-prometheus--node_exporter--http2_headers"></a>`http2_headers`
-
-Data type: `Optional[Hash]`
-
-
-
-Default value: `undef`
-
-##### <a name="-prometheus--node_exporter--basic_auth_users"></a>`basic_auth_users`
-
-Data type: `Optional[Hash]`
 
 
 
@@ -9086,6 +9062,8 @@ The following parameters are available in the `prometheus::postgres_exporter` cl
 * [`data_source_uri`](#-prometheus--postgres_exporter--data_source_uri)
 * [`proxy_server`](#-prometheus--postgres_exporter--proxy_server)
 * [`proxy_type`](#-prometheus--postgres_exporter--proxy_type)
+* [`web_config_file`](#-prometheus--postgres_exporter--web_config_file)
+* [`web_config_content`](#-prometheus--postgres_exporter--web_config_content)
 * [`options`](#-prometheus--postgres_exporter--options)
 * [`export_scrape_job`](#-prometheus--postgres_exporter--export_scrape_job)
 * [`scrape_host`](#-prometheus--postgres_exporter--scrape_host)
@@ -9326,6 +9304,22 @@ Data type: `Optional[Enum['none', 'http', 'https', 'ftp']]`
 Optional proxy server type (none|http|https|ftp)
 
 Default value: `undef`
+
+##### <a name="-prometheus--postgres_exporter--web_config_file"></a>`web_config_file`
+
+Data type: `Stdlib::Absolutepath`
+
+Path of file where the web-config will be saved to
+
+Default value: `'/etc/postgres_exporter_web-config.yml'`
+
+##### <a name="-prometheus--postgres_exporter--web_config_content"></a>`web_config_content`
+
+Data type: `Prometheus::Web_config`
+
+Unless empty the content of the web-config yaml which will handed over as option to the exporter
+
+Default value: `{}`
 
 ##### <a name="-prometheus--postgres_exporter--options"></a>`options`
 
@@ -14631,4 +14625,67 @@ Alias of `Pattern[/^s3:\/\//]`
 A URI that can be used to fetch a Prometheus configuration file
 
 Alias of `Variant[Stdlib::Filesource, Stdlib::HTTPUrl, Stdlib::HTTPSUrl, Prometheus::S3Uri, Prometheus::GsUri]`
+
+### <a name="Prometheus--Web_config"></a>`Prometheus::Web_config`
+
+webconfig for the exporter
+
+* **See also**
+  * https://github.com/prometheus/exporter-toolkit/blob/v0.10.0/docs/web-configuration.md
+
+Alias of
+
+```puppet
+Struct[{
+    Optional[tls_server_config] => Prometheus::Web_config::Tls_server_config,
+    Optional[http_server_config] => Prometheus::Web_config::Http_server_config,
+    Optional[basic_auth_users] => Hash[String[1],String[1],1],
+}]
+```
+
+### <a name="Prometheus--Web_config--Http_server_config"></a>`Prometheus::Web_config::Http_server_config`
+
+http_server_config of a exporter webconfig
+
+* **See also**
+  * https://github.com/prometheus/exporter-toolkit/blob/v0.10.0/docs/web-configuration.md
+
+Alias of
+
+```puppet
+Struct[{
+    Optional[http2] => Boolean,
+    Optional[headers] => Struct[{
+        Optional['Content-Security-Policy'] => String[1],
+        Optional['X-Frame-Options'] => String[1],
+        Optional['X-Content-Type-Options'] => String[1],
+        Optional['X-XSS-Protection'] => String[1],
+        Optional['Strict-Transport-Security'] => String[1],
+    }]
+}]
+```
+
+### <a name="Prometheus--Web_config--Tls_server_config"></a>`Prometheus::Web_config::Tls_server_config`
+
+tls_server_config of a exporter webconfig
+
+* **See also**
+  * https://github.com/prometheus/exporter-toolkit/blob/v0.10.0/docs/web-configuration.md
+
+Alias of
+
+```puppet
+Struct[{
+    cert_file => Stdlib::Absolutepath,
+    key_file => Stdlib::Absolutepath,
+    Optional[client_ca_file] => Stdlib::Absolutepath,
+    Optional[client_auth_type] => String[1],
+    Optional[client_allowed_sans] => Array[String[1],1],
+    Optional[min_version] => String[1],
+    Optional[max_version] => String[1],
+    Optional[cipher_suites] => Array[String[1],1],
+    Optional[prefer_server_cipher_suites] => Boolean,
+    Optional[curve_preferences] => Array[String[1],1],
+}]
+```
 

--- a/manifests/apache_exporter.pp
+++ b/manifests/apache_exporter.pp
@@ -53,6 +53,10 @@
 #  Optional proxy server, with port number if needed. ie: https://example.com:8080
 # @param proxy_type
 #  Optional proxy server type (none|http|https|ftp)
+# @param web_config_file
+#  Path of file where the web-config will be saved to
+# @param web_config_content
+#  Unless empty the content of the web-config yaml which will handed over as option to the exporter
 class prometheus::apache_exporter (
   String[1] $scrape_uri                                      = 'http://localhost/server-status/?auto',
   String $download_extension                                 = 'tar.gz',
@@ -86,6 +90,8 @@ class prometheus::apache_exporter (
   Optional[Hash] $scrape_job_labels                          = undef,
   Optional[String[1]] $proxy_server                          = undef,
   Optional[Enum['none', 'http', 'https', 'ftp']] $proxy_type = undef,
+  Stdlib::Absolutepath $web_config_file                      = '/etc/apache_exporter_web-config.yml',
+  Prometheus::Web_config $web_config_content                 = {},
 ) inherits prometheus {
   #Please provide the download_url for versions < 0.9.0
   $real_download_url    = pick($download_url,"${download_url_base}/download/v${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
@@ -94,11 +100,41 @@ class prometheus::apache_exporter (
     default => undef,
   }
 
-  if versioncmp($version, '0.8.0') < 0 {
-    $options = "-scrape_uri '${scrape_uri}' ${extra_options}"
-  } else {
-    $options = "--scrape_uri '${scrape_uri}' ${extra_options}"
+  $_web_config_ensure = $web_config_content.empty ? {
+    true    => absent,
+    default => file,
   }
+
+  file { $web_config_file:
+    ensure  => $_web_config_ensure,
+    owner   => $user,
+    group   => $group,
+    mode    => '0640',
+    content => $web_config_content.stdlib::to_yaml,
+    notify  => $notify_service,
+  }
+
+  $_web_config = if $web_config_content.empty {
+    ''
+  } else {
+    if versioncmp($version, '1.0.0') >= 0 {
+      "--web.config.file=${$web_config_file}"
+    } else {
+      "--web.config=${$web_config_file}"
+    }
+  }
+
+  $_scrape_uri = if versioncmp($version, '0.8.0') < 0 {
+    "-scrape_uri '${scrape_uri}'"
+  } else {
+    "--scrape_uri '${scrape_uri}'"
+  }
+
+  $options = [
+    $_scrape_uri,
+    $extra_options,
+    $_web_config,
+  ].filter |$x| { !$x.empty }.join(' ')
 
   prometheus::daemon { $service_name:
     install_method     => $install_method,

--- a/manifests/node_exporter.pp
+++ b/manifests/node_exporter.pp
@@ -62,6 +62,10 @@
 #  Optional proxy server, with port number if needed. ie: https://example.com:8080
 # @param proxy_type
 #  Optional proxy server type (none|http|https|ftp)
+# @param web_config_file
+#  Path of file where the web-config will be saved to
+# @param web_config_content
+#  Unless empty the content of the web-config yaml which will handed over as option to the exporter
 class prometheus::node_exporter (
   String $download_extension,
   Prometheus::Uri $download_url_base,
@@ -99,27 +103,8 @@ class prometheus::node_exporter (
   Stdlib::Absolutepath $env_file_path                        = $prometheus::env_file_path,
   Optional[String[1]] $proxy_server                          = undef,
   Optional[Enum['none', 'http', 'https', 'ftp']] $proxy_type = undef,
-
-  ### TLS
-  Boolean $use_tls_server_config                     = false,
-  Optional[Stdlib::Absolutepath] $tls_cert_file      = undef,
-  Optional[Stdlib::Absolutepath] $tls_key_file       = undef,
-  Optional[Stdlib::Absolutepath] $tls_client_ca_file = undef,
-  String[1] $tls_client_auth_type                    = 'RequireAndVerifyClientCert',
-  Stdlib::Absolutepath $web_config_file              = '/etc/node_exporter_web-config.yml',
-  String[1] $tls_min_version                         = 'TLS12',
-  String[1] $tls_max_version                         = 'TLS13',
-  Optional[Array[String[1]]] $tls_cipher_suites      = undef,
-  Optional[Array[String[1]]] $tls_curve_preferences  = undef,
-  Boolean $tls_prefer_server_cipher_suites           = true,
-
-  ### HTTP/2
-  Boolean $use_http_server_config = false,
-  Boolean $http2                  = true,
-  Optional[Hash] $http2_headers   = undef,
-
-  ### Basic Auth
-  Optional[Hash] $basic_auth_users = undef,
+  Stdlib::Absolutepath $web_config_file                      = '/etc/node_exporter_web-config.yml',
+  Prometheus::Web_config $web_config_content                 = {},
 ) inherits prometheus {
   # Prometheus added a 'v' on the realease name at 0.13.0
   if versioncmp ($version, '0.13.0') >= 0 {
@@ -147,65 +132,27 @@ class prometheus::node_exporter (
     "--no-collector.${collector}"
   }
 
-  if $use_tls_server_config {
-    # if tls is enabled, these values have to be set and cannot be undef anymore
-    $valid_tls_cert_file        = assert_type(Stdlib::Absolutepath, $tls_cert_file)
-    $valid_tls_key_file         = assert_type(Stdlib::Absolutepath, $tls_key_file)
-
-    $tls_server_config = {
-      tls_server_config => {
-        cert_file        => $valid_tls_cert_file,
-        key_file         => $valid_tls_key_file,
-        client_ca_file   => $tls_client_ca_file,
-        client_auth_type => $tls_client_auth_type,
-        min_version      => $tls_min_version,
-        max_version      => $tls_max_version,
-        cipher_suites    => $tls_cipher_suites,
-        prefer_server_cipher_suites => $tls_prefer_server_cipher_suites,
-        curve_preferences           => $tls_curve_preferences,
-      },
-    }
-  } else {
-    $tls_server_config = {}
+  $_web_config_ensure = $web_config_content.empty ? {
+    true    => absent,
+    default => file,
   }
 
-  if $use_http_server_config {
-    $http_server_config = {
-      http_server_config => {
-        http2   => $http2,
-        headers => $http2_headers,
-      },
-    }
-  } else {
-    $http_server_config = {}
+  file { $web_config_file:
+    ensure  => $_web_config_ensure,
+    owner   => $user,
+    group   => $group,
+    mode    => '0640',
+    content => $web_config_content.stdlib::to_yaml,
+    notify  => $notify_service,
   }
 
-  if $basic_auth_users =~ Undef {
-    $basic_auth_config = {}
+  $_web_config = if $web_config_content.empty {
+    ''
   } else {
-    $basic_auth_config = {
-      basic_auth_users => $basic_auth_users,
-    }
-  }
-
-  $web_config_content = $tls_server_config + $http_server_config + $basic_auth_config
-
-  if empty($web_config_content) {
-    file { $web_config_file:
-      ensure  => absent,
-    }
-
-    $web_config = ''
-  } else {
-    file { $web_config_file:
-      ensure  => file,
-      content => $web_config_content.stdlib::to_yaml,
-    }
-
     if versioncmp($version, '1.5.0') >= 0 {
-      $web_config = "--web.config.file=${$web_config_file}"
+      "--web.config.file=${$web_config_file}"
     } else {
-      $web_config = "--web.config=${$web_config_file}"
+      "--web.config=${$web_config_file}"
     }
   }
 
@@ -213,8 +160,8 @@ class prometheus::node_exporter (
     $extra_options,
     $cmd_collectors_enable.join(' '),
     $cmd_collectors_disable.join(' '),
-    $web_config,
-  ].join(' ')
+    $_web_config,
+  ].filter |$x| { !$x.empty }.join(' ')
 
   prometheus::daemon { $service_name:
     install_method     => $install_method,

--- a/spec/classes/blackbox_exporter_spec.rb
+++ b/spec/classes/blackbox_exporter_spec.rb
@@ -41,6 +41,23 @@ describe 'prometheus::blackbox_exporter' do
             verify_contents(catalogue, '/etc/blackbox-exporter.yaml', ['---', 'modules:', '  http_2xx:', '    prober: http'])
           }
         end
+
+        context 'with tls set in web-config.yml' do
+          let(:params) do
+            {
+              web_config_content: {
+                tls_server_config: {
+                  cert_file: '/etc/blackbox_exporter/foo.cert',
+                  key_file: '/etc/blackbox_exporter/foo.key'
+                }
+              }
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_file('/etc/blackbox_exporter_web-config.yml').with(ensure: 'file') }
+          it { is_expected.to contain_prometheus__daemon('blackbox_exporter').with(options: '--config.file=/etc/blackbox-exporter.yaml --web.config.file=/etc/blackbox_exporter_web-config.yml') }
+        end
       end
     end
   end

--- a/spec/classes/elasticsearch_exporter_spec.rb
+++ b/spec/classes/elasticsearch_exporter_spec.rb
@@ -27,6 +27,23 @@ describe 'prometheus::elasticsearch_exporter' do
         describe 'install correct binary' do
           it { is_expected.to contain_file('/usr/local/bin/elasticsearch_exporter').with('target' => '/opt/elasticsearch_exporter-1.0.0.linux-amd64/elasticsearch_exporter') }
         end
+
+        context 'with tls set in web-config.yml' do
+          let(:params) do
+            super().merge(
+              web_config_content: {
+                tls_server_config: {
+                  cert_file: '/etc/elasticsearch_exporter/foo.cert',
+                  key_file: '/etc/elasticsearch_exporter/foo.key'
+                }
+              }
+            )
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_file('/etc/elasticsearch_exporter_web-config.yml').with(ensure: 'file') }
+          it { is_expected.to contain_prometheus__daemon('elasticsearch_exporter').with(options: '--es.uri=http://localhost:9200 --es.timeout=5s --web.config.file=/etc/elasticsearch_exporter_web-config.yml') }
+        end
       end
     end
   end

--- a/spec/classes/haproxy_exporter_spec.rb
+++ b/spec/classes/haproxy_exporter_spec.rb
@@ -63,6 +63,23 @@ describe 'prometheus::haproxy_exporter' do
           it { is_expected.to raise_error(Puppet::Error) }
         end
       end
+
+      context 'with tls set in web-config.yml' do
+        let(:params) do
+          {
+            web_config_content: {
+              tls_server_config: {
+                cert_file: '/etc/haproxy_exporter/foo.cert',
+                key_file: '/etc/haproxy_exporter/foo.key'
+              }
+            }
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/etc/haproxy_exporter_web-config.yml').with(ensure: 'file') }
+        it { is_expected.to contain_prometheus__daemon('haproxy_exporter').with(options: '--haproxy.scrape-uri="http://localhost:1234/haproxy?stats;csv" --web.config.file=/etc/haproxy_exporter_web-config.yml') }
+      end
     end
   end
 end

--- a/spec/classes/mysqld_exporter_spec.rb
+++ b/spec/classes/mysqld_exporter_spec.rb
@@ -11,7 +11,7 @@ describe 'prometheus::mysqld_exporter' do
 
       context 'default' do
         describe 'options is correct' do
-          it { is_expected.to contain_prometheus__daemon('mysqld_exporter').with('options' => '--config.my-cnf=/etc/.my.cnf ') }
+          it { is_expected.to contain_prometheus__daemon('mysqld_exporter').with('options' => '--config.my-cnf=/etc/.my.cnf') }
         end
       end
 
@@ -23,7 +23,7 @@ describe 'prometheus::mysqld_exporter' do
         end
 
         describe 'options is correct' do
-          it { is_expected.to contain_prometheus__daemon('mysqld_exporter').with('options' => '-config.my-cnf=/etc/.my.cnf ') }
+          it { is_expected.to contain_prometheus__daemon('mysqld_exporter').with('options' => '-config.my-cnf=/etc/.my.cnf') }
         end
       end
 
@@ -38,6 +38,24 @@ describe 'prometheus::mysqld_exporter' do
           content = catalogue.resource('file', '/etc/.my.cnf').send(:parameters)[:content]
           expect(content).to include('secret')
         end
+      end
+
+      context 'with tls set in web-config.yml' do
+        let(:params) do
+          {
+            web_config_content: {
+              tls_server_config: {
+                cert_file: '/etc/mysqld_exporter/foo.cert',
+                key_file: '/etc/mysqld_exporter/foo.key'
+              }
+            }
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/etc/mysqld_exporter_web-config.yml').with(ensure: 'file') }
+
+        it { is_expected.to contain_prometheus__daemon('mysqld_exporter').with(options: '--config.my-cnf=/etc/.my.cnf --web.config.file=/etc/mysqld_exporter_web-config.yml') }
       end
     end
   end

--- a/spec/classes/node_exporter_spec.rb
+++ b/spec/classes/node_exporter_spec.rb
@@ -21,14 +21,14 @@ describe 'prometheus::node_exporter' do
           it { is_expected.to contain_package('prometheus-node-exporter') }
           it { is_expected.not_to contain_systemd__unit_file('node_exporter.service') }
           it { is_expected.to contain_service('prometheus-node-exporter') }
-          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '   ') }
+          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '') }
         else
           it { is_expected.to contain_user('node-exporter') }
           it { is_expected.to contain_group('node-exporter') }
           it { is_expected.to contain_file('/opt/node_exporter-1.0.1.linux-amd64/node_exporter') }
           it { is_expected.to contain_file('/usr/local/bin/node_exporter') }
           it { is_expected.to contain_service('node_exporter') }
-          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '   ') }
+          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '') }
           it { is_expected.to contain_systemd__unit_file('node_exporter.service') }
         end
         # rubocop:disable RSpec/RepeatedExample
@@ -58,7 +58,7 @@ describe 'prometheus::node_exporter' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_archive('/tmp/node_exporter-1.0.1.tar.gz') }
-        it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: ' --collector.foo --collector.bar --no-collector.baz --no-collector.qux ') }
+        it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '--collector.foo --collector.bar --no-collector.baz --no-collector.qux') }
 
         if facts[:os]['name'] == 'Archlinux'
           it { is_expected.to contain_file('/usr/bin/node_exporter') }
@@ -81,7 +81,7 @@ describe 'prometheus::node_exporter' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '--path.procfs /host/proc --path.sysfs /host/sys --collector.foo --collector.bar --no-collector.baz --no-collector.qux ') }
+        it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '--path.procfs /host/proc --path.sysfs /host/sys --collector.foo --collector.bar --no-collector.baz --no-collector.qux') }
       end
 
       context 'with version specified' do
@@ -122,9 +122,9 @@ describe 'prometheus::node_exporter' do
         it { is_expected.to contain_file('/etc/node_exporter_web-config.yml').with(ensure: 'absent') }
 
         if facts[:os]['name'] == 'Archlinux'
-          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '   ') }
+          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '') }
         else
-          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '   ') }
+          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '') }
         end
       end
 
@@ -132,9 +132,12 @@ describe 'prometheus::node_exporter' do
         let(:params) do
           {
             version: '1.4.0',
-            use_tls_server_config: true,
-            tls_cert_file: '/etc/node_exporter/foo.cert',
-            tls_key_file: '/etc/node_exporter/foo.key'
+            web_config_content: {
+              tls_server_config: {
+                cert_file: '/etc/node_exporter/foo.cert',
+                key_file: '/etc/node_exporter/foo.key'
+              }
+            }
           }
         end
 
@@ -142,9 +145,9 @@ describe 'prometheus::node_exporter' do
         it { is_expected.to contain_file('/etc/node_exporter_web-config.yml').with(ensure: 'file') }
 
         if facts[:os]['name'] == 'Archlinux'
-          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '   --web.config=/etc/node_exporter_web-config.yml') }
+          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '--web.config=/etc/node_exporter_web-config.yml') }
         else
-          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '   --web.config=/etc/node_exporter_web-config.yml') }
+          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '--web.config=/etc/node_exporter_web-config.yml') }
         end
       end
 
@@ -152,9 +155,12 @@ describe 'prometheus::node_exporter' do
         let(:params) do
           {
             version: '1.5.0',
-            use_tls_server_config: true,
-            tls_cert_file: '/etc/node_exporter/foo.cert',
-            tls_key_file: '/etc/node_exporter/foo.key'
+            web_config_content: {
+              tls_server_config: {
+                cert_file: '/etc/node_exporter/foo.cert',
+                key_file: '/etc/node_exporter/foo.key'
+              }
+            }
           }
         end
 
@@ -162,19 +168,22 @@ describe 'prometheus::node_exporter' do
         it { is_expected.to contain_file('/etc/node_exporter_web-config.yml').with(ensure: 'file') }
 
         if facts[:os]['name'] == 'Archlinux'
-          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '   --web.config.file=/etc/node_exporter_web-config.yml') }
+          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '--web.config.file=/etc/node_exporter_web-config.yml') }
         else
-          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '   --web.config.file=/etc/node_exporter_web-config.yml') }
+          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '--web.config.file=/etc/node_exporter_web-config.yml') }
         end
       end
 
-      context 'with tls set in web-config.yml version higher to 1.5.0' do
+      context 'with tls set in web-config.yml version higher than 1.5.0' do
         let(:params) do
           {
             version: '1.5.1',
-            use_tls_server_config: true,
-            tls_cert_file: '/etc/node_exporter/foo.cert',
-            tls_key_file: '/etc/node_exporter/foo.key'
+            web_config_content: {
+              tls_server_config: {
+                cert_file: '/etc/node_exporter/foo.cert',
+                key_file: '/etc/node_exporter/foo.key'
+              }
+            }
           }
         end
 
@@ -182,9 +191,9 @@ describe 'prometheus::node_exporter' do
         it { is_expected.to contain_file('/etc/node_exporter_web-config.yml').with(ensure: 'file') }
 
         if facts[:os]['name'] == 'Archlinux'
-          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '   --web.config.file=/etc/node_exporter_web-config.yml') }
+          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '--web.config.file=/etc/node_exporter_web-config.yml') }
         else
-          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '   --web.config.file=/etc/node_exporter_web-config.yml') }
+          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '--web.config.file=/etc/node_exporter_web-config.yml') }
         end
       end
     end

--- a/spec/classes/postgres_exporter_spec.rb
+++ b/spec/classes/postgres_exporter_spec.rb
@@ -30,6 +30,23 @@ describe 'prometheus::postgres_exporter' do
           it { is_expected.to contain_group('postgres-exporter') }
           it { is_expected.to contain_service('postgres_exporter') }
         end
+
+        context 'with tls set in web-config.yml' do
+          let(:params) do
+            super().merge(
+              web_config_content: {
+                tls_server_config: {
+                  cert_file: '/etc/postgres_exporter/foo.cert',
+                  key_file: '/etc/postgres_exporter/foo.key'
+                }
+              }
+            )
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_file('/etc/postgres_exporter_web-config.yml').with(ensure: 'file') }
+          it { is_expected.to contain_prometheus__daemon('postgres_exporter').with(options: '--web.config.file=/etc/postgres_exporter_web-config.yml') }
+        end
       end
     end
   end

--- a/spec/type_aliases/web_config/http_server_config_spec.rb
+++ b/spec/type_aliases/web_config/http_server_config_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Prometheus::Web_config::Http_server_config' do
+  describe 'accepts minimal usage' do
+    it { is_expected.to allow_value({}) }
+  end
+
+  describe 'accepts all paramters' do
+    it {
+      is_expected.to allow_value(
+        {
+          'http2' => true,
+          'headers' => {
+            'Content-Security-Policy' => 'default-src \'self\'',
+            'X-Frame-Options' => 'SAMEORIGIN',
+            'X-Content-Type-Options' => 'nosniff',
+            'X-XSS-Protection' => '1; mode=block',
+            'Strict-Transport-Security' => 'max-age=31536000; includeSubDomains',
+          }
+        }
+      )
+    }
+  end
+end

--- a/spec/type_aliases/web_config/tls_server_config_spec.rb
+++ b/spec/type_aliases/web_config/tls_server_config_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Prometheus::Web_config::Tls_server_config' do
+  describe 'accepts minimal usage' do
+    it {
+      is_expected.to allow_value(
+        {
+          'cert_file' => '/etc/pki/tls/certs/example.com.pem',
+          'key_file' => '/etc/pki/tls/private/example.com.pem',
+        }
+      )
+    }
+  end
+
+  describe 'accepts all paramters' do
+    it {
+      is_expected.to allow_value(
+        {
+          'cert_file' => '/etc/pki/tls/certs/example.com.pem',
+          'key_file' => '/etc/pki/tls/private/example.com.pem',
+          'client_ca_file' => '/etc/pki/tls/cert.pem',
+          'client_auth_type' => 'NoClientCert',
+          'client_allowed_sans' => [
+            'client.example.com'
+          ],
+          'min_version' => 'TLS12',
+          'max_version' => 'TLS13',
+          'cipher_suites' => %w[
+            TLS_CHACHA20_POLY1305_SHA256
+            TLS_AES_256_GCM_SHA384
+            TLS_AES_128_GCM_SHA256
+          ],
+          'prefer_server_cipher_suites' => true,
+          'curve_preferences' => [
+            'X25519'
+          ]
+        }
+      )
+    }
+  end
+end

--- a/spec/type_aliases/web_config_spec.rb
+++ b/spec/type_aliases/web_config_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Prometheus::Web_config' do
+  describe 'accepts minimal tls usage' do
+    it {
+      is_expected.to allow_value(
+        {
+          'tls_server_config' => {
+            'cert_file' => '/etc/pki/tls/certs/example.com.pem',
+            'key_file' => '/etc/pki/tls/private/example.com.pem',
+          }
+        }
+      )
+    }
+  end
+
+  describe 'accepts all paramters' do
+    it {
+      is_expected.to allow_value(
+        {
+          'http_server_config' => {
+            'http2' => true,
+            'headers' => {
+              'Content-Security-Policy' => 'default-src \'self\'',
+              'X-Frame-Options' => 'SAMEORIGIN',
+              'X-Content-Type-Options' => 'nosniff',
+              'X-XSS-Protection' => '1; mode=block',
+              'Strict-Transport-Security' => 'max-age=31536000; includeSubDomains',
+            }
+          },
+          'tls_server_config' => {
+            'cert_file' => '/etc/pki/tls/certs/example.com.pem',
+            'key_file' => '/etc/pki/tls/private/example.com.pem',
+            'client_ca_file' => '/etc/pki/tls/cert.pem',
+            'client_auth_type' => 'NoClientCert',
+            'client_allowed_sans' => [
+              'client.example.com'
+            ],
+            'min_version' => 'TLS12',
+            'max_version' => 'TLS13',
+            'cipher_suites' => %w[
+              TLS_CHACHA20_POLY1305_SHA256
+              TLS_AES_256_GCM_SHA384
+              TLS_AES_128_GCM_SHA256
+            ],
+            'prefer_server_cipher_suites' => true,
+            'curve_preferences' => [
+              'X25519'
+            ]
+          },
+          'basic_auth_users' => {
+            'john.doe' => '$2b$05$XC0SLeu3npPRPgbPMBhjCu/2GZRfcIfjGtW5yLeDTLUO0.zAfdkjm'
+          }
+        }
+      )
+    }
+  end
+end

--- a/types/web_config.pp
+++ b/types/web_config.pp
@@ -1,0 +1,7 @@
+# @summary webconfig for the exporter
+# @see https://github.com/prometheus/exporter-toolkit/blob/v0.10.0/docs/web-configuration.md
+type Prometheus::Web_config = Struct[{
+    Optional[tls_server_config] => Prometheus::Web_config::Tls_server_config,
+    Optional[http_server_config] => Prometheus::Web_config::Http_server_config,
+    Optional[basic_auth_users] => Hash[String[1],String[1],1],
+}]

--- a/types/web_config/http_server_config.pp
+++ b/types/web_config/http_server_config.pp
@@ -1,0 +1,12 @@
+# @summary http_server_config of a exporter webconfig
+# @see https://github.com/prometheus/exporter-toolkit/blob/v0.10.0/docs/web-configuration.md
+type Prometheus::Web_config::Http_server_config = Struct[{
+    Optional[http2] => Boolean,
+    Optional[headers] => Struct[{
+        Optional['Content-Security-Policy'] => String[1],
+        Optional['X-Frame-Options'] => String[1],
+        Optional['X-Content-Type-Options'] => String[1],
+        Optional['X-XSS-Protection'] => String[1],
+        Optional['Strict-Transport-Security'] => String[1],
+    }]
+}]

--- a/types/web_config/tls_server_config.pp
+++ b/types/web_config/tls_server_config.pp
@@ -1,0 +1,14 @@
+# @summary tls_server_config of a exporter webconfig
+# @see https://github.com/prometheus/exporter-toolkit/blob/v0.10.0/docs/web-configuration.md
+type Prometheus::Web_config::Tls_server_config = Struct[{
+    cert_file => Stdlib::Absolutepath,
+    key_file => Stdlib::Absolutepath,
+    Optional[client_ca_file] => Stdlib::Absolutepath,
+    Optional[client_auth_type] => String[1],
+    Optional[client_allowed_sans] => Array[String[1],1],
+    Optional[min_version] => String[1],
+    Optional[max_version] => String[1],
+    Optional[cipher_suites] => Array[String[1],1],
+    Optional[prefer_server_cipher_suites] => Boolean,
+    Optional[curve_preferences] => Array[String[1],1],
+}]


### PR DESCRIPTION
#### Pull Request (PR) description
* Rework web-config support for node exporter
* Fix missing owner, group and mode for web_config_file
* Fix missing notify to service from web_config_file
* Add web-config support to apache_exporter
* Add web-config support to blackbox_exporter
* Add web-config support to elasticsearch_exporter
* Add web-config support to haproxy_exporter
* Add web-config support to mysqld_exporter
* Add web-config support to postgres_exporter

#### This Pull Request (PR) fixes the following issues
none