### PR TITLE
bird_exporter: Allow passing extract_path

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2314,6 +2314,7 @@ The following parameters are available in the `prometheus::bird_exporter` class:
 * [`arch`](#-prometheus--bird_exporter--arch)
 * [`bin_dir`](#-prometheus--bird_exporter--bin_dir)
 * [`download_extension`](#-prometheus--bird_exporter--download_extension)
+* [`extract_path`](#-prometheus--bird_exporter--extract_path)
 * [`download_url`](#-prometheus--bird_exporter--download_url)
 * [`download_url_base`](#-prometheus--bird_exporter--download_url_base)
 * [`extra_groups`](#-prometheus--bird_exporter--extra_groups)
@@ -2368,6 +2369,14 @@ Data type: `String`
 Extension for the release binary archive
 
 Default value: `''`
+
+##### <a name="-prometheus--bird_exporter--extract_path"></a>`extract_path`
+
+Data type: `Stdlib::Absolutepath`
+
+Path where to find extracted binary
+
+Default value: `'/opt'`
 
 ##### <a name="-prometheus--bird_exporter--download_url"></a>`download_url`
 

--- a/manifests/bird_exporter.pp
+++ b/manifests/bird_exporter.pp
@@ -7,6 +7,8 @@
 #  Directory where binaries are located
 # @param download_extension
 #  Extension for the release binary archive
+# @param extract_path
+#  Path where to find extracted binary
 # @param download_url
 #  Complete URL corresponding to the where the release binary archive can be downloaded
 # @param download_url_base
@@ -68,6 +70,7 @@
 #
 class prometheus::bird_exporter (
   String $download_extension                                 = '', # lint:ignore:params_empty_string_assignment
+  Stdlib::Absolutepath $extract_path                         = '/opt',
   Prometheus::Uri $download_url_base                         = 'https://github.com/czerwonk/bird_exporter/releases',
   Array[String] $extra_groups                                = ['bird'],
   String[1] $group                                           = 'bird-exporter',
@@ -112,6 +115,7 @@ class prometheus::bird_exporter (
     install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,
+    extract_path       => $extract_path,
     os                 => $os,
     arch               => $arch,
     real_download_url  => $real_download_url,


### PR DESCRIPTION
Like when the upstream tarball doesn't have a directory in it

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Allow passing extract_path here in case the archive tarball doesn't have a directory structure / would be extracted straight into /opt

Example:
```
file { '/opt/bird_exporter-1.5.0.linux-amd64/':
    ensure => directory,
    owner  => 'root',
    group  => 'root',
    mode   => '0755',
  }

  class { 'prometheus::bird_exporter':
    extra_options      => '-bird.v2 -web.listen-address=0.0.0.0:9324 -format.new=true -bird.socket=/run/bird/bird.ctl -format.description-labels',
    service_enable     => $enabled,
    service_ensure     => $service_ensure,
    download_extension => 'tar.gz',
    download_url       => 'https://github.com/czerwonk/bird_exporter/releases/download/v1.5.0/bird_exporter_1.5.0_linux_amd64.tar.gz',
    version            => '1.5.0',
    extract_path       => '/opt/bird_exporter-1.5.0.linux-amd64/',
    require            => [Service['bird'], File['/opt/bird_exporter-1.5.0.linux-amd64/'],],
  }
```
