### PR TITLE
make statsd exporter mappings optional

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -13287,7 +13287,7 @@ Name of the statsd exporter service (default 'statsd_exporter')
 
 ##### <a name="-prometheus--statsd_exporter--mappings"></a>`mappings`
 
-Data type: `Array[Hash]`
+Data type: `Optional[Array[Hash]]`
 
 The hiera array for mappings:
   - map: 'test.dispatcher.*.*.*'
@@ -13295,6 +13295,8 @@ The hiera array for mappings:
     labels:
       processor: '$2'
       action: '$1'
+
+Default value: `undef`
 
 ##### <a name="-prometheus--statsd_exporter--user"></a>`user`
 

--- a/manifests/statsd_exporter.pp
+++ b/manifests/statsd_exporter.pp
@@ -67,9 +67,9 @@ class prometheus::statsd_exporter (
   String[1] $package_ensure,
   String[1] $package_name,
   String[1] $service_name,
-  Array[Hash] $mappings,
   String[1] $user,
   String[1] $version,
+  Optional[Array[Hash]] $mappings                            = undef,
   String[1] $arch                                            = $prometheus::real_arch,
   Stdlib::Absolutepath $bin_dir                              = $prometheus::bin_dir,
   String[1] $config_mode                                     = $prometheus::config_mode,
@@ -105,13 +105,15 @@ class prometheus::statsd_exporter (
     default => undef,
   }
 
-  file { $mapping_config_path:
-    ensure  => 'file',
-    mode    => $config_mode,
-    owner   => 'root',
-    group   => $group,
-    content => stdlib::to_yaml({ mappings => $mappings }),
-    notify  => $notify_service,
+  if $mappings {
+    file { $mapping_config_path:
+      ensure  => 'file',
+      mode    => $config_mode,
+      owner   => 'root',
+      group   => $group,
+      content => stdlib::to_yaml({ mappings => $mappings }),
+      notify  => $notify_service,
+    }
   }
 
   # Switched to POSIX like flags in version 0.7.0

--- a/spec/classes/statsd_exporter_spec.rb
+++ b/spec/classes/statsd_exporter_spec.rb
@@ -102,10 +102,6 @@ describe 'prometheus::statsd_exporter' do
         describe 'compile manifest' do
           it { is_expected.to compile.with_all_deps }
         end
-
-        describe 'not install config' do
-          it { is_expected.not_to contain_file('/etc/statsd-exporter-mapping.yaml') }
-        end
       end
 
       context 'with older version that does not support posix like option flags specified' do

--- a/spec/classes/statsd_exporter_spec.rb
+++ b/spec/classes/statsd_exporter_spec.rb
@@ -104,9 +104,8 @@ describe 'prometheus::statsd_exporter' do
         end
 
         describe 'not install config' do
-          it { should_not contain_file('/etc/statsd-exporter-mapping.yaml') }
+          it { is_expected.not_to contain_file('/etc/statsd-exporter-mapping.yaml') }
         end
-
       end
 
       context 'with older version that does not support posix like option flags specified' do

--- a/spec/classes/statsd_exporter_spec.rb
+++ b/spec/classes/statsd_exporter_spec.rb
@@ -88,6 +88,27 @@ describe 'prometheus::statsd_exporter' do
         end
       end
 
+      context 'with no mappings' do
+        let(:params) do
+          {
+            version: '0.8.0',
+            arch: 'amd64',
+            os: 'linux',
+            bin_dir: '/usr/local/bin',
+            install_method: 'url',
+          }
+        end
+
+        describe 'compile manifest' do
+          it { is_expected.to compile.with_all_deps }
+        end
+
+        describe 'not install config' do
+          it { should_not contain_file('/etc/statsd-exporter-mapping.yaml') }
+        end
+
+      end
+
       context 'with older version that does not support posix like option flags specified' do
         let(:params) do
           {


### PR DESCRIPTION
#### Pull Request (PR) description
This PR addresses Issue #680 

#### This Pull Request (PR) fixes the following issues
Makes statsd exporter mappings optional (so you can provide your own config)
