### PR TITLE
statsd_exporter: allow disabling of mappings config file

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -13447,6 +13447,7 @@ The following parameters are available in the `prometheus::statsd_exporter` clas
 * [`manage_group`](#-prometheus--statsd_exporter--manage_group)
 * [`manage_service`](#-prometheus--statsd_exporter--manage_service)
 * [`manage_user`](#-prometheus--statsd_exporter--manage_user)
+* [`manage_mappings`](#-prometheus--statsd_exporter--manage_mappings)
 * [`os`](#-prometheus--statsd_exporter--os)
 * [`package_ensure`](#-prometheus--statsd_exporter--package_ensure)
 * [`package_name`](#-prometheus--statsd_exporter--package_name)
@@ -13576,6 +13577,14 @@ Default value: `true`
 Data type: `Boolean`
 
 Whether to create user or rely on external code for that
+
+Default value: `true`
+
+##### <a name="-prometheus--statsd_exporter--manage_mappings"></a>`manage_mappings`
+
+Data type: `Boolean`
+
+Whether to create mappings or rely on external code for that
 
 Default value: `true`
 

--- a/manifests/statsd_exporter.pp
+++ b/manifests/statsd_exporter.pp
@@ -27,6 +27,8 @@
 #  Should puppet manage the service? (default true)
 # @param manage_user
 #  Whether to create user or rely on external code for that
+# @param manage_mappings
+#  Whether to create mappings or rely on external code for that
 # @param os
 #  Operating system (linux is the only one supported)
 # @param package_ensure
@@ -84,6 +86,7 @@ class prometheus::statsd_exporter (
   Boolean $manage_group                                      = true,
   Boolean $manage_service                                    = true,
   Boolean $manage_user                                       = true,
+  Boolean $manage_mappings                                   = true,
   Optional[String[1]] $extra_options                         = undef,
   Optional[Prometheus::Uri] $download_url                    = undef,
   Boolean $export_scrape_job                                 = false,
@@ -106,13 +109,15 @@ class prometheus::statsd_exporter (
     default => undef,
   }
 
-  file { $mapping_config_path:
-    ensure  => 'file',
-    mode    => $config_mode,
-    owner   => 'root',
-    group   => $group,
-    content => stdlib::to_yaml({ mappings => $mappings }),
-    notify  => $notify_service,
+  if $manage_mappings {
+    file { $mapping_config_path:
+      ensure  => 'file',
+      mode    => $config_mode,
+      owner   => 'root',
+      group   => $group,
+      content => stdlib::to_yaml({ mappings => $mappings }),
+      notify  => $notify_service,
+    }
   }
 
   # Switched to POSIX like flags in version 0.7.0

--- a/spec/classes/statsd_exporter_spec.rb
+++ b/spec/classes/statsd_exporter_spec.rb
@@ -88,6 +88,29 @@ describe 'prometheus::statsd_exporter' do
         end
       end
 
+      context 'with no mappings' do
+        let(:params) do
+          {
+            version: '0.8.0',
+            arch: 'amd64',
+            os: 'linux',
+            bin_dir: '/usr/local/bin',
+            install_method: 'url',
+            manage_mappings: false,
+          }
+        end
+
+        describe 'compile manifest' do
+          it { is_expected.to compile.with_all_deps }
+        end
+
+        describe 'no mapping config file' do
+          it {
+            expect(subject).not_to contain_file('/etc/statsd-exporter-mapping.yaml')
+          }
+        end
+      end
+
       context 'with older version that does not support posix like option flags specified' do
         let(:params) do
           {


### PR DESCRIPTION
#### Pull Request (PR) description
Adds a manage_mappings parameter to `prometheus::statsd_exporter`, as well as a test to verify it works correctly. Supersedes PR #721

#### This Pull Request (PR) fixes the following issues

Fixes #680 
