### PR TITLE
feat(daemon,archive): allow to override the flags for the extract command

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -136,6 +136,7 @@ The following parameters are available in the `prometheus` class:
 * [`storage_retention`](#-prometheus--storage_retention)
 * [`external_url`](#-prometheus--external_url)
 * [`extract_command`](#-prometheus--extract_command)
+* [`extract_flags`](#-prometheus--extract_flags)
 * [`collect_tag`](#-prometheus--collect_tag)
 * [`collect_scrape_jobs`](#-prometheus--collect_scrape_jobs)
 * [`max_open_files`](#-prometheus--max_open_files)
@@ -556,6 +557,15 @@ Data type: `Optional[String[1]]`
 Custom command passed to the archive resource to extract the downloaded archive.
 
 Default value: `undef`
+
+##### <a name="-prometheus--extract_flags"></a>`extract_flags`
+
+Data type: `Hash[String[1], String[1]]`
+
+Custom arguments passed to the archive resource to extract the downloaded archive.
+This is a hash with the key being which extract command is used, and the value being the arguments to pass the the command.
+
+Default value: `{ 'tar' => '--no-same-owner --no-same-permissions --no-xattrs --no-acls -xf' }`
 
 ##### <a name="-prometheus--collect_tag"></a>`collect_tag`
 
@@ -15105,6 +15115,7 @@ The following parameters are available in the `prometheus::daemon` defined type:
 * [`service_enable`](#-prometheus--daemon--service_enable)
 * [`manage_service`](#-prometheus--daemon--manage_service)
 * [`extract_command`](#-prometheus--daemon--extract_command)
+* [`extract_flags`](#-prometheus--daemon--extract_flags)
 * [`extract_path`](#-prometheus--daemon--extract_path)
 * [`archive_bin_path`](#-prometheus--daemon--archive_bin_path)
 * [`init_style`](#-prometheus--daemon--init_style)
@@ -15267,6 +15278,15 @@ Data type: `Optional[String[1]]`
 Custom command passed to the archive resource to extract the downloaded archive.
 
 Default value: `$prometheus::extract_command`
+
+##### <a name="-prometheus--daemon--extract_flags"></a>`extract_flags`
+
+Data type: `Hash[String[1], String[1]]`
+
+Custom arguments passed to the archive resource to extract the downloaded archive.
+This is a hash with the key being which extract command is used, and the value being the arguments to pass the the command.
+
+Default value: `$prometheus::extract_flags`
 
 ##### <a name="-prometheus--daemon--extract_path"></a>`extract_path`
 

--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -37,6 +37,9 @@
 #  Should puppet manage the service? (default true)
 # @param extract_command
 #  Custom command passed to the archive resource to extract the downloaded archive.
+# @param extract_flags
+#  Custom arguments passed to the archive resource to extract the downloaded archive.
+#  This is a hash with the key being which extract command is used, and the value being the arguments to pass the the command.
 # @param extract_path
 #  Path where to find extracted binary
 # @param archive_bin_path
@@ -78,6 +81,7 @@ define prometheus::daemon (
   Hash[String[1], Scalar] $env_vars                          = {},
   Stdlib::Absolutepath $env_file_path                        = $prometheus::env_file_path,
   Optional[String[1]] $extract_command                       = $prometheus::extract_command,
+  Hash[String[1], String[1]] $extract_flags                  = $prometheus::extract_flags,
   Stdlib::Absolutepath $extract_path                         = '/opt',
   Stdlib::Absolutepath $archive_bin_path                     = "/opt/${name}-${version}.${os}-${arch}/${name}",
   Boolean $export_scrape_job                                 = false,
@@ -121,6 +125,7 @@ define prometheus::daemon (
           cleanup         => true,
           before          => File[$archive_bin_path],
           extract_command => $extract_command,
+          extract_flags   => $extract_flags,
           proxy_server    => $proxy_server,
           proxy_type      => $proxy_type,
         }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,6 +98,9 @@
 #  If omitted, relevant URL components will be derived automatically.
 # @param extract_command
 #  Custom command passed to the archive resource to extract the downloaded archive.
+# @param extract_flags
+#  Custom arguments passed to the archive resource to extract the downloaded archive.
+#  This is a hash with the key being which extract command is used, and the value being the arguments to pass the the command.
 # @param collect_tag
 #  Only collect scrape jobs tagged with this label. Allowing to split jobs over multiple prometheuses.
 # @param collect_scrape_jobs
@@ -261,6 +264,7 @@ class prometheus (
   Optional[String[1]] $extra_options                                            = undef,
   Optional[String] $download_url                                                = undef,
   Optional[String[1]] $extract_command                                          = undef,
+  Hash[String[1], String[1]] $extract_flags                                     = { 'tar' => '--no-same-owner --no-same-permissions --no-xattrs --no-acls -xf' },
   Stdlib::Absolutepath $usershell                                               = '/usr/bin/nologin',
   Optional[String[1]] $web_listen_address                                       = undef,
   Optional[String[1]] $web_read_timeout                                         = undef,

--- a/spec/defines/daemon_spec.rb
+++ b/spec/defines/daemon_spec.rb
@@ -53,6 +53,7 @@ describe 'prometheus::daemon' do
               'checksum_verify' => false,
               'creates' => "/opt/smurf_exporter-#{parameters[:version]}.#{prom_os}-#{prom_arch}/smurf_exporter",
               'cleanup' => true,
+              'extract_flags' => { 'tar' => '--no-same-owner --no-same-permissions --no-xattrs --no-acls -xf' },
             ).that_comes_before("File[/opt/smurf_exporter-#{parameters[:version]}.#{prom_os}-#{prom_arch}/smurf_exporter]")
           }
 
@@ -92,6 +93,14 @@ describe 'prometheus::daemon' do
             end
 
             it { is_expected.to contain_archive("/tmp/smurf_exporter-#{parameters[:version]}.tar.gz").with_extract_path('/opt/foo') }
+          end
+
+          context 'with overidden extract_flags' do
+            let(:params) do
+              parameters.merge(extract_flags: { 'tar' => '--some-flag' })
+            end
+
+            it { is_expected.to contain_archive("/tmp/smurf_exporter-#{parameters[:version]}.tar.gz").with_extract_flags({ 'tar' => '--some-flag' }) }
           end
 
           it { is_expected.to contain_class('systemd') }


### PR DESCRIPTION
#### Pull Request (PR) description
This exposes the `extract_flags` globally to allow overriding the value of the parameters of each extract command individually.
Defaults to some safe values.

#### This Pull Request (PR) fixes the following issues
