### PR TITLE
fix: tests for archlinux

### DIFF
--- a/spec/acceptance/prometheus_server_spec.rb
+++ b/spec/acceptance/prometheus_server_spec.rb
@@ -45,10 +45,20 @@ describe 'prometheus server basics' do
     end
   end
 
-  it 'can access static files' do
-    shell('curl -s http://127.0.0.1:9090/graph') do |r|
-      expect(r.stdout).to match(%r{doctype html})
-      expect(r.exit_code).to eq(0)
+  if host_inventory['facter']['os']['name'] == 'Archlinux'
+    # Archlinux ships promethes >= 3.0.0
+    it 'can access static files' do
+      shell('curl -s http://127.0.0.1:9090/query') do |r|
+        expect(r.stdout).to match(%r{doctype html})
+        expect(r.exit_code).to eq(0)
+      end
+    end
+  else
+    it 'can access static files' do
+      shell('curl -s http://127.0.0.1:9090/graph') do |r|
+        expect(r.stdout).to match(%r{doctype html})
+        expect(r.exit_code).to eq(0)
+      end
     end
   end
 


### PR DESCRIPTION
archlinux ships prometheus >= 3.0.0 this is a quick hack to fix the tests more work is needed to make the module compatible with prometheus >= 3.0.0

