### PR TITLE
use $service_name instead of a hard-coded name for prometheus::daemon

### DIFF
--- a/manifests/beanstalkd_exporter.pp
+++ b/manifests/beanstalkd_exporter.pp
@@ -113,15 +113,15 @@ class prometheus::beanstalkd_exporter (
   file { $config:
     ensure  => $real_file_ensure,
     content => $beanstalkd_address,
-    before  => Prometheus::Daemon['beanstalkd_exporter'],
+    before  => Prometheus::Daemon[$service_name],
   }
 
   file { $mapping_config:
     ensure => $real_file_ensure,
-    before => Prometheus::Daemon['beanstalkd_exporter'],
+    before => Prometheus::Daemon[$service_name],
   }
 
-  prometheus::daemon { 'beanstalkd_exporter':
+  prometheus::daemon { $service_name:
     install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,

--- a/manifests/consul_exporter.pp
+++ b/manifests/consul_exporter.pp
@@ -125,7 +125,7 @@ class prometheus::consul_exporter (
     $options = "--consul.server=${consul_server} ${real_consul_health_summary} --web.listen-address=${web_listen_address} --web.telemetry-path=${web_telemetry_path} --log.level=${log_level} ${extra_options}"
   }
 
-  prometheus::daemon { 'consul_exporter':
+  prometheus::daemon { $service_name:
     install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,

--- a/manifests/elasticsearch_exporter.pp
+++ b/manifests/elasticsearch_exporter.pp
@@ -149,7 +149,7 @@ class prometheus::elasticsearch_exporter (
     $_web_config,
   ].filter |$x| { !$x.empty }.join(' ')
 
-  prometheus::daemon { 'elasticsearch_exporter':
+  prometheus::daemon { $service_name:
     install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,

--- a/manifests/graphite_exporter.pp
+++ b/manifests/graphite_exporter.pp
@@ -86,7 +86,7 @@ class prometheus::graphite_exporter (
     default => undef,
   }
 
-  prometheus::daemon { 'graphite_exporter':
+  prometheus::daemon { $service_name:
     install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,

--- a/manifests/ipsec_exporter.pp
+++ b/manifests/ipsec_exporter.pp
@@ -98,7 +98,7 @@ class prometheus::ipsec_exporter (
     default => undef,
   }
 
-  prometheus::daemon { 'ipsec_exporter':
+  prometheus::daemon { $service_name:
     install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,

--- a/manifests/jmx_exporter.pp
+++ b/manifests/jmx_exporter.pp
@@ -113,9 +113,7 @@ class prometheus::jmx_exporter (
     default => "${java_options} "
   }
 
-  $_name = 'jmx_exporter'
-
-  prometheus::daemon { $_name:
+  prometheus::daemon { $service_name:
     notify_service     => $notify_service,
     install_method     => 'url',
     version            => $version,
@@ -132,7 +130,7 @@ class prometheus::jmx_exporter (
     manage_bin_link    => false,
     bin_dir            => dirname($java_bin_path),
     bin_name           => basename($java_bin_path),
-    options            => "${_java_options}-jar /opt/${_name}-${version}.${os}-${arch}/${_name} ${port} ${config_file_location}",
+    options            => "${_java_options}-jar /opt/${service_name}-${version}.${os}-${arch}/${service_name} ${port} ${config_file_location}",
     os                 => $os,
     arch               => $arch,
   }

--- a/manifests/mesos_exporter.pp
+++ b/manifests/mesos_exporter.pp
@@ -96,7 +96,7 @@ class prometheus::mesos_exporter (
 
   $options = "-${server_type} ${cnf_scrape_uri} ${extra_options}"
 
-  prometheus::daemon { 'mesos_exporter':
+  prometheus::daemon { $service_name:
     install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,

--- a/manifests/nginx_vts_exporter.pp
+++ b/manifests/nginx_vts_exporter.pp
@@ -101,7 +101,7 @@ class prometheus::nginx_vts_exporter (
 
   $options = "-nginx.scrape_uri=\"${nginx_scrape_uri}\" ${extra_options}"
 
-  prometheus::daemon { 'nginx-vts-exporter':
+  prometheus::daemon { $service_name:
     install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,

--- a/manifests/rabbitmq_exporter.pp
+++ b/manifests/rabbitmq_exporter.pp
@@ -128,7 +128,7 @@ class prometheus::rabbitmq_exporter (
 
   $real_env_vars = stdlib::merge($env_vars, $extra_env_vars)
 
-  prometheus::daemon { 'rabbitmq_exporter':
+  prometheus::daemon { $service_name:
     install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,

--- a/manifests/snmp_exporter.pp
+++ b/manifests/snmp_exporter.pp
@@ -126,7 +126,7 @@ class prometheus::snmp_exporter (
     notify  => $notify_service,
   }
 
-  prometheus::daemon { 'snmp_exporter':
+  prometheus::daemon { $service_name:
     install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,

--- a/manifests/statsd_exporter.pp
+++ b/manifests/statsd_exporter.pp
@@ -123,7 +123,7 @@ class prometheus::statsd_exporter (
   }
   $options = "${option_prefix}statsd.mapping-config=\'${prometheus::statsd_exporter::mapping_config_path}\' ${prometheus::statsd_exporter::extra_options}"
 
-  prometheus::daemon { 'statsd_exporter':
+  prometheus::daemon { $service_name:
     install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,

--- a/manifests/varnish_exporter.pp
+++ b/manifests/varnish_exporter.pp
@@ -89,7 +89,7 @@ class prometheus::varnish_exporter (
   }
 
   $options = " ${extra_options}"
-  prometheus::daemon { $package_name:
+  prometheus::daemon { $service_name:
     install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Some exporters are using a hard-coded name in `prometheus::daemon { 'some_exporter':` which will break, if `service_name` is set to a different value

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
