### PR TITLE
change path or my.cnf for mysqld_exporter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6678,7 +6678,7 @@ Data type: `Stdlib::Absolutepath`
 
 The path to put the my.cnf file
 
-Default value: `'/etc/.my.cnf'`
+Default value: `'/etc/mysqld_exporter-my.cnf'`
 
 ##### <a name="-prometheus--mysqld_exporter--cnf_host"></a>`cnf_host`
 

--- a/manifests/mysqld_exporter.pp
+++ b/manifests/mysqld_exporter.pp
@@ -78,7 +78,7 @@ class prometheus::mysqld_exporter (
   String[1] $service_name,
   String[1] $user,
   String[1] $version,
-  Stdlib::Absolutepath $cnf_config_path                      = '/etc/.my.cnf',
+  Stdlib::Absolutepath $cnf_config_path                      = '/etc/mysqld_exporter-my.cnf',
   Stdlib::Host $cnf_host                                     = localhost,
   Stdlib::Port $cnf_port                                     = 3306,
   String[1] $cnf_user                                        = login,

--- a/spec/classes/mysqld_exporter_spec.rb
+++ b/spec/classes/mysqld_exporter_spec.rb
@@ -11,7 +11,7 @@ describe 'prometheus::mysqld_exporter' do
 
       context 'default' do
         describe 'options is correct' do
-          it { is_expected.to contain_prometheus__daemon('mysqld_exporter').with('options' => '--config.my-cnf=/etc/.my.cnf') }
+          it { is_expected.to contain_prometheus__daemon('mysqld_exporter').with('options' => '--config.my-cnf=/etc/mysqld_exporter-my.cnf') }
         end
       end
 
@@ -23,7 +23,7 @@ describe 'prometheus::mysqld_exporter' do
         end
 
         describe 'options is correct' do
-          it { is_expected.to contain_prometheus__daemon('mysqld_exporter').with('options' => '-config.my-cnf=/etc/.my.cnf') }
+          it { is_expected.to contain_prometheus__daemon('mysqld_exporter').with('options' => '-config.my-cnf=/etc/mysqld_exporter-my.cnf') }
         end
       end
 
@@ -35,7 +35,7 @@ describe 'prometheus::mysqld_exporter' do
         end
 
         it do
-          content = catalogue.resource('file', '/etc/.my.cnf').send(:parameters)[:content]
+          content = catalogue.resource('file', '/etc/mysqld_exporter-my.cnf').send(:parameters)[:content]
           expect(content).to include('secret')
         end
       end
@@ -55,7 +55,7 @@ describe 'prometheus::mysqld_exporter' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_file('/etc/mysqld_exporter_web-config.yml').with(ensure: 'file') }
 
-        it { is_expected.to contain_prometheus__daemon('mysqld_exporter').with(options: '--config.my-cnf=/etc/.my.cnf --web.config.file=/etc/mysqld_exporter_web-config.yml') }
+        it { is_expected.to contain_prometheus__daemon('mysqld_exporter').with(options: '--config.my-cnf=/etc/mysqld_exporter-my.cnf --web.config.file=/etc/mysqld_exporter_web-config.yml') }
       end
     end
   end


### PR DESCRIPTION
previously /etc/.my.cnf was used. This is the default mysql config path for many other tools and should not be modified by this module

fixes #226 