### PR TITLE
fix: use install_method param in exporters

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5898,6 +5898,7 @@ The following parameters are available in the `prometheus::jmx_exporter` class:
 * [`proxy_server`](#-prometheus--jmx_exporter--proxy_server)
 * [`proxy_type`](#-prometheus--jmx_exporter--proxy_type)
 * [`java_options`](#-prometheus--jmx_exporter--java_options)
+* [`install_method`](#-prometheus--jmx_exporter--install_method)
 
 ##### <a name="-prometheus--jmx_exporter--version"></a>`version`
 
@@ -6073,6 +6074,14 @@ Data type: `Optional[String]`
 Optional options for the JVM of the standalone jmx exporter
 
 Default value: `undef`
+
+##### <a name="-prometheus--jmx_exporter--install_method"></a>`install_method`
+
+Data type: `Prometheus::Install`
+
+
+
+Default value: `$prometheus::install_method`
 
 ### <a name="prometheus--memcached_exporter"></a>`prometheus::memcached_exporter`
 

--- a/manifests/jmx_exporter.pp
+++ b/manifests/jmx_exporter.pp
@@ -59,6 +59,7 @@ class prometheus::jmx_exporter (
   String[1] $arch                                            = $prometheus::real_arch,
   Stdlib::Absolutepath $bin_dir                              = $prometheus::bin_dir,
   String[1] $config_mode                                     = $prometheus::config_mode,
+  Prometheus::Install $install_method                        = $prometheus::install_method,
   Boolean $restart_on_change                                 = true,
   Boolean $manage_user                                       = true,
   Boolean $manage_group                                      = true,
@@ -115,7 +116,7 @@ class prometheus::jmx_exporter (
 
   prometheus::daemon { $service_name:
     notify_service     => $notify_service,
-    install_method     => 'url',
+    install_method     => $install_method,
     version            => $version,
     download_extension => '',
     real_download_url  => $real_download_url,

--- a/manifests/systemd_exporter.pp
+++ b/manifests/systemd_exporter.pp
@@ -88,7 +88,7 @@ class prometheus::systemd_exporter (
   $options = $extra_options
 
   prometheus::daemon { $service_name:
-    install_method     => 'url',
+    install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,
     os                 => $os,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
The PR fixes the issue by using `install_method` class param here - https://github.com/voxpupuli/puppet-prometheus/blob/99d7ac2c7b65f0820449733aedbd52824e174855/manifests/systemd_exporter.pp#L91 

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
Fixes #939 
