### PR TITLE
remove custom use of archive for several exporters

### DIFF
--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -125,7 +125,7 @@ define prometheus::daemon (
         mode  => '0555',
       }
       if $manage_bin_link {
-        file { "${bin_dir}/${name}":
+        file { "${bin_dir}/${bin_name}":
           ensure  => link,
           notify  => $notify_service,
           target  => $archive_bin_path,

--- a/manifests/nginx_prometheus_exporter.pp
+++ b/manifests/nginx_prometheus_exporter.pp
@@ -99,42 +99,17 @@ class prometheus::nginx_prometheus_exporter (
 
   $options = "-nginx.scrape-uri '${scrape_uri}' ${extra_options}"
 
-  if $install_method == 'url' {
-    # Not a big fan of copypasting but prometheus::daemon takes for granted
-    # a specific path embedded in the prometheus *_exporter tarball, which
-    # nginx_prometheus_exporter lacks currently as of version 0.9.0
-    # TODO: patch prometheus::daemon to support custom extract directories
-    $real_install_method = 'none'
-    $install_dir = "/opt/${package_name}-${version}.${os}-${arch}"
-    file { $install_dir:
-      ensure => 'directory',
-      owner  => 'root',
-      group  => 0, # 0 instead of root because OS X uses "wheel".
-      mode   => '0555',
-    }
-    -> archive { "/tmp/${package_name}-${version}.${download_extension}":
-      ensure          => present,
-      extract         => true,
-      extract_path    => $install_dir,
-      source          => $real_download_url,
-      checksum_verify => false,
-      creates         => "${install_dir}/${package_name}",
-      cleanup         => true,
-      proxy_server    => $proxy_server,
-      proxy_type      => $proxy_type,
-    }
-    -> file { "${bin_dir}/${package_name}":
-      ensure => link,
-      notify => $notify_service,
-      target => "${install_dir}/${package_name}",
-      before => Prometheus::Daemon[$service_name],
-    }
-  } else {
-    $real_install_method = $install_method
-  }
+  $extract_path = "/opt/${package_name}-${version}.${os}-${arch}"
+  $archive_bin_path = "${extract_path}/${bin_name}"
 
-  prometheus::daemon { $service_name:
-    install_method     => $real_install_method,
+  file { $extract_path:
+    ensure => 'directory',
+    owner  => 'root',
+    group  => 0, # 0 instead of root because OS X uses "wheel".
+    mode   => '0555',
+  }
+  -> prometheus::daemon { $service_name:
+    install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,
     os                 => $os,
@@ -165,5 +140,7 @@ class prometheus::nginx_prometheus_exporter (
     env_file_path      => $env_file_path,
     proxy_server       => $proxy_server,
     proxy_type         => $proxy_type,
+    extract_path       => $extract_path,
+    archive_bin_path   => $archive_bin_path,
   }
 }

--- a/manifests/php_fpm_exporter.pp
+++ b/manifests/php_fpm_exporter.pp
@@ -100,40 +100,17 @@ class prometheus::php_fpm_exporter (
 
   $options = "server --phpfpm.scrape-uri '${scrape_uri}' ${extra_options}"
 
-  if $install_method == 'url' {
-    # Not a big fan of copypasting but prometheus::daemon takes for granted
-    # a specific path embedded in the prometheus *_exporter tarball, which
-    # php-fpm_exporter lacks currently as of version 2.0.4
-    # TODO: patch prometheus::daemon to support custom extract directories
-    $real_install_method = 'none'
-    $install_dir = "/opt/${package_name}-${version}.${os}-${arch}"
-    file { $install_dir:
-      ensure => 'directory',
-      owner  => 'root',
-      group  => 0, # 0 instead of root because OS X uses "wheel".
-      mode   => '0555',
-    }
-    -> archive { "/tmp/${package_name}-${version}.${download_extension}":
-      ensure          => present,
-      extract         => true,
-      extract_path    => $install_dir,
-      source          => $real_download_url,
-      checksum_verify => false,
-      creates         => "${install_dir}/${package_name}",
-      cleanup         => true,
-    }
-    -> file { "${bin_dir}/${package_name}":
-      ensure => link,
-      notify => $notify_service,
-      target => "${install_dir}/${package_name}",
-      before => Prometheus::Daemon[$service_name],
-    }
-  } else {
-    $real_install_method = $install_method
-  }
+  $extract_path = "/opt/${package_name}-${version}.${os}-${arch}"
+  $archive_bin_path = "${extract_path}/${bin_name}"
 
-  prometheus::daemon { $service_name:
-    install_method     => $real_install_method,
+  file { $extract_path:
+    ensure => 'directory',
+    owner  => 'root',
+    group  => 0, # 0 instead of root because OS X uses "wheel".
+    mode   => '0555',
+  }
+  -> prometheus::daemon { $service_name:
+    install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,
     os                 => $os,
@@ -164,5 +141,7 @@ class prometheus::php_fpm_exporter (
     env_file_path      => $env_file_path,
     proxy_server       => $proxy_server,
     proxy_type         => $proxy_type,
+    extract_path       => $extract_path,
+    archive_bin_path   => $archive_bin_path,
   }
 }

--- a/manifests/postgres_exporter.pp
+++ b/manifests/postgres_exporter.pp
@@ -164,41 +164,8 @@ class prometheus::postgres_exporter (
     }
   }
 
-  if $install_method == 'url' {
-    # Not a big fan of copypasting but prometheus::daemon takes for granted
-    # a specific path embedded in the prometheus *_exporter tarball, which
-    # postgres_exporter lacks.
-    # TODO: patch prometheus::daemon to support custom extract directories
-    $exporter_install_method = 'none'
-    $install_dir = "/opt/${service_name}-${version}.${os}-${arch}"
-    file { $install_dir:
-      ensure => 'directory',
-      owner  => 'root',
-      group  => 0, # 0 instead of root because OS X uses "wheel".
-      mode   => '0555',
-    }
-    -> archive { "/tmp/${service_name}-${version}.${download_extension}":
-      ensure          => present,
-      extract         => true,
-      extract_path    => $install_dir,
-      extract_flags   => '--strip-components=1 -xzf',
-      source          => $real_download_url,
-      checksum_verify => false,
-      creates         => "${install_dir}/${service_name}",
-      cleanup         => true,
-    }
-    -> file { "${bin_dir}/${service_name}":
-      ensure => link,
-      notify => $notify_service,
-      target => "${install_dir}/${service_name}",
-      before => Prometheus::Daemon[$service_name],
-    }
-  } else {
-    $exporter_install_method = $install_method
-  }
-
   prometheus::daemon { $service_name:
-    install_method     => $exporter_install_method,
+    install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,
     env_vars           => $env_vars,
@@ -227,5 +194,6 @@ class prometheus::postgres_exporter (
     scrape_job_labels  => $scrape_job_labels,
     proxy_server       => $proxy_server,
     proxy_type         => $proxy_type,
+    archive_bin_path   => "/opt/${package_name}_v${version}_${os}-${arch}/postgres_exporter",
   }
 }

--- a/spec/classes/nginx_prometheus_exporter_spec.rb
+++ b/spec/classes/nginx_prometheus_exporter_spec.rb
@@ -13,7 +13,7 @@ describe 'prometheus::nginx_prometheus_exporter' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_systemd__unit_file('nginx_prometheus_exporter.service') }
         it { is_expected.not_to contain_package('nginx-prometheus-exporter') }
-        it { is_expected.to contain_archive('/tmp/nginx-prometheus-exporter-0.11.0.tar.gz') }
+        it { is_expected.to contain_archive('/tmp/nginx_prometheus_exporter-0.11.0.tar.gz') }
         it { is_expected.to contain_file('/opt/nginx-prometheus-exporter-0.11.0.linux-amd64') }
       end
 
@@ -29,7 +29,7 @@ describe 'prometheus::nginx_prometheus_exporter' do
 
         describe 'with specific params' do
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_archive('/tmp/nginx-prometheus-exporter-0.11.0.tar.gz') }
+          it { is_expected.to contain_archive('/tmp/nginx_prometheus_exporter-0.11.0.tar.gz') }
           it { is_expected.to contain_class('prometheus') }
           it { is_expected.to contain_group('nginx-prometheus-exporter') }
           it { is_expected.to contain_user('nginx-prometheus-exporter') }
@@ -57,7 +57,7 @@ describe 'prometheus::nginx_prometheus_exporter' do
 
         describe 'with specific params' do
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_archive('/tmp/nginx-prometheus-exporter-0.11.0.tar.gz') }
+          it { is_expected.to contain_archive('/tmp/nginx_prometheus_exporter-0.11.0.tar.gz') }
           it { is_expected.to contain_class('prometheus') }
           it { is_expected.to contain_group('nginx-prometheus-exporter') }
           it { is_expected.to contain_user('nginx-prometheus-exporter') }

--- a/spec/classes/node_exporter_spec.rb
+++ b/spec/classes/node_exporter_spec.rb
@@ -84,21 +84,22 @@ describe 'prometheus::node_exporter' do
       context 'with version specified' do
         let(:params) do
           {
-            version: '0.13.0',
             arch: 'amd64',
             os: 'linux',
             bin_dir: '/usr/local/bin',
             service_name: 'node_exporter',
-            install_method: 'url'
+            install_method: 'url',
+            package_name: 'node_exporter', # reuired to override defaults for Archlinux
+            bin_name: 'node_exporter' # reuired to override defaults for Archlinux
           }
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_archive('/tmp/node_exporter-0.13.0.tar.gz') }
-        it { is_expected.to contain_file('/opt/node_exporter-0.13.0.linux-amd64/node_exporter') }
+        it { is_expected.to contain_archive('/tmp/node_exporter-1.8.1.tar.gz') }
+        it { is_expected.to contain_file('/opt/node_exporter-1.8.1.linux-amd64/node_exporter') }
 
         describe 'install correct binary' do
-          it { is_expected.to contain_file('/usr/local/bin/node_exporter').with('target' => '/opt/node_exporter-0.13.0.linux-amd64/node_exporter') }
+          it { is_expected.to contain_file('/usr/local/bin/node_exporter').with('target' => '/opt/node_exporter-1.8.1.linux-amd64/node_exporter') }
         end
       end
 

--- a/spec/classes/postgres_exporter_spec.rb
+++ b/spec/classes/postgres_exporter_spec.rb
@@ -24,7 +24,7 @@ describe 'prometheus::postgres_exporter' do
 
         describe 'with all defaults' do
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_file('/usr/local/bin/postgres_exporter').with('target' => '/opt/postgres_exporter-0.4.6.linux-amd64/postgres_exporter') }
+          it { is_expected.to contain_file('/usr/local/bin/postgres_exporter').with('target' => '/opt/postgres_exporter_v0.4.6_linux-amd64/postgres_exporter') }
           it { is_expected.to contain_prometheus__daemon('postgres_exporter') }
           it { is_expected.to contain_user('postgres-exporter') }
           it { is_expected.to contain_group('postgres-exporter') }


### PR DESCRIPTION
some exporters have a layout of the release archives that does not fit the assumptions in prometheus::daemon. For these exporters workarounds where in place to handle the different layouts. All theses cases are now implemented using the options that prometheus::daemon provides.

fixes #606
