### PR TITLE
Fix Archlinux acceptance test

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,10 +406,7 @@ In version 0.1.14 of this module the alertmanager was configured to run as the s
 
 Do not use version 1.0.0 of Prometheus: https://groups.google.com/forum/#!topic/prometheus-developers/vuSIxxUDff8 ; it is not compatible with this module!
 
-Even if the module has templates for several linux distributions, only RedHat family distributions were tested.
-
-This module has unit tests for CentOS/RHEL, Debian, Ubuntu and Archlinux. Acceptance tests are executed for CentOS, Debian and Ubuntu. Other operating systems may work but are untested.
-
+Postfix is not supported on Archlinux because it relies on puppet-postfix, which does not support Archlinux.
 
 ## Development
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -4965,13 +4965,13 @@ The following parameters are available in the `prometheus::ipmi_exporter` class:
 * [`version`](#-prometheus--ipmi_exporter--version)
 * [`proxy_server`](#-prometheus--ipmi_exporter--proxy_server)
 * [`proxy_type`](#-prometheus--ipmi_exporter--proxy_type)
+* [`unprivileged`](#-prometheus--ipmi_exporter--unprivileged)
 * [`scrape_host`](#-prometheus--ipmi_exporter--scrape_host)
 * [`export_scrape_job`](#-prometheus--ipmi_exporter--export_scrape_job)
 * [`scrape_port`](#-prometheus--ipmi_exporter--scrape_port)
 * [`scrape_job_name`](#-prometheus--ipmi_exporter--scrape_job_name)
 * [`scrape_job_labels`](#-prometheus--ipmi_exporter--scrape_job_labels)
 * [`bin_name`](#-prometheus--ipmi_exporter--bin_name)
-* [`unprivileged`](#-prometheus--ipmi_exporter--unprivileged)
 * [`script_dir`](#-prometheus--ipmi_exporter--script_dir)
 
 ##### <a name="-prometheus--ipmi_exporter--arch"></a>`arch`
@@ -5198,6 +5198,14 @@ Optional proxy server type (none|http|https|ftp)
 
 Default value: `undef`
 
+##### <a name="-prometheus--ipmi_exporter--unprivileged"></a>`unprivileged`
+
+Data type: `Boolean`
+
+If true, run the exporter as an unprivileged user and add sudoers entries
+
+Default value: `true`
+
 ##### <a name="-prometheus--ipmi_exporter--scrape_host"></a>`scrape_host`
 
 Data type: `Optional[Stdlib::Host]`
@@ -5245,14 +5253,6 @@ Data type: `Optional[String[1]]`
 
 
 Default value: `undef`
-
-##### <a name="-prometheus--ipmi_exporter--unprivileged"></a>`unprivileged`
-
-Data type: `Boolean`
-
-
-
-Default value: `true`
 
 ##### <a name="-prometheus--ipmi_exporter--script_dir"></a>`script_dir`
 

--- a/data/Archlinux.yaml
+++ b/data/Archlinux.yaml
@@ -4,11 +4,10 @@ prometheus::server::manage_user: false
 prometheus::server::manage_group: false
 prometheus::server::package_ensure: 'installed'
 prometheus::server::manage_config_dir: false
-prometheus::server::manage_init_file: false
+prometheus::server::manage_init_file: true
 prometheus::configname: 'prometheus.yml'
-prometheus::version: '2.46.0'
-prometheus::install_method: 'package'
-prometheus::bin_dir: '/usr/bin'
+prometheus::server::install_method: 'package'
+prometheus::server::bin_dir: '/usr/bin'
 prometheus::env_file_path: '/etc/conf.d'
 prometheus::node_exporter::package_name: 'prometheus-node-exporter'
 prometheus::node_exporter::install_method: 'package'
@@ -26,3 +25,11 @@ prometheus::bird_exporter::manage_user: false
 prometheus::bird_exporter::manage_group: false
 prometheus::bird_exporter::init_style: 'none'
 prometheus::bird_exporter::service_name: 'prometheus-bird-exporter'
+prometheus::memcached_exporter::install_method: 'package'
+prometheus::memcached_exporter::package_name: 'prometheus-memcached-exporter'
+prometheus::memcached_exporter::manage_user: false
+prometheus::memcached_exporter::manage_group: false
+prometheus::memcached_exporter::init_style: 'none'
+prometheus::memcached_exporter::service_name: 'prometheus-memcached-exporter'
+prometheus::varnish_exporter::extra_options: '-no-exit'
+prometheus::ipmi_exporter::unprivileged: false # Set to false because it breaks sudo in acceptance testing

--- a/manifests/ipmi_exporter.pp
+++ b/manifests/ipmi_exporter.pp
@@ -55,6 +55,8 @@
 #  Optional proxy server, with port number if needed. ie: https://example.com:8080
 # @param proxy_type
 #  Optional proxy server type (none|http|https|ftp)
+# @param unprivileged
+#  If true, run the exporter as an unprivileged user and add sudoers entries
 class prometheus::ipmi_exporter (
   Stdlib::Absolutepath $config_file                          = '/etc/ipmi_exporter.yaml',
   String[1] $package_name                                    = 'ipmi_exporter',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -80,7 +80,8 @@ class prometheus::server (
 
   $extra_alerts.each | String $alerts_file_name, Hash $alerts_config | {
     prometheus::alerts { $alerts_file_name:
-      alerts   => $alerts_config,
+      alerts  => $alerts_config,
+      bin_dir => $bin_dir,
     }
   }
   $extra_rule_files = suffix(prefix(keys($extra_alerts), "${config_dir}/rules/"), '.rules')
@@ -90,6 +91,7 @@ class prometheus::server (
       alerts   => $alerts,
       location => $config_dir,
       version  => $version,
+      bin_dir  => $bin_dir,
     }
     $_rule_files = concat(["${config_dir}/alert.rules"], $extra_rule_files, $rule_files)
   }

--- a/spec/acceptance/node_exporter_spec.rb
+++ b/spec/acceptance/node_exporter_spec.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 require 'spec_helper_acceptance'
+service_name = if host_inventory['facter']['os']['name'] == 'Archlinux'
+                 'prometheus-node-exporter'
+               else
+                 'node_exporter'
+               end
 
 describe 'prometheus node_exporter' do
   it 'node_exporter works idempotently with no errors' do
@@ -10,7 +15,7 @@ describe 'prometheus node_exporter' do
     apply_manifest(pp, catch_changes: true)
   end
 
-  describe service('node_exporter') do
+  describe service(service_name) do
     it { is_expected.to be_running }
     it { is_expected.to be_enabled }
   end
@@ -28,7 +33,7 @@ describe 'prometheus node_exporter' do
       apply_manifest(pp, catch_changes: true)
     end
 
-    describe service('node_exporter') do
+    describe service(service_name) do
       it { is_expected.to be_running }
       it { is_expected.to be_enabled }
     end
@@ -44,7 +49,7 @@ describe 'prometheus node_exporter' do
       apply_manifest(pp, catch_changes: true)
     end
 
-    describe service('node_exporter') do
+    describe service(service_name) do
       it { is_expected.to be_running }
       it { is_expected.to be_enabled }
     end
@@ -63,7 +68,7 @@ describe 'prometheus node_exporter' do
       apply_manifest(pp, catch_changes: true)
     end
 
-    describe service('node_exporter') do
+    describe service(service_name) do
       it { is_expected.to be_running }
       it { is_expected.to be_enabled }
     end

--- a/spec/acceptance/postfix_exporter_spec.rb
+++ b/spec/acceptance/postfix_exporter_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper_acceptance'
 
-describe 'prometheus postfix exporter' do
+describe 'prometheus postfix exporter', if: host_inventory['facter']['os']['name'] != 'Archlinux' do
   describe 'install postfix' do
     before do
       shell('puppet module install puppet/postfix')

--- a/spec/classes/apache_exporter_spec.rb
+++ b/spec/classes/apache_exporter_spec.rb
@@ -18,15 +18,9 @@ describe 'prometheus::apache_exporter' do
           it { is_expected.to contain_systemd__unit_file('apache_exporter.service') }
         end
 
-        if facts[:os]['name'] == 'Archlinux'
-          it { is_expected.to contain_package('apache_exporter') }
-          it { is_expected.not_to contain_archive('/tmp/apache_exporter-0.8.0.tar.gz') }
-          it { is_expected.not_to contain_file('/opt/apache_exporter-0.8.0.linux-amd64/apache_exporter') }
-        else
-          it { is_expected.not_to contain_package('apache-exporter') }
-          it { is_expected.to contain_archive('/tmp/apache_exporter-0.8.0.tar.gz') }
-          it { is_expected.to contain_file('/opt/apache_exporter-0.8.0.linux-amd64/apache_exporter') }
-        end
+        it { is_expected.not_to contain_package('apache-exporter') }
+        it { is_expected.to contain_archive('/tmp/apache_exporter-0.8.0.tar.gz') }
+        it { is_expected.to contain_file('/opt/apache_exporter-0.8.0.linux-amd64/apache_exporter') }
       end
 
       context 'with some params' do

--- a/spec/classes/dellhw_exporter_spec.rb
+++ b/spec/classes/dellhw_exporter_spec.rb
@@ -13,16 +13,10 @@ describe 'prometheus::dellhw_exporter' do
         describe 'with all defaults' do
           it { is_expected.to compile.with_all_deps }
 
-          if facts[:os]['name'] == 'Archlinux'
-            it { is_expected.to contain_package('dellhw_exporter') }
-            it { is_expected.not_to contain_file('/usr/local/bin/dellhw_exporter') }
-            it { is_expected.not_to contain_archive('/tmp/dellhw_exporter-1.6.0.tar.gz') }
-          else
-            it { is_expected.to contain_archive('/tmp/dellhw_exporter-1.6.0.tar.gz') }
-            it { is_expected.to contain_file('/usr/local/bin/dellhw_exporter').with('target' => '/opt/dellhw_exporter-1.6.0.linux-amd64/dellhw_exporter') }
-            it { is_expected.to contain_file('/opt/dellhw_exporter-1.6.0.linux-amd64/dellhw_exporter') }
-            it { is_expected.not_to contain_package('dellhw_exporter') }
-          end
+          it { is_expected.to contain_archive('/tmp/dellhw_exporter-1.6.0.tar.gz') }
+          it { is_expected.to contain_file('/usr/local/bin/dellhw_exporter').with('target' => '/opt/dellhw_exporter-1.6.0.linux-amd64/dellhw_exporter') }
+          it { is_expected.to contain_file('/opt/dellhw_exporter-1.6.0.linux-amd64/dellhw_exporter') }
+          it { is_expected.not_to contain_package('dellhw_exporter') }
           it { is_expected.to contain_prometheus__daemon('dellhw_exporter') }
           it { is_expected.to contain_user('dellhw-exporter') }
           it { is_expected.to contain_group('dellhw-exporter') }

--- a/spec/classes/ipmi_exporter_spec.rb
+++ b/spec/classes/ipmi_exporter_spec.rb
@@ -12,18 +12,17 @@ describe 'prometheus::ipmi_exporter' do
       context 'without parameters' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('prometheus') }
-        it { is_expected.to contain_prometheus__daemon('ipmi_exporter').with(options: '--config.file=/etc/ipmi_exporter.yaml  --freeipmi.path=/usr/local/bin') }
         it { is_expected.to contain_service('ipmi_exporter') }
         it { is_expected.to contain_user('ipmi-exporter') }
         it { is_expected.to contain_group('ipmi-exporter') }
+        it { is_expected.to contain_file('/opt/ipmi_exporter-1.4.0.linux-amd64/ipmi_exporter') }
+        it { is_expected.to contain_file('/usr/local/bin/ipmi_exporter') }
 
         if facts[:os]['name'] == 'Archlinux'
-          it { is_expected.not_to contain_file('/opt/ipmi_exporter-1.4.0.linux-amd64/ipmi_exporter') }
-          it { is_expected.not_to contain_file('/usr/local/bin/ipmi_exporter') }
           it { is_expected.to contain_systemd__unit_file('ipmi_exporter.service') }
+          it { is_expected.to contain_prometheus__daemon('ipmi_exporter').with(options: '--config.file=/etc/ipmi_exporter.yaml  ') }
         else
-          it { is_expected.to contain_file('/opt/ipmi_exporter-1.4.0.linux-amd64/ipmi_exporter') }
-          it { is_expected.to contain_file('/usr/local/bin/ipmi_exporter') }
+          it { is_expected.to contain_prometheus__daemon('ipmi_exporter').with(options: '--config.file=/etc/ipmi_exporter.yaml  --freeipmi.path=/usr/local/bin') }
         end
 
         if facts[:os]['family'] == 'RedHat'
@@ -44,14 +43,13 @@ describe 'prometheus::ipmi_exporter' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_archive('/tmp/ipmi_exporter-1.3.1.tar.gz') }
-        it { is_expected.to contain_prometheus__daemon('ipmi_exporter').with(options: '--config.file=/etc/ipmi_exporter.yaml  --freeipmi.path=/usr/local/bin') }
+        it { is_expected.to contain_file('/usr/local/bin/ipmi_exporter') }
+        it { is_expected.not_to contain_file('/usr/bin/ipmi_exporter') }
 
         if facts[:os]['name'] == 'Archlinux'
-          it { is_expected.to contain_file('/usr/bin/ipmi_exporter') }
-          it { is_expected.not_to contain_file('/usr/local/bin/ipmi_exporter') }
+          it { is_expected.to contain_prometheus__daemon('ipmi_exporter').with(options: '--config.file=/etc/ipmi_exporter.yaml  ') }
         else
-          it { is_expected.to contain_file('/usr/local/bin/ipmi_exporter') }
-          it { is_expected.not_to contain_file('/usr/bin/ipmi_exporter') }
+          it { is_expected.to contain_prometheus__daemon('ipmi_exporter').with(options: '--config.file=/etc/ipmi_exporter.yaml  --freeipmi.path=/usr/local/bin') }
         end
         it do
           verify_contents(catalogue, '/etc/ipmi_exporter.yaml', [
@@ -91,7 +89,12 @@ describe 'prometheus::ipmi_exporter' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_prometheus__daemon('ipmi_exporter').with(options: '--config.file=/etc/ipmi_exporter.yaml --path.procfs /host/proc --path.sysfs /host/sys --freeipmi.path=/usr/local/bin') }
+
+        if facts[:os]['name'] == 'Archlinux'
+          it { is_expected.to contain_prometheus__daemon('ipmi_exporter').with(options: '--config.file=/etc/ipmi_exporter.yaml --path.procfs /host/proc --path.sysfs /host/sys ') }
+        else
+          it { is_expected.to contain_prometheus__daemon('ipmi_exporter').with(options: '--config.file=/etc/ipmi_exporter.yaml --path.procfs /host/proc --path.sysfs /host/sys --freeipmi.path=/usr/local/bin') }
+        end
       end
 
       context 'with no download_extension' do

--- a/spec/classes/memcached_exporter_spec.rb
+++ b/spec/classes/memcached_exporter_spec.rb
@@ -14,18 +14,20 @@ describe 'prometheus::memcached_exporter' do
           it { is_expected.to compile.with_all_deps }
 
           if facts[:os]['name'] == 'Archlinux'
-            it { is_expected.to contain_package('memcached_exporter') }
+            it { is_expected.to contain_package('prometheus-memcached-exporter') }
             it { is_expected.not_to contain_file('/usr/local/bin/memcached_exporter') }
             it { is_expected.not_to contain_archive('/tmp/memcached_exporter-0.6.0.tar.gz') }
+            it { is_expected.to contain_prometheus__daemon('prometheus-memcached-exporter') }
+            it { is_expected.to contain_service('prometheus-memcached-exporter') }
           else
             it { is_expected.to contain_archive('/tmp/memcached_exporter-0.6.0.tar.gz') }
             it { is_expected.to contain_file('/usr/local/bin/memcached_exporter').with('target' => '/opt/memcached_exporter-0.6.0.linux-amd64/memcached_exporter') }
             it { is_expected.not_to contain_package('memcached_exporter') }
+            it { is_expected.to contain_prometheus__daemon('memcached_exporter') }
+            it { is_expected.to contain_user('memcached-exporter') }
+            it { is_expected.to contain_group('memcached-exporter') }
+            it { is_expected.to contain_service('memcached_exporter') }
           end
-          it { is_expected.to contain_prometheus__daemon('memcached_exporter') }
-          it { is_expected.to contain_user('memcached-exporter') }
-          it { is_expected.to contain_group('memcached-exporter') }
-          it { is_expected.to contain_service('memcached_exporter') }
           it { is_expected.to contain_class('prometheus') }
         end
       end

--- a/spec/classes/nginx_prometheus_exporter_spec.rb
+++ b/spec/classes/nginx_prometheus_exporter_spec.rb
@@ -18,15 +18,9 @@ describe 'prometheus::nginx_prometheus_exporter' do
           it { is_expected.to contain_systemd__unit_file('nginx_prometheus_exporter.service') }
         end
 
-        if facts[:os]['name'] == 'Archlinux'
-          it { is_expected.to contain_package('nginx-prometheus-exporter') }
-          it { is_expected.not_to contain_archive('/tmp/nginx-prometheus-exporter-0.9.0.tar.gz') }
-          it { is_expected.not_to contain_file('/opt/nginx-prometheus-exporter-0.9.0.linux-amd64') }
-        else
-          it { is_expected.not_to contain_package('nginx-prometheus-exporter') }
-          it { is_expected.to contain_archive('/tmp/nginx-prometheus-exporter-0.9.0.tar.gz') }
-          it { is_expected.to contain_file('/opt/nginx-prometheus-exporter-0.9.0.linux-amd64') }
-        end
+        it { is_expected.not_to contain_package('nginx-prometheus-exporter') }
+        it { is_expected.to contain_archive('/tmp/nginx-prometheus-exporter-0.9.0.tar.gz') }
+        it { is_expected.to contain_file('/opt/nginx-prometheus-exporter-0.9.0.linux-amd64') }
       end
 
       context 'with some params' do

--- a/spec/classes/node_exporter_spec.rb
+++ b/spec/classes/node_exporter_spec.rb
@@ -60,10 +60,7 @@ describe 'prometheus::node_exporter' do
         it { is_expected.to contain_archive('/tmp/node_exporter-1.0.1.tar.gz') }
         it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '--collector.foo --collector.bar --no-collector.baz --no-collector.qux') }
 
-        if facts[:os]['name'] == 'Archlinux'
-          it { is_expected.to contain_file('/usr/bin/node_exporter') }
-          it { is_expected.not_to contain_file('/usr/local/bin/node_exporter') }
-        else
+        if facts[:os]['name'] != 'Archlinux'
           it { is_expected.to contain_file('/usr/local/bin/node_exporter') }
           it { is_expected.not_to contain_file('/usr/bin/node_exporter') }
         end

--- a/spec/classes/php_fpm_exporter_spec.rb
+++ b/spec/classes/php_fpm_exporter_spec.rb
@@ -18,15 +18,9 @@ describe 'prometheus::php_fpm_exporter' do
           it { is_expected.to contain_systemd__unit_file('php-fpm_exporter.service') }
         end
 
-        if facts[:os]['name'] == 'Archlinux'
-          it { is_expected.to contain_package('php-fpm_exporter') }
-          it { is_expected.not_to contain_archive('/tmp/php-fpm_exporter-2.0.4.tar.gz') }
-          it { is_expected.not_to contain_file('/opt/php-fpm_exporter-2.0.4.linux-amd64') }
-        else
-          it { is_expected.not_to contain_package('php-fpm_exporter') }
-          it { is_expected.to contain_archive('/tmp/php-fpm_exporter-2.0.4.tar.gz') }
-          it { is_expected.to contain_file('/opt/php-fpm_exporter-2.0.4.linux-amd64') }
-        end
+        it { is_expected.not_to contain_package('php-fpm_exporter') }
+        it { is_expected.to contain_archive('/tmp/php-fpm_exporter-2.0.4.tar.gz') }
+        it { is_expected.to contain_file('/opt/php-fpm_exporter-2.0.4.linux-amd64') }
       end
 
       context 'with some params' do

--- a/spec/classes/puppetdb_exporter_spec.rb
+++ b/spec/classes/puppetdb_exporter_spec.rb
@@ -13,16 +13,10 @@ describe 'prometheus::puppetdb_exporter' do
         describe 'with all defaults' do
           it { is_expected.to compile.with_all_deps }
 
-          if facts[:os]['name'] == 'Archlinux'
-            it { is_expected.to contain_package('puppetdb_exporter') }
-            it { is_expected.not_to contain_file('/usr/local/bin/puppetdb_exporter') }
-            it { is_expected.not_to contain_archive('/tmp/puppetdb_exporter-1.1.0.tar.gz') }
-          else
-            it { is_expected.to contain_archive('/tmp/puppetdb_exporter-1.1.0.tar.gz') }
-            it { is_expected.to contain_file('/usr/local/bin/puppetdb_exporter').with('target' => '/opt/prometheus-puppetdb-exporter-1.1.0.linux-amd64/prometheus-puppetdb-exporter') }
-            it { is_expected.to contain_file('/opt/prometheus-puppetdb-exporter-1.1.0.linux-amd64/prometheus-puppetdb-exporter') }
-            it { is_expected.not_to contain_package('puppetdb_exporter') }
-          end
+          it { is_expected.to contain_archive('/tmp/puppetdb_exporter-1.1.0.tar.gz') }
+          it { is_expected.to contain_file('/usr/local/bin/puppetdb_exporter').with('target' => '/opt/prometheus-puppetdb-exporter-1.1.0.linux-amd64/prometheus-puppetdb-exporter') }
+          it { is_expected.to contain_file('/opt/prometheus-puppetdb-exporter-1.1.0.linux-amd64/prometheus-puppetdb-exporter') }
+          it { is_expected.not_to contain_package('puppetdb_exporter') }
           it { is_expected.to contain_prometheus__daemon('puppetdb_exporter') }
           it { is_expected.to contain_user('puppetdb-exporter') }
           it { is_expected.to contain_group('puppetdb-exporter') }


### PR DESCRIPTION
This fixes the Archlinux tests. Most notably the default for `install_method` is reset to the default for Archlinux. This is because  most exporters actually don't have a package for Archlinux. The changes are somwhat backwards incompatible, but I would argue that previously the module was broken for Archlinux. So I consider this a bugfix instead.
