### PR TITLE
mongodb_exporter: make service name and binary path configureable

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6276,7 +6276,7 @@ Default value: `$prometheus::bin_dir`
 
 Data type: `String[1]`
 
-Name of the binary to execute
+The name of the binary to execute
 
 Default value: `'mongodb_exporter'`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6224,6 +6224,7 @@ The following parameters are available in the `prometheus::mongodb_exporter` cla
 
 * [`arch`](#-prometheus--mongodb_exporter--arch)
 * [`bin_dir`](#-prometheus--mongodb_exporter--bin_dir)
+* [`bin_name`](#-prometheus--mongodb_exporter--bin_name)
 * [`cnf_uri`](#-prometheus--mongodb_exporter--cnf_uri)
 * [`download_extension`](#-prometheus--mongodb_exporter--download_extension)
 * [`download_url`](#-prometheus--mongodb_exporter--download_url)
@@ -6270,6 +6271,14 @@ Data type: `Stdlib::Absolutepath`
 Directory where binaries are located
 
 Default value: `$prometheus::bin_dir`
+
+##### <a name="-prometheus--mongodb_exporter--bin_name"></a>`bin_name`
+
+Data type: `String[1]`
+
+Name of the binary to execute
+
+Default value: `'mongodb_exporter'`
 
 ##### <a name="-prometheus--mongodb_exporter--cnf_uri"></a>`cnf_uri`
 

--- a/manifests/mongodb_exporter.pp
+++ b/manifests/mongodb_exporter.pp
@@ -113,7 +113,7 @@ class prometheus::mongodb_exporter (
 
   $options = "${flag_prefix}mongodb.uri=${cnf_uri} ${extra_options}"
 
-  prometheus::daemon { 'mongodb_exporter':
+  prometheus::daemon { $service_name:
     install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,

--- a/manifests/mongodb_exporter.pp
+++ b/manifests/mongodb_exporter.pp
@@ -3,6 +3,8 @@
 #  Architecture (amd64 or i386)
 # @param bin_dir
 #  Directory where binaries are located
+# @param bin_name
+#  The name of the binary to execute
 # @param cnf_uri
 #  The URI to obtain MongoDB stats from
 # @param download_extension
@@ -81,6 +83,7 @@ class prometheus::mongodb_exporter (
   Optional[Prometheus::Uri] $download_url                    = undef,
   String[1] $arch                                            = $prometheus::real_arch,
   Stdlib::Absolutepath $bin_dir                              = $prometheus::bin_dir,
+  String[1] $bin_name                                        = 'mongodb_exporter',
   Boolean $export_scrape_job                                 = false,
   Optional[Stdlib::Host] $scrape_host                        = undef,
   Stdlib::Port $scrape_port                                  = 9216,
@@ -118,6 +121,7 @@ class prometheus::mongodb_exporter (
     arch               => $arch,
     real_download_url  => $real_download_url,
     bin_dir            => $bin_dir,
+    bin_name           => $bin_name,
     archive_bin_path   => $archive_bin_path,
     notify_service     => $notify_service,
     package_name       => $package_name,


### PR DESCRIPTION
#### Pull Request (PR) description

Set the parameter `$service_name` as the name for the MongoDB exporter `daemon` resource and add a parameter to allow overriding the name of the service binary.

#### This Pull Request (PR) fixes the following issues

Fixes #698