### PR TITLE
fix idempotency test for alertmanger archlinux

### DIFF
--- a/data/Archlinux.yaml
+++ b/data/Archlinux.yaml
@@ -26,3 +26,5 @@ prometheus::bird_exporter::manage_user: false
 prometheus::bird_exporter::manage_group: false
 prometheus::bird_exporter::init_style: 'none'
 prometheus::bird_exporter::service_name: 'prometheus-bird-exporter'
+prometheus::alertmanager::config_file: "%{hiera('prometheus::alertmanager::config_dir')}/alertmanager.yml"
+prometheus::alertmanager::templates: [ "%{lookup('prometheus::alertmanager::config_dir')}/template/*.tmpl" ]

--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -197,6 +197,17 @@ class prometheus::alertmanager (
     recurse => $purge_config_dir,
   }
 
+  # arch package comes with a separate template directory
+  if $facts['os']['name'] == 'Archlinux' {
+    file { "${config_dir}/template":
+      ensure  => 'directory',
+      owner   => 'root',
+      group   => $group,
+      purge   => $purge_config_dir,
+      recurse => $purge_config_dir,
+    }
+  }
+
   if (( versioncmp($version, '0.10.0') >= 0 ) and ( $install_method == 'url' )) {
     # If version >= 0.10.0 then install amtool - Alertmanager validation tool
     file { "${bin_dir}/amtool":

--- a/spec/acceptance/node_exporter_spec.rb
+++ b/spec/acceptance/node_exporter_spec.rb
@@ -2,6 +2,12 @@
 
 require 'spec_helper_acceptance'
 
+service_name = if host_inventory['facter']['os']['name'] == 'Archlinux'
+  'prometheus-node-exporter'
+else
+  'node_exporter'
+end
+
 describe 'prometheus node_exporter' do
   it 'node_exporter works idempotently with no errors' do
     pp = 'include prometheus::node_exporter'
@@ -10,7 +16,7 @@ describe 'prometheus node_exporter' do
     apply_manifest(pp, catch_changes: true)
   end
 
-  describe service('node_exporter') do
+  describe service(service_name.to_s) do
     it { is_expected.to be_running }
     it { is_expected.to be_enabled }
   end
@@ -28,7 +34,7 @@ describe 'prometheus node_exporter' do
       apply_manifest(pp, catch_changes: true)
     end
 
-    describe service('node_exporter') do
+    describe service(service_name.to_s) do
       it { is_expected.to be_running }
       it { is_expected.to be_enabled }
     end
@@ -44,7 +50,7 @@ describe 'prometheus node_exporter' do
       apply_manifest(pp, catch_changes: true)
     end
 
-    describe service('node_exporter') do
+    describe service(service_name.to_s) do
       it { is_expected.to be_running }
       it { is_expected.to be_enabled }
     end
@@ -63,7 +69,7 @@ describe 'prometheus node_exporter' do
       apply_manifest(pp, catch_changes: true)
     end
 
-    describe service('node_exporter') do
+    describe service(service_name.to_s) do
       it { is_expected.to be_running }
       it { is_expected.to be_enabled }
     end

--- a/spec/classes/alertmanager_spec.rb
+++ b/spec/classes/alertmanager_spec.rb
@@ -9,6 +9,12 @@ describe 'prometheus::alertmanager' do
         facts.merge(os_specific_facts(facts))
       end
 
+      config_file = if facts[:os]['family'] == 'Archlinux'
+                      '/etc/alertmanager/alertmanager.yml'
+                    else
+                      '/etc/alertmanager/alertmanager.yaml'
+                    end
+
       context 'with version specified' do
         let(:params) do
           {
@@ -36,12 +42,12 @@ describe 'prometheus::alertmanager' do
 
         describe 'config file contents' do
           it {
-            expect(subject).to contain_file('/etc/alertmanager/alertmanager.yaml').with_notify('Service[alertmanager]')
-            verify_contents(catalogue, '/etc/alertmanager/alertmanager.yaml', ['---', 'global:', '  smtp_smarthost: localhost:25', '  smtp_from: alertmanager@localhost'])
+            expect(subject).to contain_file(config_file.to_s).with_notify('Service[alertmanager]')
+            verify_contents(catalogue, config_file.to_s, ['---', 'global:', '  smtp_smarthost: localhost:25', '  smtp_from: alertmanager@localhost'])
           }
 
           it {
-            expect(subject).not_to contain_file('/etc/alertmanager/alertmanager.yaml').with_content(%r{mute_time_intervals})
+            expect(subject).not_to contain_file(config_file.to_s).with_content(%r{mute_time_intervals})
           }
         end
 
@@ -71,7 +77,7 @@ describe 'prometheus::alertmanager' do
         end
 
         it {
-          verify_contents(catalogue, '/etc/alertmanager/alertmanager.yaml', [
+          verify_contents(catalogue, config_file.to_s, [
                             'mute_time_intervals:',
                             '- name: weekend',
                             '  time_intervals:',
@@ -99,10 +105,10 @@ describe 'prometheus::alertmanager' do
           }
         end
 
-        it { is_expected.to contain_file('/etc/alertmanager/alertmanager.yaml').without(content: %r{mute_time_intervals}) }
+        it { is_expected.to contain_file(config_file.to_s).without(content: %r{mute_time_intervals}) }
 
         it {
-          verify_contents(catalogue, '/etc/alertmanager/alertmanager.yaml', [
+          verify_contents(catalogue, config_file.to_s, [
                             'time_intervals:',
                             '- name: weekend',
                             '  time_intervals:',
@@ -117,7 +123,7 @@ describe 'prometheus::alertmanager' do
         let(:params) { { reload_on_change: true } }
 
         it {
-          expect(subject).to contain_file('/etc/alertmanager/alertmanager.yaml').with_notify('Exec[alertmanager-reload]')
+          expect(subject).to contain_file(config_file.to_s).with_notify('Exec[alertmanager-reload]')
         }
       end
 
@@ -138,7 +144,7 @@ describe 'prometheus::alertmanager' do
             end
 
             it {
-              expect(subject).not_to contain_file('/etc/alertmanager/alertmanager.yaml')
+              expect(subject).not_to contain_file(config_file.to_s)
             }
           end
         end
@@ -154,7 +160,7 @@ describe 'prometheus::alertmanager' do
         end
 
         it {
-          expect(subject).to contain_file('/etc/alertmanager/alertmanager.yaml').without_validate_cmd
+          expect(subject).to contain_file(config_file.to_s).without_validate_cmd
         }
       end
 
@@ -169,7 +175,7 @@ describe 'prometheus::alertmanager' do
         end
 
         it {
-          expect(subject).to contain_file('/etc/alertmanager/alertmanager.yaml').with_validate_cmd('/bin/amtool check-config --alertmanager.url=\'\' %')
+          expect(subject).to contain_file(config_file.to_s).with_validate_cmd('/bin/amtool check-config --alertmanager.url=\'\' %')
         }
       end
     end


### PR DESCRIPTION
for archlinux it changes the config file name to alertmanager.yml and the template directory to /etc/alertmanager/template

