### PR TITLE
fix(prometheus): Use web_listen_address for default config target

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,6 +6,8 @@ class prometheus::config {
 
   $enable_tracing = $prometheus::server::enable_tracing
 
+  $target_address = $prometheus::web_listen_address.lest || { 'localhost:9090' }
+
   if $prometheus::server::include_default_scrape_configs {
     $default_scrape_configs = [
       {
@@ -14,7 +16,7 @@ class prometheus::config {
         'scrape_timeout'  => '10s',
         'static_configs'  => [
           {
-            'targets' => ['localhost:9090'],
+            'targets' => [$target_address],
             'labels'  => {
               'alias' => 'Prometheus',
             },


### PR DESCRIPTION
If Prometheus is configured to listen to a different IP that 0.0.0.0 or localhost, the default config will not work. We can trivially fix this by reusing the parameter.