### PR TITLE
swap postfix_exporter to sarab97

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -9391,7 +9391,7 @@ Default value: `$prometheus::env_file_path`
 manages prometheus postfix_exporter
 
 * **See also**
-  * https://github.com/kumina/postfix_exporter
+  * https://github.com/sarab97/postfix_exporter
 
 #### Examples
 
@@ -9405,6 +9405,8 @@ include prometheus::postfix_exporter
 
 The following parameters are available in the `prometheus::postfix_exporter` class:
 
+* [`arch`](#-prometheus--postfix_exporter--arch)
+* [`os`](#-prometheus--postfix_exporter--os)
 * [`install_method`](#-prometheus--postfix_exporter--install_method)
 * [`download_url`](#-prometheus--postfix_exporter--download_url)
 * [`download_url_base`](#-prometheus--postfix_exporter--download_url_base)
@@ -9432,6 +9434,22 @@ The following parameters are available in the `prometheus::postfix_exporter` cla
 * [`proxy_type`](#-prometheus--postfix_exporter--proxy_type)
 * [`scrape_host`](#-prometheus--postfix_exporter--scrape_host)
 
+##### <a name="-prometheus--postfix_exporter--arch"></a>`arch`
+
+Data type: `String[1]`
+
+architecture for the pacakge being downloaded, taken from prometheus::real_arch
+
+Default value: `$prometheus::real_arch`
+
+##### <a name="-prometheus--postfix_exporter--os"></a>`os`
+
+Data type: `String[1]`
+
+Operating system (linux is the only one supported)
+
+Default value: `downcase($facts['kernel'])`
+
 ##### <a name="-prometheus--postfix_exporter--install_method"></a>`install_method`
 
 Data type: `Prometheus::Install`
@@ -9454,7 +9472,7 @@ Data type: `Stdlib::HTTPUrl`
 
 Base URL for the binary archive. (This option is only relevant when `install_method` is `url`.)
 
-Default value: `'https://github.com/kumina/postfix_exporter/releases'`
+Default value: `'https://github.com/sarab97/postfix_exporter/releases'`
 
 ##### <a name="-prometheus--postfix_exporter--download_extension"></a>`download_extension`
 
@@ -9462,7 +9480,7 @@ Data type: `String`
 
 Extension for the release binary archive. (This option is only relevant when `install_method` is `url`.)
 
-Default value: `''`
+Default value: `'tar.gz'`
 
 ##### <a name="-prometheus--postfix_exporter--version"></a>`version`
 
@@ -9470,7 +9488,7 @@ Data type: `String[1]`
 
 The binary release version. (This option is only relevant when `install_method` is `url`.)
 
-Default value: `'0.2.0'`
+Default value: `'0.6.0'`
 
 ##### <a name="-prometheus--postfix_exporter--package_ensure"></a>`package_ensure`
 

--- a/manifests/postfix_exporter.pp
+++ b/manifests/postfix_exporter.pp
@@ -1,7 +1,11 @@
 # @summary manages prometheus postfix_exporter
 # @example Basic usage
 #   include prometheus::postfix_exporter
-# @see https://github.com/kumina/postfix_exporter
+# @see https://github.com/sarab97/postfix_exporter
+# @param arch
+#   architecture for the pacakge being downloaded, taken from prometheus::real_arch
+# @param os
+#  Operating system (linux is the only one supported)
 # @param install_method
 #   Installation method: `url` or `package`. (Note `package` is not available on most OSes.)
 # @param download_url
@@ -56,11 +60,13 @@
 #  Optional proxy server type (none|http|https|ftp)
 class prometheus::postfix_exporter (
   # Installation options
+  String[1] $arch                                            = $prometheus::real_arch,
+  String[1] $os                                              = downcase($facts['kernel']),
   Prometheus::Install $install_method                        = 'url',
   Optional[Stdlib::HTTPUrl] $download_url                    = undef,
-  Stdlib::HTTPUrl $download_url_base                         = 'https://github.com/kumina/postfix_exporter/releases',
-  String $download_extension                                 = '', # lint:ignore:params_empty_string_assignment
-  String[1] $version                                         = '0.2.0',
+  Stdlib::HTTPUrl $download_url_base                         = 'https://github.com/sarab97/postfix_exporter/releases',
+  String $download_extension                                 = 'tar.gz', # lint:ignore:params_empty_string_assignment
+  String[1] $version                                         = '0.6.0',
   Optional[String[1]] $proxy_server                          = undef,
   Optional[Enum['none', 'http', 'https', 'ftp']] $proxy_type = undef,
 
@@ -92,21 +98,30 @@ class prometheus::postfix_exporter (
   Stdlib::Port   $scrape_port       = 9154,
   String[1]      $scrape_job_name   = 'postfix',
   Optional[Hash] $scrape_job_labels = undef,
-) {
-  include prometheus
-
-  $real_download_url = pick($download_url,"${download_url_base}/download/${version}/${package_name}")
+) inherits prometheus {
+  $real_download_url = pick($download_url,"${download_url_base}/download/v${version}/${package_name}_${version}_${os}_${arch}.${download_extension}")
   $notify_service = $restart_on_change ? {
     true    => Service[$service_name],
     default => undef,
   }
 
-  prometheus::daemon { $service_name:
+  # changing sarab97's release, it uses a flat archive, unlike prometheus::daemon's default archive_bin_path assumption. 
+  # Extract into our own versioned dir, same as nginx_prometheus_exporter 
+  $extract_path     = "/opt/${package_name}-${version}.${os}-${arch}"
+  $archive_bin_path = "${extract_path}/${package_name}"
+
+  file { $extract_path:
+    ensure => 'directory',
+    owner  => 'root',
+    group  => 0, # 0 instead of root because OS X uses "wheel".
+    mode   => '0555',
+  }
+  -> prometheus::daemon { $service_name:
     install_method     => $install_method,
     version            => $version,
     download_extension => $download_extension,
-    os                 => $prometheus::os,
-    arch               => $prometheus::real_arch,
+    os                 => $os,
+    arch               => $arch,
     real_download_url  => $real_download_url,
     bin_dir            => $prometheus::bin_dir,
     notify_service     => $notify_service,
@@ -129,5 +144,7 @@ class prometheus::postfix_exporter (
     scrape_job_labels  => $scrape_job_labels,
     proxy_server       => $proxy_server,
     proxy_type         => $proxy_type,
+    extract_path       => $extract_path,
+    archive_bin_path   => $archive_bin_path,
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

swap the postfix_exporter upstream provider to sarab97 maintained version


#### This Pull Request (PR) fixes the following issues

no direct fixes, just a swap to supported version of postfix support (fork or original one it seems) defaults to v 0.6 which is current supported version 

