### PR TITLE
fix: update minimum version for stdlib to 9.2.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 9.0.0 < 10.0.0"
+      "version_requirement": ">= 9.2.0 < 10.0.0"
     },
     {
       "name": "puppet/systemd",


### PR DESCRIPTION
parameter `use_strict_setting` for `deprecation()` was added in 9.2.0 and is required for puppet 8, since it treats warnings as errors by default.

Fixes: #921

