### PR TITLE
fix: missing `WorkDirectory` in systemd unit file for archliinux

### DIFF
--- a/data/Archlinux.yaml
+++ b/data/Archlinux.yaml
@@ -9,6 +9,8 @@ prometheus::configname: 'prometheus.yml'
 prometheus::server::install_method: 'package'
 prometheus::server::bin_dir: '/usr/bin'
 prometheus::env_file_path: '/etc/conf.d'
+prometheus::systemd_service_options:
+  WorkingDirectory: /usr/share/prometheus
 prometheus::node_exporter::package_name: 'prometheus-node-exporter'
 prometheus::node_exporter::install_method: 'package'
 prometheus::node_exporter::bin_name: 'prometheus-node-exporter'

--- a/spec/acceptance/prometheus_server_spec.rb
+++ b/spec/acceptance/prometheus_server_spec.rb
@@ -45,6 +45,13 @@ describe 'prometheus server basics' do
     end
   end
 
+  it 'can access static files' do
+    shell('curl -s http://127.0.0.1:9090/graph') do |r|
+      expect(r.stdout).to match(%r{doctype html})
+      expect(r.exit_code).to eq(0)
+    end
+  end
+
   describe 'updating configuration to enable Admin API' do
     it 'prometheus server via main class works idempotently with no errors' do
       pp = "class{'prometheus': manage_prometheus_server => true, web_enable_admin_api => true }"


### PR DESCRIPTION
kept using the systemd unit from the module to keep the ability to configure command line flags.

fixes #792