### PR TITLE
Change openldap_exporter to https://github.com/hm-edu/openldap-exporter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -8398,7 +8398,7 @@ Data type: `String`
 
 Extension for the release binary archive
 
-Default value: `''`
+Default value: `'tar.gz'`
 
 ##### <a name="-prometheus--openldap_exporter--download_url"></a>`download_url`
 
@@ -8414,7 +8414,7 @@ Data type: `Prometheus::Uri`
 
 Base URL for the binary archive
 
-Default value: `'https://github.com/tomcz/openldap_exporter/releases'`
+Default value: `'https://github.com/hm-edu/openldap-exporter/releases'`
 
 ##### <a name="-prometheus--openldap_exporter--extra_groups"></a>`extra_groups`
 
@@ -8501,9 +8501,9 @@ Default value: `'latest'`
 
 Data type: `String[1]`
 
-The binary package name - not available yet
+The binary package name - used to reference the name in the archive.
 
-Default value: `'openldap_exporter'`
+Default value: `'openldap-exporter'`
 
 ##### <a name="-prometheus--openldap_exporter--restart_on_change"></a>`restart_on_change`
 
@@ -8551,7 +8551,7 @@ Data type: `String[1]`
 
 The binary release version
 
-Default value: `'2.2.2'`
+Default value: `'v2.5.0'`
 
 ##### <a name="-prometheus--openldap_exporter--ldap_binddn"></a>`ldap_binddn`
 

--- a/spec/acceptance/openldap_exporter_spec.rb
+++ b/spec/acceptance/openldap_exporter_spec.rb
@@ -18,10 +18,9 @@ describe 'prometheus openldap exporter' do
     it { is_expected.to be_listening.with('tcp6') }
   end
 
-  # rubocop:disable RSpec/RepeatedExampleGroupBody,RSpec/RepeatedExampleGroupDescription
   describe 'openldap_exporter works with ldap_binddn + ldap_password config' do
     it 'is idempotent' do
-      pp = "class{'prometheus::openldap_exporter': version => '2.0', ldap_binddn => 'cn=user', ldap_password => 'password'}"
+      pp = "class{'prometheus::openldap_exporter': version => 'v2.4.4', ldap_binddn => 'cn=user', ldap_password => 'password'}"
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
     end
@@ -38,7 +37,7 @@ describe 'prometheus openldap exporter' do
 
   describe 'openldap_exporter works with extra options defined' do
     it 'is idempotent' do
-      pp = "class{'prometheus::openldap_exporter': version => '2.0', options => '--ldapAddr localhost:636'}"
+      pp = "class{'prometheus::openldap_exporter': version => 'v2.4.4', options => '--ldap-addr ldaps://localhost:636'}"
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
     end
@@ -53,9 +52,10 @@ describe 'prometheus openldap exporter' do
     end
   end
 
-  describe 'openldap_exporter update from 2.0 to 2.1' do
+  # rubocop:disable RSpec/RepeatedExampleGroupBody,RSpec/RepeatedExampleGroupDescription
+  describe 'openldap_exporter update from v2.4.4 to v2.5.0' do
     it 'is idempotent' do
-      pp = "class{'prometheus::openldap_exporter': version => '2.0'}"
+      pp = "class{'prometheus::openldap_exporter': version => 'v2.4.4'}"
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
     end
@@ -70,7 +70,7 @@ describe 'prometheus openldap exporter' do
     end
 
     it 'is idempotent' do
-      pp = "class{'prometheus::openldap_exporter': version => '2.1'}"
+      pp = "class{'prometheus::openldap_exporter': version => 'v2.5.0'}"
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
     end
@@ -82,12 +82,6 @@ describe 'prometheus openldap exporter' do
 
     describe port(9330) do
       it { is_expected.to be_listening.with('tcp6') }
-    end
-
-    it 'upgrades to new download format' do
-      pp = "class{'prometheus::openldap_exporter': version => '2.2.1'}"
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
     end
 
     describe service('openldap_exporter') do

--- a/spec/classes/openldap_exporter_spec.rb
+++ b/spec/classes/openldap_exporter_spec.rb
@@ -9,38 +9,36 @@ describe 'prometheus::openldap_exporter' do
         facts.merge(os_specific_facts(facts))
       end
 
+      context 'without parameters' do
+        it { is_expected.to contain_class('prometheus') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_prometheus__daemon('openldap_exporter') }
+        it { is_expected.to contain_user('openldap-exporter') }
+        it { is_expected.to contain_group('openldap-exporter') }
+        it { is_expected.to contain_service('openldap_exporter') }
+      end
+
       context 'with version specified' do
         let(:params) do
           {
-            version: '2.1',
-            bin_dir: '/usr/local/bin',
-            install_method: 'url'
+            version: 'v2.4.4',
           }
         end
 
         describe 'with all defaults' do
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_file('/usr/local/bin/openldap_exporter').with('target' => '/opt/openldap_exporter-2.1.linux-amd64/openldap_exporter') }
+          it { is_expected.to contain_file('/usr/local/bin/openldap_exporter').with('target' => '/opt/openldap_exporter-v2.4.4.linux-x86_64/openldap-exporter') }
           it { is_expected.to contain_prometheus__daemon('openldap_exporter') }
           it { is_expected.to contain_user('openldap-exporter') }
           it { is_expected.to contain_group('openldap-exporter') }
           it { is_expected.to contain_service('openldap_exporter') }
-        end
-      end
 
-      context 'with version specified using new download format' do
-        let(:params) do
-          {
-            version: '2.2.1',
+          it {
+            expect(subject).to contain_prometheus__daemon('openldap_exporter').with(
+              real_download_url: 'https://github.com/hm-edu/openldap-exporter/releases/download/v2.4.4/openldap-exporter_linux_x86_64.tar.gz'
+            )
           }
         end
-
-        it {
-          expect(subject).to contain_prometheus__daemon('openldap_exporter').with(
-            download_extension: 'gz',
-            real_download_url: 'https://github.com/tomcz/openldap_exporter/releases/download/v2.2.1/openldap_exporter-linux-amd64.gz'
-          )
-        }
       end
     end
   end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Replace the unmaintained tomcz/openldap_exporter by the actively maintained fork hm-edu/openldap-exporter

This is an API breaking change due to how the releases are made in the fork. The defaults just work, but users are advised to update their parameters if they override the version/base url of the downloaded archive.

The exporter also has different command line arguments, they changed the arguments from camelcase to hyphened (`--ldapAddr` -> `--ldap-addr`).

Note: currently the daemon doesn't start with default options due to a bug in openldap-exporter (fix PR https://github.com/hm-edu/openldap-exporter/pull/79).

(This work is related to https://github.com/voxpupuli/puppet-prometheus/pull/873)