### PR TITLE
Cleanup architecture selection, dont fail on unknown architecture

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -312,16 +312,13 @@ class prometheus (
   Optional[Enum['none', 'http', 'https', 'ftp']] $proxy_type                    = undef,
 ) {
   case $arch {
-    'x86_64', 'amd64': { $real_arch = 'amd64' }
-    'i386':            { $real_arch = '386' }
-    'aarch64':         { $real_arch = 'arm64' }
-    'armv7l':          { $real_arch = 'armv7' }
-    'armv6l':          { $real_arch = 'armv6' }
-    'armv5l':          { $real_arch = 'armv5' }
-    'ppc64le':         { $real_arch = 'ppc64le' }
-    default:           {
-      fail("Unsupported kernel architecture: ${arch}")
-    }
+    'x86_64':  { $real_arch = 'amd64' }
+    'i386':    { $real_arch = '386' }
+    'aarch64': { $real_arch = 'arm64' }
+    'armv7l':  { $real_arch = 'armv7' }
+    'armv6l':  { $real_arch = 'armv6' }
+    'armv5l':  { $real_arch = 'armv5' }
+    default:   { $real_arch = $arch }
   }
 
   if $manage_prometheus_server {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -311,14 +311,14 @@ class prometheus (
   Optional[String[1]] $proxy_server                                             = undef,
   Optional[Enum['none', 'http', 'https', 'ftp']] $proxy_type                    = undef,
 ) {
-  case $arch {
-    'x86_64':  { $real_arch = 'amd64' }
-    'i386':    { $real_arch = '386' }
-    'aarch64': { $real_arch = 'arm64' }
-    'armv7l':  { $real_arch = 'armv7' }
-    'armv6l':  { $real_arch = 'armv6' }
-    'armv5l':  { $real_arch = 'armv5' }
-    default:   { $real_arch = $arch }
+  $real_arch = $arch ? {
+    'x86_64'  => 'amd64',
+    'i386'    => '386',
+    'aarch64' => 'arm64',
+    'armv7l'  => 'armv7',
+    'armv6l'  => 'armv6',
+    'armv5l'  => 'armv5',
+    default   => $arch,
   }
 
   if $manage_prometheus_server {


### PR DESCRIPTION
prometheus exporters are built for so many architectures, chances are high that a platform we're not aware of works out of the box. We should not block this.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
