### PR TITLE
Fix ensure type for upstart in daemon.pp

### DIFF
--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -191,7 +191,7 @@ define prometheus::daemon (
         content => template('prometheus/daemon.upstart.erb'),
       }
       file { "/etc/init.d/${name}":
-        ensure => stdlib::ensure($ensure, 'file'),
+        ensure => stdlib::ensure($ensure, 'link'),
         target => '/lib/init/upstart-job',
         owner  => 'root',
         group  => 'root',


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Fix wrong type in daemon.pp

#### This Pull Request (PR) fixes the following issues

The `ensure` option was changed in [this PR](https://github.com/voxpupuli/puppet-prometheus/commit/9f2e26e5df53a0b7c6760c3d35036d04bc29548e#diff-f412b3198f69ae83d1b0cc30d72d126f99303f4e8f4eb931415a3aaddd20d84cR194). Obviously, that's the wrong type.

The current implementation leads to recurring corrective changes:

```
2025-09-16 10:58:13 +0200 /Stage[main]/Prometheus::Node_exporter/Prometheus::Daemon[node_exporter]/File[/etc/init.d/node_exporter]/target (notice): target changed 'notlink' to '/lib/init/upstart-job' (corrective)
2025-09-16 11:28:39 +0200 /Stage[main]/Prometheus::Node_exporter/Prometheus::Daemon[node_exporter]/File[/etc/init.d/node_exporter]/ensure (notice): ensure changed 'link' to 'file' (corrective)
2025-09-16 11:58:30 +0200 /Stage[main]/Prometheus::Node_exporter/Prometheus::Daemon[node_exporter]/File[/etc/init.d/node_exporter]/target (notice): target changed 'notlink' to '/lib/init/upstart-job' (corrective)
2025-09-16 12:28:36 +0200 /Stage[main]/Prometheus::Node_exporter/Prometheus::Daemon[node_exporter]/File[/etc/init.d/node_exporter]/ensure (notice): ensure changed 'link' to 'file' (corrective)
```