### PR TITLE
Enable options for listen_address for node exporter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -8149,6 +8149,7 @@ The following parameters are available in the `prometheus::node_exporter` class:
 * [`web_config_file`](#-prometheus--node_exporter--web_config_file)
 * [`web_config_content`](#-prometheus--node_exporter--web_config_content)
 * [`scrape_port`](#-prometheus--node_exporter--scrape_port)
+* [`listen_address`](#-prometheus--node_exporter--listen_address)
 * [`scrape_host`](#-prometheus--node_exporter--scrape_host)
 * [`export_scrape_job`](#-prometheus--node_exporter--export_scrape_job)
 * [`scrape_job_name`](#-prometheus--node_exporter--scrape_job_name)
@@ -8422,6 +8423,17 @@ Scrape port for configuring scrape targets on the prometheus server via exported
 If changed from default 9100 the option `--web.listen-address=':${scrape_port}'` will be added to the command line arguments
 
 Default value: `9100`
+
+##### <a name="-prometheus--node_exporter--listen_address"></a>`listen_address`
+
+Data type: `Optional[Stdlib::IP::Address]`
+
+The IP address or hostname that node_exporter should bind to for incoming requests.
+This will be used together with `scrape_port` to form the complete listen address.
+If `listen_address` is set to `127.0.0.1` and `scrape_port` is `9090`, node_exporter will be started with the option:  `--web.listen-address='127.0.0.1:9090'`.
+Defaults to all interfaces
+
+Default value: `undef`
 
 ##### <a name="-prometheus--node_exporter--scrape_host"></a>`scrape_host`
 

--- a/manifests/node_exporter.pp
+++ b/manifests/node_exporter.pp
@@ -69,6 +69,11 @@
 # @param scrape_port
 #  Scrape port for configuring scrape targets on the prometheus server via exported `prometheus::scrape_job` resources
 #  If changed from default 9100 the option `--web.listen-address=':${scrape_port}'` will be added to the command line arguments
+# @param listen_address
+#  The IP address or hostname that node_exporter should bind to for incoming requests.
+#  This will be used together with `scrape_port` to form the complete listen address.
+#  If `listen_address` is set to `127.0.0.1` and `scrape_port` is `9090`, node_exporter will be started with the option:  `--web.listen-address='127.0.0.1:9090'`.
+#  Defaults to all interfaces
 class prometheus::node_exporter (
   String $download_extension = 'tar.gz',
   Prometheus::Uri $download_url_base = 'https://github.com/prometheus/node_exporter/releases',
@@ -99,6 +104,7 @@ class prometheus::node_exporter (
   Array[String] $collectors_disable                          = [],
   Optional[Stdlib::Host] $scrape_host                        = undef,
   Boolean $export_scrape_job                                 = false,
+  Optional[Stdlib::IP::Address] $listen_address              = undef,
   Stdlib::Port $scrape_port                                  = 9100,
   String[1] $scrape_job_name                                 = 'node',
   Optional[Hash] $scrape_job_labels                          = undef,
@@ -160,17 +166,18 @@ class prometheus::node_exporter (
     }
   }
 
-  if $scrape_port != 9100 {
-    $listen_address = "--web.listen-address=':${scrape_port}'"
+  if $listen_address or $scrape_port != 9100 {
+    $web_listen_address = "--web.listen-address='${listen_address}:${scrape_port}'"
   } else {
-    $listen_address = ''
+    $web_listen_address = ''
   }
+
   $options = [
     $extra_options,
     $cmd_collectors_enable.join(' '),
     $cmd_collectors_disable.join(' '),
     $_web_config,
-    $listen_address,
+    $web_listen_address,
   ].filter |$x| { !$x.empty }.join(' ')
 
   prometheus::daemon { $service_name:

--- a/spec/classes/node_exporter_spec.rb
+++ b/spec/classes/node_exporter_spec.rb
@@ -217,6 +217,39 @@ describe 'prometheus::node_exporter' do
           it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '--web.listen-address=\':9101\'') }
         end
       end
+
+      context 'with non default scrape address' do
+        let(:params) do
+          {
+            listen_address: '127.0.0.1',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        if facts[:os]['name'] == 'Archlinux'
+          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '--web.listen-address=\'127.0.0.1:9100\'') }
+        else
+          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '--web.listen-address=\'127.0.0.1:9100\'') }
+        end
+      end
+
+      context 'with non default scrape address and port' do
+        let(:params) do
+          {
+            listen_address: '10.1.2.3',
+            scrape_port:    1234,
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        if facts[:os]['name'] == 'Archlinux'
+          it { is_expected.to contain_prometheus__daemon('prometheus-node-exporter').with(options: '--web.listen-address=\'10.1.2.3:1234\'') }
+        else
+          it { is_expected.to contain_prometheus__daemon('node_exporter').with(options: '--web.listen-address=\'10.1.2.3:1234\'') }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR is a rebase of #955

It adds a listen_address so that one may choose on which netmask to listen, and is not constrained to listen on all interfaces, which might exposes the scrapping endpoint publicly.