### PR TITLE
Fix scrape_job_name for openvpn exporter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -8486,7 +8486,7 @@ Data type: `String[1]`
 
 
 
-Default value: `'node'`
+Default value: `'openvpn'`
 
 ##### <a name="-prometheus--openvpn_exporter--scrape_job_labels"></a>`scrape_job_labels`
 

--- a/manifests/openvpn_exporter.pp
+++ b/manifests/openvpn_exporter.pp
@@ -80,7 +80,7 @@ class prometheus::openvpn_exporter (
   Optional[Stdlib::Host] $scrape_host                        = undef,
   Boolean $export_scrape_job                                 = false,
   Stdlib::Port $scrape_port                                  = 9176,
-  String[1] $scrape_job_name                                 = 'node',
+  String[1] $scrape_job_name                                 = 'openvpn',
   Optional[Hash] $scrape_job_labels                          = undef,
   Optional[String[1]] $bin_name                              = undef,
   Optional[String[1]] $proxy_server                          = undef,


### PR DESCRIPTION
The openvpn scrape job name was previously set to 'node' which caused scraping to merge it with node_exporter's jobs.