### PR TITLE
Drop Ubuntu 18.04, allow systemd 6.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 1.1.1 < 6.0.0"
+      "version_requirement": ">= 1.1.1 < 7.0.0"
     },
     {
       "name": "puppet/archive",
@@ -75,7 +75,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
         "20.04",
         "22.04"
       ]


### PR DESCRIPTION
#### Pull Request (PR) description
This bumps the systemd dependency to < 7 to allow latest, though systemd >= 6 drops support of Ubuntu 18.04 (which went out of support in May, so dropping here as well)

