### PR TITLE
puppet/systemd: Allow 9.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 7.1.0 < 9.0.0"
+      "version_requirement": ">= 7.1.0 < 10.0.0"
     },
     {
       "name": "puppet/archive",


### PR DESCRIPTION
#### Pull Request (PR) description

The `systemd` module is already up to `9.x.0`. The only breaking change for systemd 9.0.0 is the openvox requirements, and those are already present in `metadata.json`.

#### This Pull Request (PR) fixes the following issues

n/a
