### PR TITLE
Update nginx_prometheus_exporter.pp to use proxy server

### DIFF
--- a/manifests/nginx_prometheus_exporter.pp
+++ b/manifests/nginx_prometheus_exporter.pp
@@ -120,6 +120,8 @@ class prometheus::nginx_prometheus_exporter (
       checksum_verify => false,
       creates         => "${install_dir}/${package_name}",
       cleanup         => true,
+      proxy_server    => $proxy_server,
+      proxy_type      => $proxy_type,
     }
     -> file { "${bin_dir}/${package_name}":
       ensure => link,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
nginx_prometheus_exporter doesn't use proxy_server or proxy_type to download its tarball without these options added to the extract class
-->

#### This Pull Request (PR) fixes the following issues
<!--
n/a
-->
