### PR TITLE
support the new scrape_config_files option, prom ~v2.45

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -123,6 +123,7 @@ The following parameters are available in the `prometheus` class:
 * [`global_config`](#-prometheus--global_config)
 * [`rule_files`](#-prometheus--rule_files)
 * [`scrape_configs`](#-prometheus--scrape_configs)
+* [`scrape_config_files`](#-prometheus--scrape_config_files)
 * [`include_default_scrape_configs`](#-prometheus--include_default_scrape_configs)
 * [`remote_read_configs`](#-prometheus--remote_read_configs)
 * [`remote_write_configs`](#-prometheus--remote_write_configs)
@@ -446,6 +447,15 @@ Data type: `Array`
 Prometheus scrape configs
 
 Default value: `[]`
+
+##### <a name="-prometheus--scrape_config_files"></a>`scrape_config_files`
+
+Data type: `Optional[Array]`
+
+Specifies an Array of file globs. Scrape configs are read from all matching files and appended to
+the list of scrape configs.
+
+Default value: `undef`
 
 ##### <a name="-prometheus--include_default_scrape_configs"></a>`include_default_scrape_configs`
 
@@ -11672,6 +11682,7 @@ The following parameters are available in the `prometheus::server` class:
 * [`global_config`](#-prometheus--server--global_config)
 * [`rule_files`](#-prometheus--server--rule_files)
 * [`scrape_configs`](#-prometheus--server--scrape_configs)
+* [`scrape_config_files`](#-prometheus--server--scrape_config_files)
 * [`include_default_scrape_configs`](#-prometheus--server--include_default_scrape_configs)
 * [`remote_read_configs`](#-prometheus--server--remote_read_configs)
 * [`remote_write_configs`](#-prometheus--server--remote_write_configs)
@@ -11875,6 +11886,14 @@ Data type: `Array`
 
 
 Default value: `$prometheus::scrape_configs`
+
+##### <a name="-prometheus--server--scrape_config_files"></a>`scrape_config_files`
+
+Data type: `Optional[Array]`
+
+
+
+Default value: `$prometheus::scrape_config_files`
 
 ##### <a name="-prometheus--server--include_default_scrape_configs"></a>`include_default_scrape_configs`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,9 @@
 #  Prometheus rule files
 # @param scrape_configs
 #  Prometheus scrape configs
+# @param scrape_config_files
+#  Specifies an Array of file globs. Scrape configs are read from all matching files and appended to
+#  the list of scrape configs.
 # @param include_default_scrape_configs
 #  Include the module default scrape configs
 # @param remote_read_configs
@@ -228,6 +231,7 @@ class prometheus (
   String $package_name = 'prometheus',
   Array $rule_files = [],
   Array $scrape_configs = [],
+  Optional[Array] $scrape_config_files = undef,
   Array $remote_read_configs = [],
   Array $remote_write_configs = [],
   Boolean $enable_tracing = false,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -21,6 +21,7 @@ class prometheus::server (
   Hash $global_config                                                           = $prometheus::global_config,
   Array $rule_files                                                             = $prometheus::rule_files,
   Array $scrape_configs                                                         = $prometheus::scrape_configs,
+  Optional[Array] $scrape_config_files                                          = $prometheus::scrape_config_files,
   Boolean $include_default_scrape_configs                                       = $prometheus::include_default_scrape_configs,
   Array $remote_read_configs                                                    = $prometheus::remote_read_configs,
   Array $remote_write_configs                                                   = $prometheus::remote_write_configs,

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -44,6 +44,27 @@ describe 'prometheus::server' do
           }
         end
 
+        describe 'scrape_config_files' do
+          context 'by default' do
+            it {
+              content = catalogue.resource('file', 'prometheus.yaml').send(:parameters)[:content]
+              expect(content).not_to include('scrape_config_files:')
+            }
+          end
+
+          context 'when set with a glob' do
+            let(:params) do
+              super().merge(scrape_config_files: ['/etc/prometheus/scrape_configs.d/*.yaml'])
+            end
+
+            it {
+              content = catalogue.resource('file', 'prometheus.yaml').send(:parameters)[:content]
+              expect(content).to include('scrape_config_files:')
+              expect(content).to include('- "/etc/prometheus/scrape_configs.d/*.yaml"')
+            }
+          end
+        end
+
         describe 'max_open_files', if: facts[:os]['name'] != 'Archlinux' do
           context 'by default' do
             it {

--- a/templates/prometheus.yaml.erb
+++ b/templates/prometheus.yaml.erb
@@ -2,6 +2,7 @@
 <% global_config = scope.lookupvar('prometheus::server::global_config') -%>
 <% rule_files = scope.lookupvar('prometheus::server::_rule_files') -%>
 <% scrape_configs = scope.lookupvar('prometheus::config::scrape_configs') -%>
+<% scrape_config_files = scope.lookupvar('prometheus::server::scrape_config_files') -%>
 <% remote_read_configs = scope.lookupvar('prometheus::server::remote_read_configs') -%>
 <% remote_write_configs = scope.lookupvar('prometheus::server::remote_write_configs') -%>
 <% tracing_config = scope.lookupvar('prometheus::server::tracing_config') -%>
@@ -14,6 +15,9 @@
     'alertmanagers'=>scope.lookupvar('prometheus::server::alertmanagers_config'),
   },
 }
+if scrape_config_files
+    full_config['scrape_config_files'] = scrape_config_files
+end
     full_config['remote_read'] = remote_read_configs
     full_config['remote_write'] = remote_write_configs
 if @enable_tracing


### PR DESCRIPTION
#### Pull Request (PR) description

Adds some config to support loading scrape configs from disk, rather than be included in the main prometheus.yml file.  This option came in at about Prom version 2.45 IIRC.  Since it's so new, took steps to try make it not appear anywhere unless it was requested (it'll make old Prom fail to load).

Happy to take some direction on how to test it better.