### PR TITLE
docs(README): Document wireguard_exporter also depending on saz/sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ This module supports below Prometheus architectures:
 - i386
 - armv71 (Tested on raspberry pi 3)
 
-The `prometheus::ipmi_exporter` and `prometheus::cgroup_exporter` classes have a dependency on [saz/sudo](https://forge.puppet.com/modules/saz/sudo) Puppet module.
+The `prometheus::cgroup_exporter`, `prometheus::ipmi_exporter`, and `prometheus::wireguard_exporter` classes have a
+dependency on [saz/sudo](https://forge.puppet.com/modules/saz/sudo) Puppet module.
 
 ## Background
 


### PR DESCRIPTION
Fairly straightforward - also organised them alphabetically.