### PR TITLE
systemd_exporter: fix comments and update download URL

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -54,7 +54,7 @@
 * [`prometheus::ssh_exporter`](#prometheus--ssh_exporter): This module manages prometheus ssh_exporter (https://github.com/treydock/ssh_exporter)
 * [`prometheus::ssl_exporter`](#prometheus--ssl_exporter): This module manages prometheus ssl_exporter (https://github.com/ribbybibby/ssl_exporter)
 * [`prometheus::statsd_exporter`](#prometheus--statsd_exporter): This module manages prometheus statsd_exporter
-* [`prometheus::systemd_exporter`](#prometheus--systemd_exporter): This module manages prometheus node redis_exporter
+* [`prometheus::systemd_exporter`](#prometheus--systemd_exporter): This module manages prometheus systemd_exporter
 * [`prometheus::unbound_exporter`](#prometheus--unbound_exporter): This module manages prometheus unbound exporter.
 * [`prometheus::varnish_exporter`](#prometheus--varnish_exporter): This module manages prometheus varnish_exporter
 * [`prometheus::wireguard_exporter`](#prometheus--wireguard_exporter): This module manages prometheus wireguard_exporter
@@ -13845,7 +13845,7 @@ Default value: `undef`
 
 ### <a name="prometheus--systemd_exporter"></a>`prometheus::systemd_exporter`
 
-This module manages prometheus node redis_exporter
+This module manages prometheus systemd_exporter
 
 #### Parameters
 
@@ -13918,7 +13918,7 @@ Data type: `Prometheus::Uri`
 
 Base URL for the binary archive
 
-Default value: `'https://github.com/povilasv/systemd_exporter/releases'`
+Default value: `'https://github.com/prometheus-community/systemd_exporter/releases'`
 
 ##### <a name="-prometheus--systemd_exporter--extra_groups"></a>`extra_groups`
 
@@ -13934,7 +13934,7 @@ Data type: `String`
 
 Extra options added to the startup command
 For a full list of the exporter's supported extra options
-please refer to https://github.com/oliver006/redis_exporter
+please refer to https://github.com/prometheus-community/systemd_exporter
 
 Default value: `''`
 
@@ -13990,7 +13990,7 @@ Default value: `true`
 
 Data type: `String[1]`
 
-Namespace for the metrics, defaults to `redis`.
+Namespace for the metrics, defaults to `systemd`.
 
 Default value: `'systemd'`
 
@@ -14046,7 +14046,7 @@ Default value: `'running'`
 
 Data type: `String[1]`
 
-Name of the node exporter service (default 'redis_exporter')
+Name of the node exporter service (default 'systemd_exporter')
 
 Default value: `'systemd_exporter'`
 

--- a/manifests/systemd_exporter.pp
+++ b/manifests/systemd_exporter.pp
@@ -1,4 +1,4 @@
-# @summary This module manages prometheus node redis_exporter
+# @summary This module manages prometheus systemd_exporter
 # @param arch
 #  Architecture (amd64 or i386)
 # @param bin_dir
@@ -14,7 +14,7 @@
 # @param extra_options
 #  Extra options added to the startup command
 #  For a full list of the exporter's supported extra options
-#  please refer to https://github.com/oliver006/redis_exporter
+#  please refer to https://github.com/prometheus-community/systemd_exporter
 # @param group
 #  Group under which the binary is running
 # @param init_style
@@ -28,7 +28,7 @@
 # @param manage_user
 #  Whether to create user or rely on external code for that
 # @param namespace
-#  Namespace for the metrics, defaults to `redis`.
+#  Namespace for the metrics, defaults to `systemd`.
 # @param os
 #  Operating system (linux is the only one supported)
 # @param package_name
@@ -42,7 +42,7 @@
 # @param service_ensure
 #  State ensured for the service (default 'running')
 # @param service_name
-#  Name of the node exporter service (default 'redis_exporter')
+#  Name of the node exporter service (default 'systemd_exporter')
 # @param user
 #  User which runs the service
 # @param version

--- a/manifests/systemd_exporter.pp
+++ b/manifests/systemd_exporter.pp
@@ -49,7 +49,7 @@
 #  The binary release version
 class prometheus::systemd_exporter (
   String $download_extension              = 'tar.gz',
-  Prometheus::Uri $download_url_base      = 'https://github.com/povilasv/systemd_exporter/releases',
+  Prometheus::Uri $download_url_base      = 'https://github.com/prometheus-community/systemd_exporter/releases',
   Array[String] $extra_groups             = [],
   String[1] $group                        = 'systemd-exporter',
   String[1] $package_name                 = 'systemd_exporter',


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This PR fixes issues left over from copying the `redis_exporter` manifest as a
template for `systemd_exporter`:
- Corrected comments in the manifest to reference `systemd_exporter`
  instead of `redis_exporter`
- Updated `download_url_base` to point to the official
  `prometheus-community/systemd_exporter` GitHub repository

No functional changes beyond correcting the download URL.

#### This Pull Request (PR) fixes the following issues
n/a