### PR TITLE
expose the env_vars and env_file_path parameters to the blackbox_exporter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2593,6 +2593,8 @@ The following parameters are available in the `prometheus::blackbox_exporter` cl
 * [`user`](#-prometheus--blackbox_exporter--user)
 * [`version`](#-prometheus--blackbox_exporter--version)
 * [`config_mode`](#-prometheus--blackbox_exporter--config_mode)
+* [`env_vars`](#-prometheus--blackbox_exporter--env_vars)
+* [`env_file_path`](#-prometheus--blackbox_exporter--env_file_path)
 * [`proxy_server`](#-prometheus--blackbox_exporter--proxy_server)
 * [`proxy_type`](#-prometheus--blackbox_exporter--proxy_type)
 * [`web_config_file`](#-prometheus--blackbox_exporter--web_config_file)
@@ -2837,6 +2839,22 @@ Data type: `String[1]`
 The permissions of the configuration files
 
 Default value: `$prometheus::config_mode`
+
+##### <a name="-prometheus--blackbox_exporter--env_vars"></a>`env_vars`
+
+Data type: `Hash[String[1], Scalar]`
+
+hash with custom environment variables thats passed to the exporter via init script / unit file
+
+Default value: `{}`
+
+##### <a name="-prometheus--blackbox_exporter--env_file_path"></a>`env_file_path`
+
+Data type: `Stdlib::Absolutepath`
+
+The path to the file with the environmetn variable that is read from the init script/systemd unit
+
+Default value: `$prometheus::env_file_path`
 
 ##### <a name="-prometheus--blackbox_exporter--proxy_server"></a>`proxy_server`
 

--- a/manifests/blackbox_exporter.pp
+++ b/manifests/blackbox_exporter.pp
@@ -59,6 +59,10 @@
 #  The binary release version
 # @param config_mode
 #  The permissions of the configuration files
+# @param env_vars
+#  hash with custom environment variables thats passed to the exporter via init script / unit file
+# @param env_file_path
+#  The path to the file with the environmetn variable that is read from the init script/systemd unit
 # @param proxy_server
 #  Optional proxy server, with port number if needed. ie: https://example.com:8080
 # @param proxy_type
@@ -111,6 +115,8 @@ class prometheus::blackbox_exporter (
   Stdlib::Port $scrape_port                                  = 9115,
   String[1] $scrape_job_name                                 = 'blackbox',
   Optional[Hash] $scrape_job_labels                          = undef,
+  Hash[String[1], Scalar] $env_vars                          = {},
+  Stdlib::Absolutepath $env_file_path                        = $prometheus::env_file_path,
   Optional[String[1]] $proxy_server                          = undef,
   Optional[Enum['none', 'http', 'https', 'ftp']] $proxy_type = undef,
   Stdlib::Absolutepath $web_config_file                      = '/etc/blackbox_exporter_web-config.yml',
@@ -189,6 +195,8 @@ class prometheus::blackbox_exporter (
     scrape_port        => $scrape_port,
     scrape_job_name    => $scrape_job_name,
     scrape_job_labels  => $scrape_job_labels,
+    env_vars           => $env_vars,
+    env_file_path      => $env_file_path,
     proxy_server       => $proxy_server,
     proxy_type         => $proxy_type,
   }

--- a/spec/classes/blackbox_exporter_spec.rb
+++ b/spec/classes/blackbox_exporter_spec.rb
@@ -59,6 +59,20 @@ describe 'prometheus::blackbox_exporter' do
           it { is_expected.to contain_prometheus__daemon('blackbox_exporter').with(options: '--config.file=/etc/blackbox-exporter.yaml --web.config.file=/etc/blackbox_exporter_web-config.yml') }
         end
       end
+
+      context 'with env vars' do
+        let :params do
+          {
+            env_vars: {
+              blub: 'foobar'
+            },
+            env_file_path: '/cows'
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_prometheus__daemon('blackbox_exporter').with({ env_vars: { 'blub' => 'foobar' }, env_file_path: '/cows' }) }
+      end
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

The `prometheus::daemon` defined type has `env_var` and `env_file_path` options.  This PR simply exposes those options to the `blackbox_exporter` subclass, as is done in several other exporter subclasses.

This will allow me to set EnvVars which match what the Systemd Unit file in the Prometheus RPM is expecting to find.